### PR TITLE
Fix tensor ops menu path handling

### DIFF
--- a/testing/AGENTS.md
+++ b/testing/AGENTS.md
@@ -8,5 +8,6 @@ Use these utilities when you want to try things quickly without the full test ha
 - `test_hub.py` runs `pytest` and writes `stub_todo.txt` so you can see which stub tests remain.
 - `stub_todo.txt` is generated automatically and lists placeholders awaiting real tests.
 - `benchmark_tensor_ops.py` measures basic operation speed across available tensor backends.
+- `tensor_ops_menu.py` lets you interactively verify abstract tensor operations using any available backend.
 
 Feel free to add your own exploratory scripts here.

--- a/testing/tensor_ops_menu.py
+++ b/testing/tensor_ops_menu.py
@@ -5,7 +5,13 @@ Allows selecting available backends and running small correctness tests.
 # --- END HEADER ---
 
 import importlib.util
+import os
+import sys
 from typing import Any, Tuple
+
+REPO_ROOT = os.path.dirname(os.path.dirname(__file__))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 
 from speaktome import tensors as ta
 


### PR DESCRIPTION
## Summary
- make tensor_ops_menu.py adjust sys.path so it can run without PYTHONPATH
- document tensor_ops_menu.py in testing/AGENTS.md

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684628bf01e0832abeada35f895fd032