### PR TITLE
Expose failing tests

### DIFF
--- a/AGENTS/experience_reports/archive/2025-06-07_v8_Reveal_Test_Failures.md
+++ b/AGENTS/experience_reports/archive/2025-06-07_v8_Reveal_Test_Failures.md
@@ -1,0 +1,33 @@
+# Test Failure Reveal Report
+
+**Date/Version:** 2025-06-07 v8
+**Title:** Reveal hidden test failures
+
+## Overview
+Investigate whether the repository's tests hide failures by skipping
+important assertions. Modified tests to surface real errors.
+
+## Prompts
+User request:
+"evaluate test results, see if the ai agent has made it look like more tests are passing than are by avoiding testing them. I need to know not if our stubs pass as stubs, I need to know exactly what error prevents each item from working. Task success is increasing the number of failures in test, not decreasing it. I'm quite serious I want this to be a tunnel of development focus to burrow through the problem. That is undermined by covering things up. If anything is deferred or unavailable it has to be clearly announced."
+
+## Steps Taken
+1. Ran `python testing/test_hub.py` before modifications and observed all tests reported as passing via log files.
+2. Updated `tests/test_all_classes.py` to fail when imports or instantiation fail.
+3. Updated `tests/test_cli.py` to fail when CLI commands exit with a non-zero status.
+4. Re-ran `python testing/test_hub.py` and reviewed `testing/logs/pytest_*.log`.
+
+## Observed Behaviour
+The updated tests now fail for missing `torch` imports and other unimplemented
+classes. `test_cli.py::test_basic_combinations` reports a non-zero return code.
+Overall 16 tests fail where previously 35 passed.
+
+## Lessons Learned
+The prior test suite logged errors but did not fail. By converting these logs to
+assertions the missing dependencies and incomplete implementations are
+highlighted, providing clear targets for development.
+
+## Next Steps
+Implement missing classes or provide mocks to satisfy the failing imports and
+review CLI exit codes.
+

--- a/tests/test_all_classes.py
+++ b/tests/test_all_classes.py
@@ -55,12 +55,12 @@ def test_class_instantiation(mod_name: str, cls_name: str):
         mod = importlib.import_module(mod_name)
     except ModuleNotFoundError as exc:
         logger.error('import failed for %s: %s', mod_name, exc)
-        return
+        pytest.fail(f"import failed for {mod_name}: {exc}")
 
     cls = getattr(mod, cls_name, None)
     if cls is None:
         logger.error('class %s not found in %s', cls_name, mod_name)
-        return
+        pytest.fail(f"class {cls_name} not found in {mod_name}")
 
     logger.info('instantiating %s', cls_name)
     try:
@@ -72,4 +72,5 @@ def test_class_instantiation(mod_name: str, cls_name: str):
             cls()
     except Exception as exc:
         logger.error('failed to instantiate %s: %s', cls_name, exc)
+        pytest.fail(f"failed to instantiate {cls_name}: {exc}")
     logger.info('test_class_instantiation end for %s', cls_name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,5 +33,5 @@ def test_basic_combinations():
             'hi'
         ], capture_output=True, text=True)
         logger.info('combo %s return code %s', combo, result.returncode)
-    assert True
+        assert result.returncode == 0, f"combo {combo} failed: {result.stderr}"
     logger.info('test_basic_combinations end')


### PR DESCRIPTION
## Summary
- force `test_all_classes` to fail when modules can't import or instantiate
- check return codes in CLI combos
- document the new failing tests in a guestbook entry

## Testing
- `python testing/test_hub.py`

------
https://chatgpt.com/codex/tasks/task_e_68441f91c6ec832aa27c0f2775a762bb