### PR TITLE
Update header pattern and utilities

### DIFF
--- a/AGENTS/CODING_STANDARDS.md
+++ b/AGENTS/CODING_STANDARDS.md
@@ -72,9 +72,9 @@ path.
 
 Every Python file should begin with a shebang and module docstring followed by
 ``from __future__ import annotations``. All subsequent imports must appear in a
-``try`` block. If an exception occurs, print the shared ``ENV_SETUP_BOX``
-message from ``AGENTS.tools.header_utils``. After the ``except`` block, include
-the sentinel line:
+``try`` block. If an exception occurs, first import ``sys``, then print the
+shared ``ENV_SETUP_BOX`` message from ``AGENTS.tools.header_utils``, and finally
+call ``sys.exit(1)``. After the ``except`` block, include the sentinel line:
 
 ```python
 #!/usr/bin/env python3
@@ -84,8 +84,8 @@ from __future__ import annotations
 try:
     from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import your_modules
-    import sys
 except Exception:
+    import sys
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/header_template.py
+++ b/AGENTS/header_template.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 try:
     from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import your_modules
-    import sys
 except Exception:
+    import sys
+
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/tools/header_utils.py
+++ b/AGENTS/tools/header_utils.py
@@ -14,6 +14,8 @@ ENV_SETUP_BOX = (
 try:
     import sys
 except Exception:
+    import sys
+
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
@@ -23,7 +25,7 @@ HEADER_REQUIREMENTS = [
     "module docstring",
     "'from __future__ import annotations' before the try block",
     "imports wrapped in a try block",
-    "except block printing ENV_SETUP_BOX",
+    "except block imports sys then prints ENV_SETUP_BOX and exits",
     "'# --- END HEADER ---' sentinel after the except block",
 ]
 

--- a/tests/test_header_guard_precommit.py
+++ b/tests/test_header_guard_precommit.py
@@ -11,15 +11,17 @@ except Exception:
     raise
 # --- END HEADER ---
 
+
 def test_check_try_header_pass(tmp_path: Path) -> None:
     path = tmp_path / "ok.py"
     path.write_text(
         "#!/usr/bin/env python3\n"
-        "\"\"\"doc\"\"\"\n"
+        '"""doc"""\n'
         "from __future__ import annotations\n"
-        "try:\n    import os\nexcept Exception:\n    print(ENV_SETUP_BOX)\n    raise\n# --- END HEADER ---\n"
+        "try:\n    import os\nexcept Exception:\n    import sys\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
     )
     assert hg.check_try_header(path) == []
+
 
 def test_check_try_header_fail(tmp_path: Path) -> None:
     path = tmp_path / "bad.py"
@@ -28,13 +30,38 @@ def test_check_try_header_fail(tmp_path: Path) -> None:
     assert "Missing shebang" in errors
     assert "Missing module docstring" in errors
 
+
 def test_check_env_print_missing(tmp_path: Path) -> None:
     path = tmp_path / "noprint.py"
     path.write_text(
         "#!/usr/bin/env python3\n"
-        "\"\"\"doc\"\"\"\n"
+        '"""doc"""\n'
         "from __future__ import annotations\n"
-        "try:\n    import os\nexcept Exception:\n    raise\n# --- END HEADER ---\n"
+        "try:\n    import os\nexcept Exception:\n    import sys\n    sys.exit(1)\n# --- END HEADER ---\n"
     )
     errors = hg.check_try_header(path)
     assert "Missing 'print(ENV_SETUP_BOX)' in except block" in errors
+
+
+def test_check_sys_import_missing(tmp_path: Path) -> None:
+    path = tmp_path / "nosys.py"
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        '"""doc"""\n'
+        "from __future__ import annotations\n"
+        "try:\n    import os\nexcept Exception:\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
+    )
+    errors = hg.check_try_header(path)
+    assert "Missing 'import sys' in except block" in errors
+
+
+def test_check_sys_exit_missing(tmp_path: Path) -> None:
+    path = tmp_path / "noexit.py"
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        '"""doc"""\n'
+        "from __future__ import annotations\n"
+        "try:\n    import os\nexcept Exception:\n    import sys\n    print(ENV_SETUP_BOX)\n# --- END HEADER ---\n"
+    )
+    errors = hg.check_try_header(path)
+    assert "Missing 'sys.exit(1)' in except block" in errors

--- a/tests/test_validate_headers.py
+++ b/tests/test_validate_headers.py
@@ -44,6 +44,9 @@ def test_validate_headers_rewrite(tmp_path, monkeypatch) -> None:
     content = mod.read_text()
     assert "HEADER" in content
     assert "def test()" in content
+    assert "import sys" in content
+    assert "print(ENV_SETUP_BOX)" in content
+    assert "sys.exit(1)" in content
     # Subsequent validation should succeed without rewrites
     code = vh.validate(pkg)
     assert code == 0


### PR DESCRIPTION
## Summary
- document importing sys in the header except block
- update the header template and utilities to match
- extend header fixer and guard precommit script to check for missing lines
- keep validation helper up to date
- adjust tests for the new header pattern

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cffi')*
- `python AGENTS/validate_guestbook.py`

------
https://chatgpt.com/codex/tasks/task_e_68476febc298832a88770dca46f65a92