### PR TITLE
Add guestbook archival and CLI permutation tests

### DIFF
--- a/speaktome/cli_permutations.py
+++ b/speaktome/cli_permutations.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from itertools import product
+from typing import Any, Dict, Iterable, List, Sequence, Tuple
+
+
+class CLIArgumentMatrix:
+    """Generate permutations of CLI arguments with simple exclusion logic."""
+
+    def __init__(self) -> None:
+        self.options: Dict[str, Sequence[Any]] = {}
+        self.exclusions: List[Tuple[str, ...]] = []
+
+    def add_option(self, flag: str, values: Sequence[Any] | None = None) -> None:
+        if values is None:
+            values = [None]
+        self.options[flag] = values
+
+    def exclude(self, *flags: str) -> None:
+        self.exclusions.append(tuple(sorted(flags)))
+
+    def _is_excluded(self, combo: Tuple[Tuple[str, Any], ...]) -> bool:
+        flags = {f for f, _ in combo if _ is not None or f.startswith('-')}
+        for exc in self.exclusions:
+            if set(exc).issubset(flags):
+                return True
+        return False
+
+    def generate(self) -> List[List[str]]:
+        keys = list(self.options)
+        all_values = [self.options[k] for k in keys]
+        combos: List[List[str]] = []
+        for values in product(*all_values):
+            items = tuple(zip(keys, values))
+            if self._is_excluded(items):
+                continue
+            args: List[str] = []
+            for flag, val in items:
+                if val is None:
+                    args.append(flag)
+                else:
+                    args.extend([flag, str(val)])
+            combos.append(args)
+        return combos
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 import subprocess
 import sys
 
+from speaktome.cli_permutations import CLIArgumentMatrix
+
 
 def test_help_message():
     result = subprocess.run([
@@ -10,3 +12,18 @@ def test_help_message():
     ], capture_output=True, text=True)
     assert result.returncode == 0
     assert 'usage:' in result.stdout.lower()
+
+
+def test_basic_combinations():
+    matrix = CLIArgumentMatrix()
+    matrix.add_option('--max_steps', [1])
+    matrix.add_option('--safe_mode', [None])
+    combos = matrix.generate()
+    for combo in combos:
+        result = subprocess.run([
+            sys.executable,
+            '-m', 'speaktome.speaktome',
+            *combo,
+            'hi'
+        ], capture_output=True, text=True)
+        assert result.returncode == 0

--- a/tests/test_cli_permutations.py
+++ b/tests/test_cli_permutations.py
@@ -1,0 +1,9 @@
+from speaktome.cli_permutations import CLIArgumentMatrix
+
+
+def test_permutation_generation():
+    matrix = CLIArgumentMatrix()
+    matrix.add_option('--flag-a', [None])
+    matrix.add_option('--num', [1, 2])
+    combos = matrix.generate()
+    assert combos == [['--flag-a', '--num', '1'], ['--flag-a', '--num', '2']]

--- a/tests/test_validate_guestbook.py
+++ b/tests/test_validate_guestbook.py
@@ -1,0 +1,33 @@
+import os
+import shutil
+from pathlib import Path
+from importlib import reload
+
+import pytest
+
+import todo.validate_guestbook as vg
+SCRIPT = Path('todo/validate_guestbook.py')
+
+
+@pytest.fixture
+def temp_reports(tmp_path, monkeypatch):
+    dst = tmp_path / 'experience_reports'
+    dst.mkdir()
+    (dst / 'template_experience_report.md').write_text('')
+    for i in range(12):
+        fname = dst / f'2025-06-0{i}_v1_Test{i}.md'
+        fname.write_text('x')
+    vg_mod = reload(vg)
+    monkeypatch.setattr(vg_mod, 'REPORTS_DIR', str(dst))
+    monkeypatch.setattr(vg_mod, 'ARCHIVE_DIR', str(dst / 'archive'))
+    monkeypatch.setattr(vg_mod, 'STICKIES_FILE', str(dst / 'stickies.txt'))
+    return dst
+
+
+def test_archives_old_files(temp_reports):
+    vg.validate_and_fix()
+    vg.archive_old_reports()
+    archived_files = sorted(os.listdir(temp_reports / 'archive'))
+    assert len(archived_files) == 2
+
+

--- a/todo/experience_reports/2025-06-10_v5_Gap_Analysis_of_Agent_Files.md
+++ b/todo/experience_reports/2025-06-10_v5_Gap_Analysis_of_Agent_Files.md
@@ -1,0 +1,33 @@
+# Template User Experience Report
+
+**Date/Version:** 2025-06-10 v5
+**Title:** Gap Analysis of Agent Files
+
+## Overview
+Explored the repository as a new automated agent to understand agent organization and information coverage. Focused on verifying guest book instructions, reading AGENTS guidelines, and inspecting example tests.
+
+## Prompts
+"You are a random automated agent. You have found this repo. Test our agent files, organization, and informational content, look for gaps."
+"Welcome, wandering LLM! This document serves as a map to the many agents that inhabit this repository. Before diving into the code, pause a moment to sign our guest book."
+"Include a section in each report that captures verbatim any prompts or scripted instructions that guided the session."
+
+## Steps Taken
+1. Read `AGENTS.md` in the repo root and `todo/AGENTS.md` for instructions.
+2. Listed files under `todo/experience_reports` to review past reports.
+3. Examined `testing/lookahead_demo.py` as an example test harness.
+4. Created this experience report using the prescribed template and naming convention.
+5. Will run the `validate_guestbook.py` script to confirm file naming.
+
+## Observed Behaviour
+- Documentation clearly explains guest book usage and encourages agents to record sessions.
+- Past reports provide useful history of project decisions.
+- Testing directory contains a simple demo script but no automated test suite.
+- No coverage reports or continuous integration configuration were found.
+
+## Lessons Learned
+The guest book framework successfully tracks agent interactions. However, the project may benefit from additional automated tests and documentation about them. Consider clarifying how to run a full test suite if one exists.
+
+## Next Steps
+- Explore whether missing tests are intentional or simply absent from this repository.
+- Check other documentation for instructions on broader automated checks.
+

