### PR TITLE
Add c_backend AGENTS file

### DIFF
--- a/speaktome/tensors/c_backend/AGENTS.md
+++ b/speaktome/tensors/c_backend/AGENTS.md
@@ -1,0 +1,9 @@
+# c_backend
+
+This subdirectory documents the design rules for the C backend implementation.
+
+* **Algorithm code must be written in C**, not Python. All heavy computation should be compiled via `cffi` or similar tooling.
+* **Support arbitrary tensor dimensions.** Functions should not assume one- or two-dimensional inputs.
+* **Mirror the behavior of PyTorch**. Operations implemented in C must produce the same results as equivalent Torch functions for the supported dtypes.
+
+Follow the repository's general coding standards and keep tests passing.


### PR DESCRIPTION
## Summary
- add AGENTS.md for c_backend with guidance to implement algorithms in C

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'cffi' and 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846e9bf21bc832a91b08db353b376e7