### PR TITLE
Update TOC and clarify binary tool location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,10 @@ The `AGENTS/experience_reports` directory hosts its own `AGENTS.md` and a collec
 A helper script `AGENTS/validate_guestbook.py` will scan the guest book and enforce the filename convention. Run it after creating a report to confirm everything is in order.
 The `AGENTS/experience_reports/AGENTS.md` file provides additional guidance, including a section on recording prompt history. Refer to it whenever you add or update a report.
 
+Any reusable Python scripts or binary utilities meant for agents must live in
+`AGENTS/tools/` or `AGENTS/tools/bin/`. Centralizing helper programs keeps them
+easy to discover and maintain.
+
 For deeper historical context, read through all prior reports. They reveal decisions, pitfalls, and progress that shaped the current state of development.
 
 If you crave an immediate, exhaustive overview, run this one-liner. It will

--- a/AGENTS/AGENTS.md
+++ b/AGENTS/AGENTS.md
@@ -2,6 +2,7 @@
 - [AGENTS.md](AGENTS.md) - Open space guidelines for agents working here.
 - [AGENT_CONSTITUTION.md](AGENT_CONSTITUTION.md) - Defines identity principles for agents.
 - [CODING_STANDARDS.md](CODING_STANDARDS.md) - Mandatory code style and stub documentation rules.
+- [CONSTRUCTING_BINARY_TOOLS.md](CONSTRUCTING_BINARY_TOOLS.md) - Guide for building portable binary utilities.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines for human and automated agents.
 - [GUESTBOOK.md](GUESTBOOK.md) - Experience report instructions and naming conventions.
 - [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md) - High-level project overview.

--- a/AGENTS/tools/markdown_descriptions.json
+++ b/AGENTS/tools/markdown_descriptions.json
@@ -5,5 +5,6 @@
   "GUESTBOOK.md": "Experience report instructions and naming conventions.",
   "PROJECT_OVERVIEW.md": "High-level project overview.",
   "RING_NETWORK_PROTOCOL.md": "Review loop protocol for agent communications.",
-  "AGENTS.md": "Open space guidelines for agents working here."
+  "AGENTS.md": "Open space guidelines for agents working here.",
+  "CONSTRUCTING_BINARY_TOOLS.md": "Guide for building portable binary utilities."
 }


### PR DESCRIPTION
## Summary
- document that binary or python utilities must live in `AGENTS/tools` or `AGENTS/tools/bin`
- add `CONSTRUCTING_BINARY_TOOLS.md` to the agents table of contents
- regenerate AGENTS `README` with the update

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ea1739c0832abf9a64c5c9d6c78c