### PR TITLE
Fix environment setup duplication and agent tools packaging

### DIFF
--- a/AGENTS/tools/README.md
+++ b/AGENTS/tools/README.md
@@ -1,0 +1,3 @@
+# Agent Tools
+
+Utility scripts and helper functions for the SpeakToMe project.

--- a/AGENTS/tools/ensure_pyproject_deps.py
+++ b/AGENTS/tools/ensure_pyproject_deps.py
@@ -4,7 +4,11 @@ import importlib.util
 import subprocess
 import sys
 from pathlib import Path
-import tomllib
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    import tomli as tomllib
 # --- END HEADER ---
 
 """Ensure optional dependencies from ``pyproject.toml`` are installed.

--- a/AGENTS/tools/pyproject.toml
+++ b/AGENTS/tools/pyproject.toml
@@ -2,20 +2,21 @@
 name = "speaktome-agent-tools"
 version = "0.1.0"
 description = "Agent tools and repo management utilities for SpeakToMe"
-authors = [
-    { name = "Your Name", email = "your@email.com" }
-]
+authors = [ { name = "Your Name", email = "your@email.com" } ]
 readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "tomli; python_version<'3.11'",
     "importlib-metadata; python_version<'3.8'",
-    "pytz"  # For timezone-aware datetime objects
-    "ntplib"      # For querying NTP servers
-    "pytest>=8.0" # Test framework
+    "pytz",
+    "ntplib",
+    "pytest>=8.0",
 ]
 
-[build-system]
-requires = ["setuptools>=61.0", "wheel"]
-build-backend = "setuptools.build_meta"
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["*"]
 
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/AGENTS/tools/setup.py
+++ b/AGENTS/tools/setup.py
@@ -1,0 +1,14 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='speaktome-agent-tools',
+    version='0.1.0',
+    packages=find_packages(),
+    install_requires=[
+        "tomli; python_version<'3.11'",
+        "importlib-metadata; python_version<'3.8'",
+        "pytz",
+        "ntplib",
+        "pytest>=8.0",
+    ],
+)

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -59,10 +59,7 @@ if ($extras) {
     }
 }
 
-# Install package in editable mode so changes are picked up automatically
-Safe-Run { & $venvPip install -e speaktome }
-
-# Install additional codebases in editable mode
+# Install codebases in editable mode so changes are picked up automatically
 foreach ($cb in $Codebases) {
     if ($cb -ne "." -and ((Test-Path "$cb\pyproject.toml") -or (Test-Path "$cb\setup.py"))) {
         Safe-Run { & $venvPip install -e $cb }

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -75,10 +75,7 @@ if [ $EXTRAS -eq 1 ]; then
   fi
 fi
 
-# Install package in editable mode so local changes apply immediately
-safe_run $VENV_PIP install -e speaktome
-
-# Install additional codebases in editable mode
+# Install codebases in editable mode so local changes apply immediately
 IFS=',' read -ra CB <<< "$CODEBASES"
 for cb in "${CB[@]}"; do
   [ "$cb" = "." ] && continue


### PR DESCRIPTION
## Summary
- avoid duplicate install of `speaktome` package in environment setup scripts
- repair optional dependency detection to fall back to `tomli`
- provide minimal packaging for agent tools
- add short readme for the agent tools codebase

## Testing
- `bash setup_env.sh --no-venv` *(passes)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684676055778832aa6a37b890a6b90ff