### PR TITLE
Implement scalar tensor ops

### DIFF
--- a/speaktome/core/lookahead_controller.py
+++ b/speaktome/core/lookahead_controller.py
@@ -121,14 +121,18 @@ class LookaheadController:
             )
             logits = outputs_dict['logits']
 
-            last_indices = self.tensor_ops.clamp(current_lengths - 1, min_val=0)
+            last_indices = self.tensor_ops.clamp(
+                self.tensor_ops.sub_scalar(current_lengths, 1), min_val=0
+            )
             last_logits = self.tensor_ops.select_by_indices(
                 logits,
                 self.tensor_ops.arange(0, B_cur, device=self.device),
                 last_indices,
             )
 
-            logprobs = self.tensor_ops.log_softmax(last_logits / self.temp, dim=-1)
+            logprobs = self.tensor_ops.log_softmax(
+                self.tensor_ops.div_scalar(last_logits, self.temp), dim=-1
+            )
             topk_scores, topk_indices = self.tensor_ops.topk(logprobs, k=self.top_k, dim=-1)
 
             num_parents = B_cur

--- a/speaktome/tensors/abstraction.py
+++ b/speaktome/tensors/abstraction.py
@@ -160,6 +160,16 @@ class AbstractTensorOperations(ABC):
     def index_select(self, tensor: Any, dim: int, indices: Any) -> Any:
         pass
 
+    @abstractmethod
+    def sub_scalar(self, tensor: Any, value: Any) -> Any:
+        """Return ``tensor`` element-wise minus ``value``."""
+        pass
+
+    @abstractmethod
+    def div_scalar(self, tensor: Any, value: Any) -> Any:
+        """Return ``tensor`` element-wise divided by ``value``."""
+        pass
+
     # --- Persistence helpers ---
     @abstractmethod
     def save(self, tensor: Any, filepath: str) -> None:

--- a/speaktome/tensors/numpy_backend.py
+++ b/speaktome/tensors/numpy_backend.py
@@ -173,6 +173,12 @@ class NumPyTensorOperations(AbstractTensorOperations):
     def index_select(self, tensor, dim, indices):
         return np.take(tensor, indices, axis=dim)
 
+    def sub_scalar(self, tensor, value):
+        return tensor - value
+
+    def div_scalar(self, tensor, value):
+        return tensor / value
+
     def save(self, tensor, filepath: str) -> None:
         np.save(filepath, tensor)
 

--- a/speaktome/tensors/pure_backend.py
+++ b/speaktome/tensors/pure_backend.py
@@ -276,6 +276,16 @@ class PurePythonTensorOperations(AbstractTensorOperations):
             return [[row[i] for i in indices] for row in tensor]
         raise NotImplementedError("index_select only implemented for dim 0 or 1")
 
+    def sub_scalar(self, tensor: Any, value: Any) -> Any:
+        if isinstance(tensor, list):
+            return [self.sub_scalar(item, value) for item in tensor]
+        return tensor - value
+
+    def div_scalar(self, tensor: Any, value: Any) -> Any:
+        if isinstance(tensor, list):
+            return [self.div_scalar(item, value) for item in tensor]
+        return tensor / value
+
     def save(self, tensor: Any, filepath: str) -> None:
         with open(filepath, "w") as f:
             json.dump(tensor, f)

--- a/speaktome/tensors/torch_backend.py
+++ b/speaktome/tensors/torch_backend.py
@@ -118,6 +118,12 @@ class PyTorchTensorOperations(AbstractTensorOperations):
     def index_select(self, tensor, dim, indices):
         return torch.index_select(tensor, dim, indices)
 
+    def sub_scalar(self, tensor, value):
+        return tensor - value
+
+    def div_scalar(self, tensor, value):
+        return tensor / value
+
     def save(self, tensor, filepath: str) -> None:
         torch.save(tensor, filepath)
 

--- a/tests/test_tensor_backends.py
+++ b/tests/test_tensor_backends.py
@@ -65,6 +65,9 @@ def run_checks(ops):
     assert vals == expect_vals
     assert idxs == expect_inds
 
+    assert ops.sub_scalar([2, 4, 6], 1) == [1, 3, 5]
+    assert ops.div_scalar([2.0, 4.0], 2.0) == [1.0, 2.0]
+
     assert ops.long_dtype is not None
     assert ops.bool_dtype is not None
 


### PR DESCRIPTION
## Summary
- add `sub_scalar` and `div_scalar` to tensor abstraction
- implement scalar ops in pure Python, NumPy and PyTorch backends
- use new scalar ops inside `LookaheadController.run`
- expand tensor backend tests to cover scalar ops

## Testing
- `python testing/test_hub.py`

------
https://chatgpt.com/codex/tasks/task_e_68463e68cf2c832abc9d7d223f989e2e