### PR TITLE
Set python env vars in dev setup scripts

### DIFF
--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -32,6 +32,17 @@ if (-not (Test-Path $venvPip)) {
 }
 
 
+# Explicitly configure Python environment variables so commands use the
+# virtual environment regardless of shell activation state.
+$env:PYTHONHOME = $venvDir
+$pyVer = & $venvPython -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"
+if ($IsWindows) {
+    $env:PYTHONPATH = Join-Path $venvDir "Lib\site-packages"
+} else {
+    $env:PYTHONPATH = Join-Path $venvDir "lib/python$pyVer/site-packages"
+}
+
+
 function Install-Speaktome-Extras {
     $speaktomeDir = Join-Path $PSScriptRoot "speaktome"
     if (-not (Test-Path $speaktomeDir -PathType Container)) {

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -36,6 +36,13 @@ if [ ! -x "$VENV_PIP" ]; then
 fi
 
 
+# Explicitly set Python environment variables so all commands run against the
+# virtual environment without relying on activation scripts.
+PY_VERSION="$($VENV_PYTHON -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+export PYTHONHOME="$SCRIPT_ROOT/.venv"
+export PYTHONPATH="$SCRIPT_ROOT/.venv/lib/python${PY_VERSION}/site-packages"
+
+
 
 install_speaktome_extras() {
   local SPEAKTOME_DIR="$SCRIPT_ROOT/speaktome"


### PR DESCRIPTION
## Summary
- ensure `setup_env_dev.sh` exports `PYTHONHOME` and `PYTHONPATH`
- ensure `setup_env_dev.ps1` sets `PYTHONHOME` and `PYTHONPATH`

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'cffi', ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68470fe6f0fc832a94b5c32e6c3f1c1f