### PR TITLE
Improve header guard to check env box

### DIFF
--- a/AGENTS/tools/header_guard_precommit.py
+++ b/AGENTS/tools/header_guard_precommit.py
@@ -144,6 +144,11 @@ def check_try_header(filepath: Path) -> list[str]:
         None,
     )
 
+    env_print = False
+    if except_idx is not None:
+        search_end = sentinel_idx if sentinel_idx is not None else len(lines)
+        env_print = any("print(ENV_SETUP_BOX)" in ln for ln in lines[except_idx:search_end])
+
     errors = []
     if not lines or not lines[0].startswith("#!"):
         errors.append("Missing shebang")
@@ -160,6 +165,8 @@ def check_try_header(filepath: Path) -> list[str]:
         errors.append("Missing 'try:' at start of header")
     if except_idx is None:
         errors.append("Missing 'except' block for header")
+    elif not env_print:
+        errors.append("Missing 'print(ENV_SETUP_BOX)' in except block")
     return errors
 
 def main():

--- a/AGENTS/tools/header_utils.py
+++ b/AGENTS/tools/header_utils.py
@@ -18,4 +18,13 @@ except Exception:
     raise
 # --- END HEADER ---
 
-__all__ = ["ENV_SETUP_BOX"]
+HEADER_REQUIREMENTS = [
+    "shebang line '#!/usr/bin/env python3'",
+    "module docstring",
+    "'from __future__ import annotations' before the try block",
+    "imports wrapped in a try block",
+    "except block printing ENV_SETUP_BOX",
+    "'# --- END HEADER ---' sentinel after the except block",
+]
+
+__all__ = ["ENV_SETUP_BOX", "HEADER_REQUIREMENTS"]

--- a/tests/test_header_guard_precommit.py
+++ b/tests/test_header_guard_precommit.py
@@ -17,7 +17,7 @@ def test_check_try_header_pass(tmp_path: Path) -> None:
         "#!/usr/bin/env python3\n"
         "\"\"\"doc\"\"\"\n"
         "from __future__ import annotations\n"
-        "try:\n    import os\nexcept Exception:\n    print('warn')\n    raise\n# --- END HEADER ---\n"
+        "try:\n    import os\nexcept Exception:\n    print(ENV_SETUP_BOX)\n    raise\n# --- END HEADER ---\n"
     )
     assert hg.check_try_header(path) == []
 
@@ -27,3 +27,14 @@ def test_check_try_header_fail(tmp_path: Path) -> None:
     errors = hg.check_try_header(path)
     assert "Missing shebang" in errors
     assert "Missing module docstring" in errors
+
+def test_check_env_print_missing(tmp_path: Path) -> None:
+    path = tmp_path / "noprint.py"
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "\"\"\"doc\"\"\"\n"
+        "from __future__ import annotations\n"
+        "try:\n    import os\nexcept Exception:\n    raise\n# --- END HEADER ---\n"
+    )
+    errors = hg.check_try_header(path)
+    assert "Missing 'print(ENV_SETUP_BOX)' in except block" in errors


### PR DESCRIPTION
## Summary
- list header requirements in `header_utils`
- check for `print(ENV_SETUP_BOX)` in `header_guard_precommit`
- test that missing print is detected

## Testing
- `python -m pytest -q tests/test_validate_headers.py tests/test_header_guard_precommit.py`

------
https://chatgpt.com/codex/tasks/task_e_68476b223efc832aad1ac112af5f78a9