### PR TITLE
Unify env setup warning

### DIFF
--- a/AGENTS/CODING_STANDARDS.md
+++ b/AGENTS/CODING_STANDARDS.md
@@ -79,11 +79,8 @@ block, include the sentinel line:
 ```python
 try:
     import your_modules
-except Exception as exc:
-    print(
-        "\n*** Did you run setup_env_dev with the correct codebases?"\
-        " Are you using the project's virtual environment?***\n"
-    )
+except Exception:
+    print(ENV_SETUP_BOX)
     raise
 # --- END HEADER ---
 ```

--- a/AGENTS/tools/header_guard_precommit.py
+++ b/AGENTS/tools/header_guard_precommit.py
@@ -1,3 +1,12 @@
+ENV_SETUP_BOX = (
+    "\n"
+    "+-----------------------------------------------------------------------+\n"
+    "| Imports failed. Run setup_env or setup_env_dev and select every    |\n"
+    "| project and module you plan to use. Missing packages mean setup was |\n"
+    "| skipped or incomplete.                                             |\n"
+    "+-----------------------------------------------------------------------+\n"
+)
+
 try:
     """Pre-commit hook enforcing HEADER, tests, and the end sentinel."""
     import sys
@@ -6,10 +15,7 @@ try:
     import os
     from pathlib import Path
 except Exception:
-    print(
-        "\n*** Did you run setup_env_dev with the correct codebases? "
-        "Is the virtual environment active?***\n"
-    )
+    print(ENV_SETUP_BOX)
     raise
 # --- END HEADER ---
 
@@ -33,10 +39,7 @@ If the pre-commit hook caught your changes, here's a friendly checklist:
        import sys
        import your_modules
    except Exception:
-       print(
-           "\n*** Did you run setup_env_dev with the correct codebases? "
-           "Is the virtual environment active?***\n"
-       )
+       print(ENV_SETUP_BOX)
        raise
    # --- END HEADER ---
    ```

--- a/AGENTS/tools/validate_headers.py
+++ b/AGENTS/tools/validate_headers.py
@@ -17,6 +17,15 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
+ENV_SETUP_BOX = (
+    "\n"
+    "+-----------------------------------------------------------------------+\n"
+    "| Imports failed. Run setup_env or setup_env_dev and select every    |\n"
+    "| project and module you plan to use. Missing packages mean setup was |\n"
+    "| skipped or incomplete.                                             |\n"
+    "+-----------------------------------------------------------------------+\n"
+)
+
 PACKAGE_ROOT = Path(__file__).parent / "speaktome"
 
 
@@ -106,10 +115,7 @@ def validate(root: Path, *, rewrite: bool = False) -> int:
                     new_lines.append(f"{indent}    HEADER = \"TODO\"")
                     new_lines.append(f"{indent}except Exception as exc:")
                     new_lines.append(
-                        f"{indent}    print('Did you run setup_env_dev with the correct codebases and groups?')"
-                    )
-                    new_lines.append(
-                        f"{indent}    print('Is your virtual environment active or are you calling the .venv python binary?')"
+                        f"{indent}    print(ENV_SETUP_BOX)"
                     )
                     new_lines.append(f"{indent}    raise")
                 if miss_test:
@@ -140,11 +146,7 @@ def main() -> None:
     except Exception as exc:  # pragma: no cover - unexpected failure
         print(
             "[AGENT_ACTIONABLE_ERROR] validate_headers failed: "
-            f"{exc}.\n"
-            "Have you run setup_env_dev with the right selection of codebases"
-            " and groups?\n"
-            "Is your virtual environment active or are you calling the .venv"
-            " python binary?"
+            f"{exc}.\n{ENV_SETUP_BOX}"
         )
         sys.exit(1)
     sys.exit(exit_code)


### PR DESCRIPTION
## Summary
- standardize header guidance across tools
- use ENV_SETUP_BOX in validator and precommit hook
- update coding standards doc

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'cffi')*

------
https://chatgpt.com/codex/tasks/task_e_684752f922ec832a8ad31f76ce1dfdaa