### PR TITLE
Improve agent docs for filesystem map and testing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ bash -c 'echo "Dumping all docs and code (huge output)..." && \
   -exec echo "===== {} =====" \; -exec cat {} \;'
 ```
 
+For a short overview of the repository layout see `AGENTS_FILESYSTEM_MAP.md`.
+Testing advice, including how `tests/` differs from `testing/`, lives in
+`AGENTS_TESTING_ADVICE.md`.
+
 # Agents Documentation
 
 This document describes the primary agents and components in the beam search and PyGeoMind-based graph search system.

--- a/AGENTS/experience_reports/archive/2025-06-17_v10_Pytest_Tee_and_Stub_Skip_Option.md
+++ b/AGENTS/experience_reports/archive/2025-06-17_v10_Pytest_Tee_and_Stub_Skip_Option.md
@@ -1,0 +1,27 @@
+# Pytest Tee and Stub Skip Option
+
+**Date/Version:** 2025-06-17 v10
+**Title:** Pytest log tee and optional stub skipping
+
+## Overview
+Implemented tee logging so stdout still prints to the console while being captured in the log file. Added a `--skip-stubs` option to skip tests marked with `@pytest.mark.stub`. The flag is off by default so unfinished tests remain visible unless explicitly suppressed.
+
+## Prompts
+"We capture pytest stdout and it's confusing agents, can we set it up to tee the output to log not steal it?  also, we have this test skipping thing? I want it present but disabled. I want it to have to be a special argument to enable skipping listed stubs, we're trying to create an on-rails development area with pytest being a procedural pressure test. We can't go around not knowing right exactly where it isn't finished. The press is to get 100% of present code working in the next 3 days, preferrably yesterday."
+
+## Steps Taken
+1. Modified `tests/conftest.py` to replace stdout with a tee stream writing to both the terminal and the log file.
+2. Added `pytest_addoption` hook for `--skip-stubs` and implemented `pytest_collection_modifyitems` to honor it.
+3. Updated `testing/test_hub.py` to accept the new argument and pass it through to pytest.
+4. Ran `python AGENTS/validate_guestbook.py` to ensure report naming and archive rules.
+5. Executed `pytest -v` to verify the logging and option behaviour.
+
+## Observed Behaviour
+- Test output now appears in the console and still writes to `testing/logs/pytest_<timestamp>.log`.
+- When invoked with `--skip-stubs`, tests marked `stub` are skipped; otherwise they run normally.
+
+## Lessons Learned
+Making the logging less intrusive helps both human and automated agents follow failures directly in the console while still archiving the session logs. Optional skipping keeps the development pressure intact by default.
+
+## Next Steps
+Continue reviewing failing tests and incrementally replace stubs with real implementations.

--- a/AGENTS_FILESYSTEM_MAP.md
+++ b/AGENTS_FILESYSTEM_MAP.md
@@ -1,0 +1,15 @@
+# Repository Filesystem Map
+
+This document summarizes the major directories in `speaktome` and their purpose. Each folder with an `AGENTS.md` file contains local guidance for agents exploring that area.
+
+- `AGENTS/` – meta guidelines, experience reports, and shared agent resources.
+- `speaktome/` – the main Python package.
+- `tests/` – automated pytest suite.
+- `testing/` – ad‑hoc helper scripts (manual demos, test runner wrappers).
+- `models/` – small pretrained models for demos.
+- `training/` – optional data prep and experimental training utilities.
+- `todo/` – planning notes and task lists.
+
+Other files in the repository root include setup scripts (`run.sh`, `setup_env.sh`) and documentation such as `README.md`.
+
+Always consult the `AGENTS.md` within a subdirectory for instructions specific to that area.

--- a/AGENTS_TESTING_ADVICE.md
+++ b/AGENTS_TESTING_ADVICE.md
@@ -1,0 +1,10 @@
+# Testing Advice for Agents
+
+Two directories relate to tests:
+
+- `tests/` contains the official `pytest` suite. Run the full suite with `pytest -v` or by executing `python testing/test_hub.py`.
+- `testing/` hosts helper scripts for manual exploration. `test_hub.py` is a small wrapper around `pytest` that also writes `testing/stub_todo.txt` listing any tests marked with the `stub` marker. Pass `--skip-stubs` to the script if you want to temporarily ignore those placeholders.
+
+Log files for each test run are stored under `testing/logs/pytest_<TIMESTAMP>.log`. The last ten logs are kept automatically.
+
+Use the scripts in `testing/` when experimenting, but rely on the suite in `tests/` for formal verification.

--- a/testing/test_hub.py
+++ b/testing/test_hub.py
@@ -1,6 +1,7 @@
 """Run the test suite and collect stubbed tests."""
 from __future__ import annotations
 
+import argparse
 import pytest
 from pathlib import Path
 
@@ -15,9 +16,21 @@ class StubCollector:
                 self.stub_tests.append(item.nodeid)
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Run pytest and collect stub tests")
+    parser.add_argument(
+        "--skip-stubs",
+        action="store_true",
+        help="Skip tests marked with @pytest.mark.stub",
+    )
+    args = parser.parse_args(argv)
+
     collector = StubCollector()
-    ret = pytest.main(['-v', 'tests'], plugins=[collector])
+    pytest_args = ['-v', 'tests']
+    if args.skip_stubs:
+        pytest_args.append('--skip-stubs')
+
+    ret = pytest.main(pytest_args, plugins=[collector])
     todo = Path('testing/stub_todo.txt')
     with todo.open('w') as f:
         if collector.stub_tests:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,25 +15,33 @@ import os  # For FORCE_ENV
 # Import faculty components for logging
 from speaktome.faculty import DEFAULT_FACULTY, FORCE_ENV, Faculty
 
-class StreamToLogger:
-    """
-    Fake file-like stream object that redirects writes to a logger instance.
-    """
-    def __init__(self, logger, log_level=logging.INFO):
+class StdoutTee:
+    """Duplicate writes to the original stdout and a logger."""
+
+    def __init__(self, stream, logger, log_level=logging.INFO) -> None:
+        self.stream = stream
         self.logger = logger
         self.log_level = log_level
 
-    def write(self, buf):
+    def write(self, buf: str) -> None:  # pragma: no cover - passthrough
+        self.stream.write(buf)
         for line in buf.rstrip().splitlines():
             self.logger.log(self.log_level, line.rstrip())
 
-    def flush(self):
-        # Our logger logs immediately, so flush is a no-op.
-        pass
+    def flush(self) -> None:  # pragma: no cover - passthrough
+        self.stream.flush()
 
-    def isatty(self):  # pragma: no cover - mimic stdout interface
-        """Return False as this stream is not an interactive tty."""
-        return False
+    def isatty(self) -> bool:  # pragma: no cover - mimic stdout interface
+        return getattr(self.stream, "isatty", lambda: False)()
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--skip-stubs",
+        action="store_true",
+        default=False,
+        help="Skip tests marked with @pytest.mark.stub",
+    )
 
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "stub: placeholder test requiring implementation")
@@ -123,9 +131,9 @@ Active Faculty for this Session:
     root_logger.info("--------------------------------------------------------------------------------")
     # --- End Enhanced Log Header & Faculty Information ---
 
-    # Store original stdout and redirect sys.stdout to our logger
+    # Store original stdout and tee writes to both stdout and the log
     config._original_stdout = sys.stdout
-    sys.stdout = StreamToLogger(root_logger, logging.INFO)
+    sys.stdout = StdoutTee(config._original_stdout, root_logger, logging.INFO)
 
 
 def pytest_unconfigure(config: pytest.Config) -> None:
@@ -138,3 +146,15 @@ def pytest_unconfigure(config: pytest.Config) -> None:
     if handler:
         logging.getLogger().removeHandler(handler)
         handler.close()
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Optionally skip tests marked ``stub``."""
+    if not config.getoption("--skip-stubs"):
+        return
+
+    skip_stub = pytest.mark.skip(reason="stub skipped via --skip-stubs")
+    for item in items:
+        if 'stub' in item.keywords:
+            item.add_marker(skip_stub)
+


### PR DESCRIPTION
## Summary
- add `AGENTS_FILESYSTEM_MAP.md` for quick directory overview
- add `AGENTS_TESTING_ADVICE.md` clarifying `tests/` vs `testing/`
- reference the new guides in `AGENTS.md`

## Testing
- `pytest -q`
- `python AGENTS/validate_guestbook.py`


------
https://chatgpt.com/codex/tasks/task_e_6844314e228c832a95b8453828508446