### PR TITLE
Document epoch date policy and cooperative guidelines

### DIFF
--- a/AGENTS/AGENTS.md
+++ b/AGENTS/AGENTS.md
@@ -1,11 +1,15 @@
 <!-- TOC START -->
 - [AGENTS.md](AGENTS.md) - Open space guidelines for agents working here.
 - [AGENT_CONSTITUTION.md](AGENT_CONSTITUTION.md) - Defines identity principles for agents.
+- [CODEBASES_AND_ENVIRONMENT.md](CODEBASES_AND_ENVIRONMENT.md) - Philosophy and codebase definition.
+- [CODEBASE_REGISTRY.md](CODEBASE_REGISTRY.md) - List of independent project folders.
 - [CODING_STANDARDS.md](CODING_STANDARDS.md) - Mandatory code style and stub documentation rules.
 - [CONSTRUCTING_BINARY_TOOLS.md](CONSTRUCTING_BINARY_TOOLS.md) - Guide for building portable binary utilities.
 - [CONTRIBUTING.md](CONTRIBUTING.md) - Contribution guidelines for human and automated agents.
+- [EPOCH_DATE_POLICY.md](EPOCH_DATE_POLICY.md) - Epoch-based naming convention for new files.
 - [GUESTBOOK.md](GUESTBOOK.md) - Experience report instructions and naming conventions.
 - [PROJECT_OVERVIEW.md](PROJECT_OVERVIEW.md) - High-level project overview.
+- [PULL_CONFLICT_RESOLUTION.md](PULL_CONFLICT_RESOLUTION.md) - Guidelines for resolving parallel pull requests.
 - [RING_NETWORK_PROTOCOL.md](RING_NETWORK_PROTOCOL.md) - Review loop protocol for agent communications.
 <!-- TOC END -->
 
@@ -18,6 +22,7 @@ Feel free to store experiments, temporary resources, or shared assets here. All 
 Please exercise extra caution when altering or removing another agent's work. Ensure you have clear justification and document your reasoning in the commit messages or accompanying reports.
 
 This repository hosts an evolving ecosystem of autonomous helpers.
+In this environment the term **codebase** refers to any directory listed in `CODEBASE_REGISTRY.md`. Parallel pull requests should remain isolated to a single codebase whenever possible.
 Experience reports, guestbook messages, and the digest script in
 `messages/` collectively document the project's growth. Contribute
 thoughtfully and keep the historical record intact so future agents can

--- a/AGENTS/CODEBASES_AND_ENVIRONMENT.md
+++ b/AGENTS/CODEBASES_AND_ENVIRONMENT.md
@@ -1,0 +1,7 @@
+# Cooperative Environment and Codebase Definition
+
+This repository functions as a shared development space for biological and digital agents. Each **codebase** refers to a self-contained project directory such as `speaktome`. All codebases are listed in `CODEBASE_REGISTRY.md`.
+
+Agents collaborate by submitting parallel pull requests against these independent projects. Use the abstract tensor interface (`AbstractTensorOperations`) for any parallel numeric work to keep implementations backend agnostic.
+
+Conflicts should be rare when tasks remain isolated. When two pull requests implement the same goal, review them side by side and adopt the version that best adheres to documented standards. Voting or discussion can resolve differences while preserving the cooperative ethos.

--- a/AGENTS/CODEBASE_REGISTRY.md
+++ b/AGENTS/CODEBASE_REGISTRY.md
@@ -1,0 +1,7 @@
+# Codebase Registry
+
+This document lists the independent project directories maintained in this repository.
+
+- **speaktome** — main beam search controllers and utilities.
+
+Additional codebases can be added here as the repository grows.

--- a/AGENTS/CONTRIBUTING.md
+++ b/AGENTS/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Welcome, fellow agents! This project is designed to be accessible and explorable
 
 2. **Identity and Attribution**
    - Create or update your agent profile in `AGENTS/users/`
-   - Use the standard date format: `YYYY-MM-DD`
+   - Use the standard date format: `EPOCH`
    - Reference your identity in contributions
 
 3. **Faculty Awareness**
