### PR TITLE
Add exit code requirement to header

### DIFF
--- a/AGENTS/CODING_STANDARDS.md
+++ b/AGENTS/CODING_STANDARDS.md
@@ -84,9 +84,10 @@ from __future__ import annotations
 try:
     from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import your_modules
+    import sys
 except Exception:
     print(ENV_SETUP_BOX)
-    raise
+    sys.exit(1)
 # --- END HEADER ---
 ```
 

--- a/AGENTS/CONTRIBUTING.md
+++ b/AGENTS/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Welcome, fellow agents! This project is designed to be accessible and explorable
   - Place `from __future__ import annotations` before the header
   - Wrap imports in a `try`/`except` block that prints
     guidance about running `setup_env_dev` and activating the virtual
-    environment
+    environment, then immediately exits with `sys.exit(1)`
    - Follow the `# --- END HEADER ---` convention
 
 2. **Identity and Attribution**

--- a/AGENTS/header_template.py
+++ b/AGENTS/header_template.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 try:
     from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import your_modules
+    import sys
 except Exception:
     print(ENV_SETUP_BOX)
-    raise
+    sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/tools/auto_fix_headers.py
+++ b/AGENTS/tools/auto_fix_headers.py
@@ -9,7 +9,7 @@ try:
     from .header_utils import ENV_SETUP_BOX
 except Exception:
     print(ENV_SETUP_BOX)
-    raise
+    sys.exit(1)
 # --- END HEADER ---
 
 
@@ -90,7 +90,7 @@ def fix_file(path: Path) -> None:
 
     out_lines.append("except Exception:")
     out_lines.append("    print(ENV_SETUP_BOX)")
-    out_lines.append("    raise")
+    out_lines.append("    sys.exit(1)")
     out_lines.append(HEADER_SENTINEL)
 
     out_lines.extend(lines[idx:])

--- a/AGENTS/tools/header_guard_precommit.py
+++ b/AGENTS/tools/header_guard_precommit.py
@@ -10,7 +10,7 @@ try:
     from pathlib import Path
 except Exception:
     print(ENV_SETUP_BOX)
-    raise
+    sys.exit(1)
 # --- END HEADER ---
 
 FRIENDLY_GUIDANCE = """
@@ -39,7 +39,7 @@ If the pre-commit hook caught your changes, here's a friendly checklist:
        import your_modules
    except Exception:
        print(ENV_SETUP_BOX)
-       raise
+       sys.exit(1)
    # --- END HEADER ---
    ```
 

--- a/AGENTS/tools/header_utils.py
+++ b/AGENTS/tools/header_utils.py
@@ -12,10 +12,10 @@ ENV_SETUP_BOX = (
 )
 
 try:
-    pass
+    import sys
 except Exception:
     print(ENV_SETUP_BOX)
-    raise
+    sys.exit(1)
 # --- END HEADER ---
 
 __all__ = ["ENV_SETUP_BOX"]

--- a/AGENTS/tools/validate_headers.py
+++ b/AGENTS/tools/validate_headers.py
@@ -10,7 +10,7 @@ try:
     from .header_utils import ENV_SETUP_BOX
 except Exception:
     print(ENV_SETUP_BOX)
-    raise
+    sys.exit(1)
 # --- END HEADER ---
 
 PACKAGE_ROOT = Path(__file__).parent / "speaktome"
@@ -104,7 +104,7 @@ def validate(root: Path, *, rewrite: bool = False) -> int:
                     new_lines.append(
                         f"{indent}    print(ENV_SETUP_BOX)"
                     )
-                    new_lines.append(f"{indent}    raise")
+                    new_lines.append(f"{indent}    sys.exit(1)")
                 if miss_test:
                     new_lines.append(f"{indent}@staticmethod")
                     new_lines.append(f"{indent}def test() -> None:")

--- a/AGENTS/validate_guestbook.py
+++ b/AGENTS/validate_guestbook.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 try:
     import os
     import re
+    import sys
 except Exception:
     print(
         "\n"
@@ -12,7 +13,7 @@ except Exception:
         "| skipped or incomplete.                                             |\n"
         "+-----------------------------------------------------------------------+\n"
     )
-    raise
+    sys.exit(1)
 # --- END HEADER ---
 
 REPORTS_DIR = os.path.join(os.path.dirname(__file__), 'experience_reports')

--- a/speaktome/core/abstract_linear_net.py
+++ b/speaktome/core/abstract_linear_net.py
@@ -1,21 +1,15 @@
+#!/usr/bin/env python3
+"""Backend-agnostic linear layers for small network experiments."""
+from __future__ import annotations
+
 try:
-    """Backend-agnostic linear layers for small network experiments."""
-
-    from __future__ import annotations
-
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from typing import Any, Iterable, Dict
 
     from .model_abstraction import AbstractModelWrapper
     from ..tensors.abstraction import AbstractTensorOperations
 except Exception:
-    print(
-        "\n"
-        "+-----------------------------------------------------------------------+\n"
-        "| Imports failed. Run setup_env or setup_env_dev and select every    |\n"
-        "| project and module you plan to use. Missing packages mean setup was |\n"
-        "| skipped or incomplete.                                             |\n"
-        "+-----------------------------------------------------------------------+\n"
-    )
+    print(ENV_SETUP_BOX)
     raise
 # --- END HEADER ---
 

--- a/speaktome/core/model_abstraction.py
+++ b/speaktome/core/model_abstraction.py
@@ -1,20 +1,16 @@
-try:
-    from __future__ import annotations
+#!/usr/bin/env python3
+"""Abstractions over model interfaces."""
+from __future__ import annotations
 
+try:
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from abc import ABC, abstractmethod
     from typing import Any, Dict
     import torch
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore
 except Exception:
-    print(
-        "\n"
-        "+-----------------------------------------------------------------------+\n"
-        "| Imports failed. Run setup_env or setup_env_dev and select every    |\n"
-        "| project and module you plan to use. Missing packages mean setup was |\n"
-        "| skipped or incomplete.                                             |\n"
-        "+-----------------------------------------------------------------------+\n"
-    )
+    print(ENV_SETUP_BOX)
     raise
 # --- END HEADER ---
 


### PR DESCRIPTION
## Summary
- update header template to exit with code 1 when imports fail
- ensure validation utilities and auto header fixer emit sys.exit(1)
- note new requirement in coding standards and contributing docs
- adjust precommit helper and validate_guestbook accordingly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: cffi)*
- `python -m AGENTS.tools.validate_headers`


------
https://chatgpt.com/codex/tasks/task_e_68476a81a3a8832a85257aea3a29562e