### PR TITLE
Update backend install prompts

### DIFF
--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -94,7 +94,7 @@ function Install-Speaktome-Extras {
     $backendGroups = @("numpy", "jax", "ctensor")
     foreach ($group in $backendGroups) {
         $response = $null
-        Write-Host "Install backend group '$group'? [y/N] (auto-skip in 3s): " -NoNewline
+        Write-Host "Install backend group '$group'? Install if you plan to run the corresponding abstract tensor backend. [y/N] (auto-skip in 3s): " -NoNewline
         for ($i=3; $i -gt 0; $i--) {
             if ($Host.UI.RawUI.KeyAvailable) {
                 $key = $Host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown")

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -82,7 +82,7 @@ install_speaktome_extras() {
 
   BACKEND_GROUPS=("numpy" "jax" "ctensor")
   for group in "${BACKEND_GROUPS[@]}"; do
-    read -t 3 -p "Install backend group '$group'? [y/N] (auto-skip in 3s): " reply
+    read -t 3 -p "Install backend group '$group'? Install if you plan to run the corresponding abstract tensor backend. [y/N] (auto-skip in 3s): " reply
     reply=${reply:-N}
     if [[ "$reply" =~ ^[Yy]$ ]]; then
       echo "Attempting to install backend group: $group"


### PR DESCRIPTION
## Summary
- clarify prompts for installing backend extras in developer setup scripts

## Testing
- `./.venv/bin/pytest -v` *(fails: ModuleNotFoundError: No module named 'scipy')*

------
https://chatgpt.com/codex/tasks/task_e_68471e5e949c832a87549d27ba666e58