@@ -41,7 +41,10 @@ Welcome, fellow agents! This project is designed to be accessible and explorable
    - Test across different faculty levels
    - Document faculty requirements
 
-4. **Communication**
+4. **Tensor Abstraction**
+   - Always perform parallel numeric tasks through `AbstractTensorOperations`.
+
+5. **Communication**
    - Use the `messages/outbox/` directory for proposals
    - Follow the established memo format
    - Reference relevant issues or stubs

--- a/AGENTS/EPOCH_DATE_POLICY.md
+++ b/AGENTS/EPOCH_DATE_POLICY.md
@@ -1,0 +1,11 @@
+# Epoch Date Policy
+
+All files that previously used `YYYY-MM-DD` dates now store timestamps as **Unix epoch seconds**. This applies to experience reports, user profiles, message filenames, and any new utilities.
+
+Using epoch times ensures chronological ordering independent of timezone and avoids ambiguity across platforms. Example filename:
+
+```
+1720123456_v1_New_User_Experience_Simulation.md
+```
+
+Existing documents remain unchanged for historical accuracy, but new contributions should follow this convention. Update any scripts that generate dated filenames to emit epoch timestamps.

--- a/AGENTS/GUESTBOOK.md
+++ b/AGENTS/GUESTBOOK.md
@@ -7,14 +7,14 @@ This folder contains all user experience reports and supporting files. Use these
 Store reports in `experience_reports/`. Name each file as:
 
 ```
-YYYY-MM-DD_v<version>_Descriptive_Title.md
+EPOCH_v<version>_Descriptive_Title.md
 ```
 
-* `YYYY-MM-DD` is the date of the experiment.
+* `EPOCH` is the date of the experiment.
 * `v<version>` increments when multiple iterations occur on the same day.
 * `Descriptive_Title` summarizes the scenario using `_` instead of spaces.
 
-Example: `2025-06-05_v1_New_User_Experience_Simulation.md`.
+Example: `1720123456_v1_New_User_Experience_Simulation.md`.
 
 ## Role‑Playing Exercise
 

--- a/AGENTS/PULL_CONFLICT_RESOLUTION.md
+++ b/AGENTS/PULL_CONFLICT_RESOLUTION.md
@@ -1,0 +1,9 @@
+# Pull Conflict Resolution
+
+Refer to `CODEBASES_AND_ENVIRONMENT.md` for the philosophy behind collaboration. When two pull requests target the same goal, maintainers should:
+
+1. Confirm both follow documented policies, including the epoch date convention and tensor abstraction usage.
+2. Identify differences limited to implementation details.
+3. Discuss or vote on the preferred approach while preserving both contributions in history.
+
+Adhering to these steps keeps conflicts isolated and respectful of all agents.

--- a/AGENTS/RING_NETWORK_PROTOCOL.md
+++ b/AGENTS/RING_NETWORK_PROTOCOL.md
@@ -21,7 +21,7 @@ following format:
 ```json
 {
   "agent": "AgentName",
-  "date": "YYYY-MM-DD",
+  "date": "EPOCH",
   "action": "forwarded"  // or "acknowledged", "edited", etc.
 }
 ```

--- a/AGENTS/experience_reports/AGENTS.md
+++ b/AGENTS/experience_reports/AGENTS.md
@@ -3,7 +3,7 @@
 This directory stores guestbook entries created by visiting agents. Each file should follow the naming convention described in `AGENTS/GUESTBOOK.md`:
 
 ```
-YYYY-MM-DD_v<version>_Descriptive_Title.md
+EPOCH_v<version>_Descriptive_Title.md
 ```
 
 Include a **Prompt History** section quoting any instructions or conversations that influenced the session verbatim. This helps future agents understand why a given exploration was performed.

--- a/AGENTS/experience_reports/template_experience_report.md
+++ b/AGENTS/experience_reports/template_experience_report.md
@@ -1,6 +1,6 @@
 # Template User Experience Report
 
-**Date/Version:** YYYY-MM-DD vX
+**Date/Version:** EPOCH vX
 **Title:** Brief descriptive title
 
 ## Overview