--- a/todo/experience_reports/2025-06-10_v6_Guestbook_Archival_and_CLI_Permutations.md
+++ b/todo/experience_reports/2025-06-10_v6_Guestbook_Archival_and_CLI_Permutations.md
@@ -1,0 +1,30 @@
+# Template User Experience Report
+
+**Date/Version:** 2025-06-10 v6
+**Title:** Guestbook Archival and CLI Permutations
+
+## Overview
+Implemented guestbook auto-archiving and started a dynamic CLI permutation helper. Added basic tests for both features.
+
+## Prompts
+"All missing tests are an oversight... This limits more powerful tests from being developed by the present agent. Modify the guestbook script to autoarchive into a folder to keep anything listed in a stickies .txt plus the last 10 entries. If you can make a test suite that will run through all arguments described in argparse..."
+
+## Steps Taken
+1. Created `archive` folder and `stickies.txt` list in `experience_reports`.
+2. Updated `validate_guestbook.py` to rename files, archive old entries, and load stickies.
+3. Added `CLIArgumentMatrix` to generate argument permutations.
+4. Wrote unit tests covering the new helper and guestbook script.
+5. Ran `todo/validate_guestbook.py` and `pytest -q`.
+
+## Observed Behaviour
+- The script moves excess reports to the archive folder.
+- Generated permutations skip excluded combinations.
+- All tests pass in the simplified environment.
+
+## Lessons Learned
+Automating guestbook maintenance will keep the directory manageable. Building a small permutation class lays groundwork for broader CLI testing.
+
+## Next Steps
+- Expand permutation coverage for more CLI options.
+- Refine archiving logic to restore files if needed.
+

--- a/todo/experience_reports/stickies.txt
+++ b/todo/experience_reports/stickies.txt
@@ -1,0 +1,2 @@
+2025-06-05_v1_New_User_Experience_Simulation.md
+2025-06-06_v4_CPU_Demo_Fallback_Issue.md

--- a/todo/validate_guestbook.py
+++ b/todo/validate_guestbook.py
@@ -3,6 +3,8 @@ import re
 
 REPORTS_DIR = os.path.join(os.path.dirname(__file__), 'experience_reports')
 TEMPLATE = 'template_experience_report.md'
+ARCHIVE_DIR = os.path.join(REPORTS_DIR, 'archive')
+STICKIES_FILE = os.path.join(REPORTS_DIR, 'stickies.txt')
 PATTERN = re.compile(r'\d{4}-\d{2}-\d{2}_v\d+_[A-Za-z0-9_]+\.md')
 
 def sanitize(name):
@@ -23,14 +25,40 @@ def validate_and_fix():
             changed = True
     return changed
 
+
+def load_stickies():
+    if not os.path.isfile(STICKIES_FILE):
+        return set()
+    with open(STICKIES_FILE, 'r', encoding='utf-8') as f:
+        lines = [ln.strip() for ln in f if ln.strip() and not ln.startswith('#')]
+    return set(lines)
+
+
+def archive_old_reports():
+    os.makedirs(ARCHIVE_DIR, exist_ok=True)
+    stickies = load_stickies()
+    files = [f for f in os.listdir(REPORTS_DIR)
+             if f.endswith('.md') and f not in {TEMPLATE}]
+    files.sort()
+    keep = stickies.union(files[-10:])
+    for fname in files:
+        if fname not in keep:
+            src = os.path.join(REPORTS_DIR, fname)
+            dest = os.path.join(ARCHIVE_DIR, fname)
+            if not os.path.exists(dest):
+                os.rename(src, dest)
+                print(f'Archived {fname}')
+
 if __name__ == '__main__':
     if not os.path.isdir(REPORTS_DIR):
         print('reports directory not found')
         raise SystemExit(1)
     changed = validate_and_fix()
+    archive_old_reports()
     files = sorted(os.listdir(REPORTS_DIR))
     print('Current files:')
     for f in files:
         print(' -', f)
     if not changed:
         print('All filenames conform to pattern.')
+


### PR DESCRIPTION
## Summary
- implement auto-archiving logic for guestbook validator
- add CLIArgumentMatrix utility and unit tests
- cover guestbook archiving with a unit test
- track sticky reports and archive folder
- document new features in a guest book entry

## Testing
- `pytest -q`
- `python todo/validate_guestbook.py`

------
https://chatgpt.com/codex/tasks/task_e_6842d9c2d7cc832a8e55bf1bad96192b