### PR TITLE
Add job dispenser instructions and minor cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,17 @@ For a short overview of the repository layout see `AGENTS_FILESYSTEM_MAP.md`.
 Testing advice, including how `tests/` differs from `testing/`, lives in
 `AGENTS_TESTING_ADVICE.md`.
 
+## Job Selection
+
+Agents unsure what to work on can request a task via the job dispenser:
+
+```bash
+python -m AGENTS.tools.dispense_job
+```
+
+Open the printed file under `AGENTS/job_descriptions/` and follow its steps.
+Record your progress in an experience report before committing changes.
+
 # Agents Documentation
 
 This document describes the primary agents and components in the beam search and PyGeoMind-based graph search system.

--- a/AGENTS/experience_reports/archive/2025-06-08_v1_Bug_Fix_Guidance_Update.md
+++ b/AGENTS/experience_reports/archive/2025-06-08_v1_Bug_Fix_Guidance_Update.md
@@ -1,0 +1,26 @@
+# Template User Experience Report
+
+**Date/Version:** 2025-06-08 v1
+**Title:** Bug fix and job guidance update
+
+## Overview
+Demonstrated the job dispenser workflow and removed a deprecation warning.
+
+## Prompts
+"gracefully and minimally guide agents in addition to present guides to, should they want to perform a commit, obtain a job and fulfill it while they are inside the repo. This is meant to be a living repo project. you may also clean out the fire block in the environmental setup. When you finish, test by obtaining a job and completing it."
+
+## Steps Taken
+1. Ran `python -m AGENTS.tools.dispense_job --seed 123` to obtain `bug_hunting_job.md`.
+2. Executed the test suite with `pytest -q` and noted deprecation warnings from `dump_headers.py`.
+3. Updated `dump_headers.py` to use `ast.Constant` instead of `ast.Str`.
+4. Removed the fire emoji block from `setup_env.sh`.
+5. Added job dispenser instructions to documentation.
+
+## Observed Behaviour
+Tests pass without warnings after the fix. Documentation now mentions how to obtain jobs.
+
+## Lessons Learned
+The job dispenser provides simple guidance when no tasks are obvious. Cleaning small warnings keeps the suite healthy.
+
+## Next Steps
+Explore other job descriptions and continue improving test coverage.

--- a/AGENTS/job_descriptions/AGENTS.md
+++ b/AGENTS/job_descriptions/AGENTS.md
@@ -1,6 +1,16 @@
 # Job Descriptions
 
-This folder hosts repeatable tasks for agents. Each Markdown file defines a job with
-clear steps and expectations. Agents should read the relevant job description
-before performing work.
+This folder hosts repeatable tasks for agents. Each Markdown file defines a job
+with clear steps and expectations. Agents should read the relevant job
+description before performing work.
+
+To obtain a task at random, run:
+
+```bash
+python -m AGENTS.tools.dispense_job
+```
+
+The script prints the name of a job description file. Open that file, follow the
+steps, then document your results in an experience report. Commit your changes
+as usual and run the test suite before opening a pull request.
 

--- a/dump_headers.py
+++ b/dump_headers.py
@@ -41,9 +41,10 @@ def collect_class_info(pyfile: Path) -> list[dict[str, object]]:
                 if (
                     isinstance(stmt, ast.Assign)
                     and any(isinstance(t, ast.Name) and t.id == "HEADER" for t in stmt.targets)
-                    and isinstance(stmt.value, ast.Str)
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
                 ):
-                    header = stmt.value.s
+                    header = stmt.value.value
                 if isinstance(stmt, ast.FunctionDef) and stmt.name == "test":
                     has_test = any(
                         isinstance(deco, ast.Name) and deco.id == "staticmethod"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -73,13 +73,7 @@ echo "❄️  Erasing digital scars..."
 echo "❄️  Severing broken LFS chains..."
 echo "❄️  History? Gone. Just code remains."
 echo
-echo "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥"
-echo "🔥       REPO REBIRTH COMPLETE        🔥"
-echo "🔥          A CLEAN BEGINNING          🔥"
-echo "🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥"
-echo
-echo "remove the fire emojis after the purge"
-echo
+echo "Repository purge complete."
 echo "✅ Environment ready. Activate with 'source .venv/bin/activate'."
 echo "   • Core  = requirements.txt + dev"
 echo "   • Plot  = matplotlib, networkx, scikit-learn"


### PR DESCRIPTION
## Summary
- show how to obtain a job via `dispense_job`
- streamline the environmental setup script
- fix `dump_headers` deprecation warning
- document the changes in a new experience report

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845d3a0a7a0832abddc0591d1563091