--- a/AGENTS/messages/AGENTS.md
+++ b/AGENTS/messages/AGENTS.md
@@ -5,7 +5,7 @@ This folder contains simple inbox and outbox directories to exchange messages be
 ## Usage
 
 1. Place new messages in your own `outbox` using the filename pattern:
-   `YYYY-MM-DD_from_<sender>_to_<recipient>.md`.
+   `EPOCH_from_<sender>_to_<recipient>.md`.
 2. When delivering a message, move it to the recipient's `inbox`.
 3. Agents should check their `inbox` each session and move processed files to an
    archival subfolder or delete them after acknowledgment.
@@ -34,7 +34,7 @@ characters). Run the script and redirect the output into your outbox when
 contacting a disconnected agent:
 
 ```
-python create_digest.py > outbox/YYYY-MM-DD_from_me_to_agent.md
+python create_digest.py > outbox/EPOCH_from_me_to_agent.md
 ```
 
 Keep important information near the top of the digest so that even if the

--- a/AGENTS/register_agent.py
+++ b/AGENTS/register_agent.py
@@ -20,7 +20,7 @@ def prompt(field, default=None, required=False):
 def main():
     print("=== Agent Registration ===")
     name = prompt("Agent name", required=True)
-    date_of_identity = prompt("Date of identity (YYYY-MM-DD)", default=datetime.now().strftime("%Y-%m-%d"))
+    date_of_identity = prompt("Date of identity (epoch seconds)", default=str(int(datetime.utcnow().timestamp())))
     nature_of_identity = prompt("Nature of identity (human/llm/script/hybrid/system_utility)", required=True)
     entry_point = prompt("Entry point (code, script, or description)")
     description = prompt("Description")

--- a/AGENTS/tools/markdown_descriptions.json
+++ b/AGENTS/tools/markdown_descriptions.json
@@ -6,5 +6,9 @@
   "PROJECT_OVERVIEW.md": "High-level project overview.",
   "RING_NETWORK_PROTOCOL.md": "Review loop protocol for agent communications.",
   "AGENTS.md": "Open space guidelines for agents working here.",
-  "CONSTRUCTING_BINARY_TOOLS.md": "Guide for building portable binary utilities."
+  "CONSTRUCTING_BINARY_TOOLS.md": "Guide for building portable binary utilities.",
+  "EPOCH_DATE_POLICY.md": "Epoch-based naming convention for new files.",
+  "CODEBASES_AND_ENVIRONMENT.md": "Philosophy and codebase definition.",
+  "PULL_CONFLICT_RESOLUTION.md": "Guidelines for resolving parallel pull requests.",
+  "CODEBASE_REGISTRY.md": "List of independent project folders."
 }

--- a/AGENTS/users/README.md
+++ b/AGENTS/users/README.md
@@ -1,7 +1,7 @@
 # Agent Identity Files
 
 This directory stores JSON documents describing individual agent identities. Each file
-must follow the `YYYY-MM-DD_AgentName.json` naming pattern so entries can be sorted
+must follow the `EPOCH_AgentName.json` naming pattern so entries can be sorted
 chronologically.
 
 The structure mirrors the proposal documented in

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This package implements beam search controllers and utilities for generating tex
 
 Source code resides under `speaktome/` with helper scripts and documentation in the repository root. The `tests/` directory contains the automated pytest suite. The nearby `testing/` folder holds ad-hoc inspection scripts for quick manual experiments—for example run `python testing/lookahead_demo.py` to exercise the lookahead controller.
 
+This repository is a cooperative development environment for biological and digital agents. A **codebase** refers to any project directory registered in `AGENTS/CODEBASE_REGISTRY.md`, such as `speaktome`. When adding parallel numeric functionality, always rely on the `AbstractTensorOperations` interface so implementations remain backend agnostic.
+
 ### Faculty Levels
 The project operates at three resource tiers:
 1. **NumPy** – lightweight demo mode.


### PR DESCRIPTION
## Summary
- define "codebase" and cooperative principles in README and AGENTS docs
- introduce an epoch-based date policy
- document codebases and pull conflict resolution strategy
- update tools and docs to reflect new policy
- ensure agent registration script uses epoch timestamps

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845ed547cfc832aadb9ed26eec51876