### PR TITLE
Ensure time_sync uses ntplib

### DIFF
--- a/time_sync/pyproject.toml
+++ b/time_sync/pyproject.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 requires-python = ">=3.8"
 license = { text = "MIT" }
 authors = [{ name = "Time Sync Authors" }]
+dependencies = [
+    "ntplib"  # Network Time Protocol client library
+]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/time_sync/time_sync/_internet.py
+++ b/time_sync/time_sync/_internet.py
@@ -5,26 +5,21 @@ from __future__ import annotations
 import datetime as _dt
 import json
 import urllib.request
-
-try:
-    import ntplib  # type: ignore
-except Exception:  # pragma: no cover - optional
-    ntplib = None
+import ntplib  # type: ignore
 
 # --- END HEADER ---
 
 
 def fetch_internet_utc() -> _dt.datetime:
     """Return the current UTC time from an online source."""
-    if ntplib is not None:
-        try:
-            client = ntplib.NTPClient()
-            resp = client.request("pool.ntp.org", version=3, timeout=5)
-            return _dt.datetime.fromtimestamp(resp.tx_time, tz=_dt.timezone.utc)
-        except Exception:
-            pass
-
-    url = "https://worldtimeapi.org/api/timezone/Etc/UTC"
-    with urllib.request.urlopen(url, timeout=10) as resp:
-        data = json.load(resp)
-    return _dt.datetime.fromisoformat(data["utc_datetime"]).astimezone(_dt.timezone.utc)
+    try:
+        client = ntplib.NTPClient()
+        resp = client.request("pool.ntp.org", version=3, timeout=5)
+        return _dt.datetime.fromtimestamp(resp.tx_time, tz=_dt.timezone.utc)
+    except Exception:  # pragma: no cover - network may fail
+        url = "https://worldtimeapi.org/api/timezone/Etc/UTC"
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = json.load(resp)
+        return _dt.datetime.fromisoformat(data["utc_datetime"]).astimezone(
+            _dt.timezone.utc
+        )


### PR DESCRIPTION
## Summary
- ensure the time_sync package depends on `ntplib`
- use `ntplib` unconditionally in the `_internet` module with a worldtimeapi fallback

## Testing
- `python testing/test_hub.py`

------
https://chatgpt.com/codex/tasks/task_e_68466de544f0832ab50df42541cfdc89