### PR TITLE
Add job descriptions and stub audit notes

### DIFF
--- a/AGENTS/job_descriptions/AGENTS.md
+++ b/AGENTS/job_descriptions/AGENTS.md
@@ -1,0 +1,6 @@
+# Job Descriptions
+
+This folder hosts repeatable tasks for agents. Each Markdown file defines a job with
+clear steps and expectations. Agents should read the relevant job description
+before performing work.
+

--- a/AGENTS/job_descriptions/check_messages_job.md
+++ b/AGENTS/job_descriptions/check_messages_job.md
@@ -1,0 +1,8 @@
+# Check Messages and Reports Job
+
+Maintain the inbox, outbox, and experience report directories.
+
+1. Review `AGENTS/messages/inbox` for new files and archive them after reading.
+2. Ensure `AGENTS/messages/outbox` contains only undelivered messages.
+3. Run `python AGENTS/validate_guestbook.py` after adding reports.
+4. Delete stale logs or temporary files as needed.

--- a/AGENTS/job_descriptions/convert_to_tensor_abstraction_job.md
+++ b/AGENTS/job_descriptions/convert_to_tensor_abstraction_job.md
@@ -1,0 +1,12 @@
+# Convert Torch Code to Tensor Abstraction Job
+
+Some modules still call PyTorch APIs directly. To keep the project backend
+agnostic, migrate these operations to use
+`AbstractTensorOperations` (see `speaktome/core/tensor_abstraction.py`).
+
+Steps:
+1. Identify direct uses of `torch` or `torch.nn.functional`.
+2. Replace them with methods from `AbstractTensorOperations` passed into the
+   module or accessed via `config.tensor_ops`.
+3. Update tests to run on multiple backends.
+4. Note any behavior changes in an experience report.

--- a/AGENTS/job_descriptions/parallelize_loops_job.md
+++ b/AGENTS/job_descriptions/parallelize_loops_job.md
@@ -1,0 +1,9 @@
+# Parallelize Loops Job
+
+Identify computational hotspots and convert serial loops into parallel
+implementations where safe.
+
+1. Profile the code using `cProfile` or similar tools.
+2. Replace Python loops with NumPy or Torch vectorized operations when possible.
+3. Consider multiprocessing or `concurrent.futures` for IO-bound work.
+4. Document performance gains in an experience report.

--- a/AGENTS/job_descriptions/prioritize_stubs_job.md
+++ b/AGENTS/job_descriptions/prioritize_stubs_job.md
@@ -1,0 +1,8 @@
+# Prioritize Stubs Job
+
+Occasionally review existing stubs and rank them by project impact.
+
+1. Run `python AGENTS/tools/stubfinder.py` to list all stubs.
+2. Estimate which incomplete features block progress or tests.
+3. Create a priority table in `prioritize_stubs.md` with rationale.
+4. Update issues or TODO files based on this ranking.

--- a/AGENTS/job_descriptions/prototype_stubs_job.md
+++ b/AGENTS/job_descriptions/prototype_stubs_job.md
@@ -1,0 +1,11 @@
+# Prototype Stubs Job
+
+When introducing new features, create well-documented stubs so others can
+follow your intent.
+
+Steps:
+1. Place high‑visibility stub comments as defined in `AGENTS/CODING_STANDARDS.md`.
+2. Include a `TODO` list with implementation tasks.
+3. If the stub should raise an error, use `NotImplementedError`.
+4. Add a brief `test()` method to demonstrate current behaviour.
+5. Document progress in an experience report.

--- a/AGENTS/job_descriptions/stub_audit_job.md
+++ b/AGENTS/job_descriptions/stub_audit_job.md
@@ -1,0 +1,11 @@
+# Stub Audit Job
+
+Verify that each file listed in `AGENTS/stub_audit_list.txt` adheres to
+`AGENTS/CODING_STANDARDS.md` for stub formatting. For each file:
+
+1. Open the file and search for `########## STUB` markers.
+2. Confirm the block comment includes PURPOSE, EXPECTED BEHAVIOR, INPUTS,
+   OUTPUTS, KEY ASSUMPTIONS, TODO, and NOTES sections.
+3. If the file has no stubs, mark it `OK`.
+4. Record your check in `AGENTS/stub_audit_signoff.txt` with `OK` or details.
+5. Commit updates and run the test suite (`pytest -q`).

--- a/AGENTS/stub_audit_signoff.txt
+++ b/AGENTS/stub_audit_signoff.txt
@@ -1,0 +1,8 @@
+# Stub Audit Manual Sign-Off
+# Mark each file as 'OK' when verified compliant with CODING_STANDARDS.
+
+AGENTS/messages/create_digest.py - OK
+AGENTS/register_agent.py - OK
+AGENTS/tools/fetch_official_time.py - OK
+AGENTS/tools/header_guard_precommit.py - OK
+speaktome/core/beam_search.py - STUB documented, OK


### PR DESCRIPTION
## Summary
- create `job_descriptions` folder with repeatable task guides
- outline stub audit procedure and other common jobs
- start a manual stub audit sign-off list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68450d4c0260832ab44c25f59179ae01