### PR TITLE
Add JAX backend conversions and tests

### DIFF
--- a/speaktome/tensors/abstraction.py
+++ b/speaktome/tensors/abstraction.py
@@ -415,4 +415,35 @@ if torch is not None and PyTorchTensorOperations is not None and NumPyTensorOper
     register_conversion(PurePythonTensorOperations, PyTorchTensorOperations,
                         lambda s, t, o: o.tensor_from_list(t, dtype=None, device=o.default_device))
 
+try:
+    from .jax_backend import JAXTensorOperations
+except Exception:  # pragma: no cover - optional backend
+    JAXTensorOperations = None  # type: ignore
+
+if (
+    np is not None
+    and NumPyTensorOperations is not None
+    and JAXTensorOperations is not None
+):
+    register_conversion(JAXTensorOperations, NumPyTensorOperations,
+                        lambda s, t, o: o.tensor_from_list(list(np.asarray(t)), dtype=None, device=None))
+    register_conversion(NumPyTensorOperations, JAXTensorOperations,
+                        lambda s, t, o: o.tensor_from_list(t.tolist(), dtype=None, device=None))
+
+if (
+    torch is not None
+    and PyTorchTensorOperations is not None
+    and JAXTensorOperations is not None
+):
+    register_conversion(PyTorchTensorOperations, JAXTensorOperations,
+                        lambda s, t, o: o.tensor_from_list(t.detach().cpu().tolist(), dtype=None, device=o.default_device))
+    register_conversion(JAXTensorOperations, PyTorchTensorOperations,
+                        lambda s, t, o: o.to_device(o.tensor_from_list(list(np.asarray(t)), dtype=None, device=None), o.default_device))
+
+if JAXTensorOperations is not None:
+    register_conversion(JAXTensorOperations, PurePythonTensorOperations,
+                        lambda s, t, o: o.tensor_from_list(list(np.asarray(t)), dtype=None, device=None))
+    register_conversion(PurePythonTensorOperations, JAXTensorOperations,
+                        lambda s, t, o: o.tensor_from_list(t, dtype=None, device=None))
+
 

--- a/tests/test_tensor_backends.py
+++ b/tests/test_tensor_backends.py
@@ -12,6 +12,7 @@ from speaktome.tensors import (
 )
 from speaktome.tensors.faculty import detect_faculty
 from speaktome.tensors.pure_backend import PurePythonTensorOperations # For isinstance check
+import itertools
 
 logger = logging.getLogger(__name__)
 
@@ -149,5 +150,21 @@ def test_basic_operator_dispatch(backend_cls):
 
     except (TypeError, NotImplementedError, AttributeError):
         raise # Let the test fail if operators are not supported as expected
+
+
+@pytest.mark.parametrize(
+    "src_cls,tgt_cls",
+    itertools.permutations(available_backends(), 2),
+)
+def test_to_backend_roundtrip(src_cls, tgt_cls):
+    """Ensure ``to_backend`` converts tensors faithfully across backends."""
+    src_ops = src_cls()
+    tgt_ops = tgt_cls()
+    data = [[1, 2], [3, 4]]
+    tensor = src_ops.tensor_from_list(data, dtype=src_ops.float_dtype, device=None)
+    converted = src_ops.to_backend(tensor, tgt_ops)
+    assert tgt_ops.tolist(converted) == data
+    roundtrip = tgt_ops.to_backend(converted, src_ops)
+    assert src_ops.tolist(roundtrip) == data
         
 


### PR DESCRIPTION
## Summary
- register multi-step JAX tensor conversions
- test backend roundtrip via `to_backend`

## Testing
- `python testing/test_hub.py`

------
https://chatgpt.com/codex/tasks/task_e_6846c3582708832a8ccb50c0def4eb0b