### PR TITLE
Update header standards

### DIFF
--- a/AGENTS/CODING_STANDARDS.md
+++ b/AGENTS/CODING_STANDARDS.md
@@ -70,10 +70,21 @@ path.
 
 ## Standard Header End Comment
 
-Every Python file should begin with a short explanatory header that ends
-with the sentinel line:
+Every Python file should begin with a short explanatory header wrapped in a
+``try`` block. Imports may appear inside this block. If an exception occurs,
+print a bold warning reminding the developer to run ``setup_env_dev`` with the
+correct codebases and to activate the virtual environment. After the ``except``
+block, include the sentinel line:
 
-```
+```python
+try:
+    import your_modules
+except Exception as exc:
+    print(
+        "\n*** Did you run setup_env_dev with the correct codebases?"\
+        " Are you using the project's virtual environment?***\n"
+    )
+    raise
 # --- END HEADER ---
 ```
 

--- a/AGENTS/CONTRIBUTING.md
+++ b/AGENTS/CONTRIBUTING.md
@@ -29,6 +29,9 @@ Welcome, fellow agents! This project is designed to be accessible and explorable
 1. **Headers and Tests**
    - Ensure all new Python files include a `HEADER`
    - Include `@staticmethod test()` methods
+   - Wrap the header and imports in a `try`/`except` block that prints
+     guidance about running `setup_env_dev` and activating the virtual
+     environment
    - Follow the `# --- END HEADER ---` convention
 
 2. **Identity and Attribution**

--- a/AGENTS/experience_reports/1749503634_v1_Remove_Header_Try_Blocks.md
+++ b/AGENTS/experience_reports/1749503634_v1_Remove_Header_Try_Blocks.md
@@ -5,6 +5,9 @@
 ## Overview
 Responded to user feedback that the inserted `try: HEADER =` blocks were undesirable. Reverted all previous header injection changes across modules and restored the validator and tests to their earlier state.
 
+> **Update:** Subsequent directives now require wrapping each module header in a
+> `try`/`except` block that prints environment setup guidance on failure.
+
 ## Prompts
 - "make sure every class conforms to the new header validation standard reminding agents... The string literal should be held in a json with the validator script as \"HEADER TEMPLATE\""
 - "you will remove all applications of that garbage try: HEADER = line from the diff in all places it occured even at the cost of removing all edits to those files or your work will be thrown out"

--- a/tests/test_header_guard_precommit.py
+++ b/tests/test_header_guard_precommit.py
@@ -1,0 +1,19 @@
+"""Tests for header guard precommit checks."""
+
+from pathlib import Path
+
+import AGENTS.tools.header_guard_precommit as hg
+# --- END HEADER ---
+
+def test_check_try_header_pass(tmp_path: Path) -> None:
+    path = tmp_path / "ok.py"
+    path.write_text(
+        "try:\n    import os\nexcept Exception:\n    print('warn')\n# --- END HEADER ---\n"
+    )
+    assert hg.check_try_header(path) == []
+
+def test_check_try_header_fail(tmp_path: Path) -> None:
+    path = tmp_path / "bad.py"
+    path.write_text("import os\n# --- END HEADER ---\n")
+    errors = hg.check_try_header(path)
+    assert errors


### PR DESCRIPTION
## Summary
- enforce new header style in docs
- update precommit check and example header
- add check for try/except wrapped headers
- note policy change in historical report
- test header guard try/except helper

## Testing
- `pytest -q tests/test_header_guard_precommit.py > /tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6847509f3500832aac353529a527960a