### PR TITLE
Extend C log_softmax to handle arbitrary dimensions

### DIFF
--- a/speaktome/tensors/c_backend.py
+++ b/speaktome/tensors/c_backend.py
@@ -64,6 +64,12 @@ ffi.cdef("""
     void rfloor_div_const(const double* a, double b, double* out, int n);
     void sqrt_double(const double* a, double* out, int n);
     void log_softmax_1d(const double* a, double* out, int n);
+    void log_softmax_dim(
+        const double* a,
+        double* out,
+        const int* shape,
+        int ndim,
+        int dim);
     void pad_double_nd(const double* input, double* output, const int* shape, const int* new_shape, const int* left_pad, int dims, double value);
     void mean_dim(const double* a, double* out, const int* shape, int ndim, int dim);
     void gather_pairs_2d(const double* a, const int* rows, const int* cols,
@@ -168,6 +174,44 @@ C_SOURCE = """
         for (int i = 0; i < n; ++i) {
             out[i] = log(out[i] / sum);
         }
+    }
+
+    typedef struct {
+        double* out;
+        int axis;
+        int* out_index;
+    } log_softmax_ctx;
+
+    static void log_softmax_callback(const double* slice, int stride, int idx, void* user_data) {
+        log_softmax_ctx* ctx = (log_softmax_ctx*)user_data;
+        double max_val = slice[0];
+        for (int i = 1; i < ctx->axis; ++i) {
+            double v = slice[i * stride];
+            if (v > max_val) max_val = v;
+        }
+        double sum = 0.0;
+        for (int i = 0; i < ctx->axis; ++i) {
+            double e = exp(slice[i * stride] - max_val);
+            ctx->out[*ctx->out_index + i] = e;
+            sum += e;
+        }
+        for (int i = 0; i < ctx->axis; ++i) {
+            double e = ctx->out[*ctx->out_index + i];
+            ctx->out[*ctx->out_index + i] = log(e / sum);
+        }
+        *ctx->out_index += ctx->axis;
+    }
+
+    void log_softmax_dim(
+        const double* a,
+        double* out,
+        const int* shape,
+        int ndim,
+        int dim) {
+        int out_idx = 0;
+        log_softmax_ctx ctx = {out, shape[dim], &out_idx};
+        for_each_cell_along_dim(a, shape, ndim, dim, log_softmax_callback, &ctx);
+    }
 
     void pad_double_nd(const double* input, double* output, const int* shape,
                        const int* new_shape, const int* left_pad, int dims,
@@ -565,12 +609,17 @@ class CTensorOperations(AbstractTensorOperations):
             tensor = CTensor.from_list(tensor, _get_shape(tensor))
         if dim < 0:
             dim += len(tensor.shape)
-        if dim != 0 or len(tensor.shape) != 1:
-            raise NotImplementedError(
-                "log_softmax only implemented for 1D tensors on the C backend"
+        shape = tensor.shape
+        if dim < 0 or dim >= len(shape):
+            raise ValueError("dim out of range")
+        out = CTensor(shape)
+        if len(shape) == 1:
+            C.log_softmax_1d(tensor.as_c_ptr(), out.as_c_ptr(), tensor.size)
+        else:
+            c_shape = ffi.new("int[]", list(shape))
+            C.log_softmax_dim(
+                tensor.as_c_ptr(), out.as_c_ptr(), c_shape, len(shape), dim
             )
-        out = CTensor(tensor.shape)
-        C.log_softmax_1d(tensor.as_c_ptr(), out.as_c_ptr(), tensor.size)
         return out
 
     def pad(self, tensor: CTensor, pad: Tuple[int, ...], value: float = 0) -> Any:

--- a/tests/test_c_backend_log_softmax.py
+++ b/tests/test_c_backend_log_softmax.py
@@ -18,3 +18,21 @@ def test_log_softmax_1d():
     expected = [math.log(v / total) for v in exps]
 
     assert pytest.approx(values) == expected
+
+
+def test_log_softmax_nd():
+    ops = CTensorOperations()
+    tensor = ops.tensor_from_list(
+        [[1.0, 2.0], [3.0, 4.0]], dtype=ops.float_dtype, device=None
+    )
+    result = ops.log_softmax(tensor, dim=1)
+    values = ops.tolist(result)
+
+    expected = []
+    for row in [[1.0, 2.0], [3.0, 4.0]]:
+        max_v = max(row)
+        exps = [math.exp(v - max_v) for v in row]
+        total = sum(exps)
+        expected.append([math.log(v / total) for v in exps])
+
+    assert pytest.approx(values) == expected


### PR DESCRIPTION
## Summary
- implement `log_softmax_dim` in `c_backend.c`
- add Python wrapper to call new C helper
- exercise ND log softmax in tests

## Testing
- `pytest tests/test_c_backend_log_softmax.py::test_log_softmax_nd` *(fails: This CFFI feature requires setuptools on Python >= 3.12)*
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'cffi')*

------
https://chatgpt.com/codex/tasks/task_e_6846f14c4a44832a8cddafb80a3fba4d