### PR TITLE
Implement PurePython tensor ops & fix NumPy backend

### DIFF
--- a/speaktome/core/tensor_abstraction.py
+++ b/speaktome/core/tensor_abstraction.py
@@ -351,7 +351,7 @@ class NumPyTensorOperations(AbstractTensorOperations):
         # Use these indices to gather the top k values
         values = np.take_along_axis(tensor, top_k_indices, axis=dim)
 
-        return values, indices
+        return values, top_k_indices
 
     def stack(self, tensors, dim=0):
         return np.stack(tensors, axis=dim)
@@ -386,7 +386,7 @@ class NumPyTensorOperations(AbstractTensorOperations):
             right_pad = pad[2 * (num_dims_to_pad - 1 - i) + 1]
             np_pad_width.append((left_pad, right_pad))
         
-        return np.pad(tensor, pad_width, constant_values=value)
+        return np.pad(tensor, np_pad_width, constant_values=value)
 
     def cat(self, tensors, dim=0):
         return np.concatenate(tensors, axis=dim)
@@ -473,6 +473,18 @@ class PurePythonTensorOperations(AbstractTensorOperations):
 
     def to_device(self, tensor: Any, device: Any) -> Any:
         return tensor
+
+    def stack(self, tensors: List[Any], dim: int = 0) -> Any:
+        if not tensors:
+            return []
+        if dim == 0:
+            return [self.clone(t) for t in tensors]
+        # verify shapes match
+        ref_shape = _get_shape(tensors[0])
+        for t in tensors:
+            if _get_shape(t) != ref_shape:
+                raise ValueError("All tensors must have the same shape")
+        return [self.stack([t[i] for t in tensors], dim=dim - 1) for i in range(len(tensors[0]))]
 
     def get_device(self, tensor: Any) -> Any:
         return "cpu_pure_python"
@@ -675,6 +687,15 @@ class PurePythonTensorOperations(AbstractTensorOperations):
         if not isinstance(tensor, list) or not isinstance(mask, list) or len(tensor) != len(mask):
             raise NotImplementedError("boolean_mask_select only supports flat lists with boolean mask")
         return [tensor[i] for i in range(len(tensor)) if mask[i]]
+
+    # Dtype helpers
+    @property
+    def long_dtype(self) -> Any:
+        return int
+
+    @property
+    def bool_dtype(self) -> Any:
+        return bool
 
 
 def _get_shape(data):

--- a/tests/test_pure_python_tensor_ops.py
+++ b/tests/test_pure_python_tensor_ops.py
@@ -1,0 +1,32 @@
+import pytest
+from speaktome.core.tensor_abstraction import PurePythonTensorOperations
+
+
+def test_stack_dim0_and_dim1():
+    ops = PurePythonTensorOperations()
+    t = [[1, 2], [3, 4]]
+    stacked0 = ops.stack([t, t], dim=0)
+    assert stacked0 == [[[1, 2], [3, 4]], [[1, 2], [3, 4]]]
+    stacked1 = ops.stack([t, t], dim=1)
+    assert stacked1 == [[[1, 2], [1, 2]], [[3, 4], [3, 4]]]
+
+
+def test_pad_2d():
+    ops = PurePythonTensorOperations()
+    t = [[1, 2], [3, 4]]
+    padded = ops.pad(t, (1, 1, 1, 1), value=0)
+    assert padded == [
+        [0, 0, 0, 0],
+        [0, 1, 2, 0],
+        [0, 3, 4, 0],
+        [0, 0, 0, 0],
+    ]
+
+
+def test_topk_and_dtypes():
+    ops = PurePythonTensorOperations()
+    values, indices = ops.topk([1, 3, 2, 4], k=2, dim=-1)
+    assert values == [4, 3]
+    assert indices == [3, 1]
+    assert ops.long_dtype is int
+    assert ops.bool_dtype is bool


### PR DESCRIPTION
## Summary
- implement missing methods in `PurePythonTensorOperations`
- fix bugs in `NumPyTensorOperations` topk and pad
- add tests for pure python backend

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843820ce280832abea04b30ad69721b