### PR TITLE
Implement render loop utilities

### DIFF
--- a/tests/test_ascii_frame_buffer.py
+++ b/tests/test_ascii_frame_buffer.py
@@ -1,0 +1,28 @@
+from time_sync.frame_buffer import AsciiFrameBuffer
+import numpy as np
+
+
+def test_framebuffer_diff_basic():
+    fb = AsciiFrameBuffer((2, 3))
+    frame = np.array([list("abc"), list("def")])
+    fb.update_render(frame)
+    diff = fb.get_diff_and_promote()
+    assert len(diff) == 6
+    assert (0, 0, "a") in diff
+
+    # No changes -> diff empty
+    diff = fb.get_diff_and_promote()
+    assert diff == []
+
+
+def test_framebuffer_resize():
+    fb = AsciiFrameBuffer((1, 2))
+    frame1 = np.array([list("hi")])
+    fb.update_render(frame1)
+    fb.get_diff_and_promote()
+
+    frame2 = np.array([list("abc"), list("def")])
+    fb.update_render(frame2)
+    diff = fb.get_diff_and_promote()
+    assert fb.shape == (2, 3)
+    assert len(diff) == 6

--- a/time_sync/draw.py
+++ b/time_sync/draw.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Terminal drawing helpers for ASCII frame diffs."""
+from __future__ import annotations
+
+try:
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    import sys
+except Exception:
+    import sys
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+
+def draw_diff(diff_data: list[tuple[int, int, str]]) -> None:
+    """Render diff data using ANSI cursor positioning."""
+    for y, x, char in diff_data:
+        sys.stdout.write(f"\x1b[{y+1};{x+1}H{char}")
+    sys.stdout.flush()

--- a/time_sync/frame_buffer.py
+++ b/time_sync/frame_buffer.py
@@ -1,24 +1,62 @@
-# framebuffer.py
-import threading
-import numpy as np
+#!/usr/bin/env python3
+"""Triple-buffered ASCII frame diff manager."""
+from __future__ import annotations
+
+try:
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    import numpy as np
+    import threading
+except Exception:
+    import sys
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
 
 class AsciiFrameBuffer:
+    """Manage ASCII frames for flicker-free terminal rendering."""
+
     def __init__(self, shape: tuple[int, int]):
+        """Allocate buffers for ``shape`` and initialize contents."""
         self.lock = threading.Lock()
         self.shape = shape
-        self.buffer_render = np.full(shape, ' ', dtype='<U1')
-        self.buffer_next = np.full(shape, ' ', dtype='<U1')
-        self.buffer_display = np.full(shape, ' ', dtype='<U1')
+        self.buffer_render = np.full(shape, " ", dtype="<U1")
+        self.buffer_next = np.full(shape, " ", dtype="<U1")
+        self.buffer_display = np.full(shape, " ", dtype="<U1")
 
-    def update_render(self, new_data: np.ndarray):
+    def _resize(self, shape: tuple[int, int]) -> None:
+        """Resize internal buffers to ``shape``."""
+        self.shape = shape
+        self.buffer_render = np.full(shape, " ", dtype="<U1")
+        self.buffer_next = np.full(shape, " ", dtype="<U1")
+        self.buffer_display = np.full(shape, " ", dtype="<U1")
+
+    def update_render(self, new_data: np.ndarray) -> None:
+        """Update the render buffer with ``new_data``.
+
+        Resizes internal buffers if ``new_data`` shape differs from
+        the current configuration.
+        """
+        if new_data.shape != self.shape:
+            with self.lock:
+                self._resize(new_data.shape)
         with self.lock:
             np.copyto(self.buffer_render, new_data)
 
-    def get_diff_and_promote(self):
+    def get_diff_and_promote(self) -> list[tuple[int, int, str]]:
+        """Return changed cells since last promotion.
+
+        Copies the render buffer into the next buffer, computes the
+        difference against the display buffer, updates the display
+        buffer, and returns a list of ``(y, x, char)`` tuples for the
+        cells that changed.
+        """
         with self.lock:
             np.copyto(self.buffer_next, self.buffer_render)
-        diff = self.buffer_next != self.buffer_display
-        coords = np.argwhere(diff)
-        updated = [(y, x, self.buffer_next[y, x]) for y, x in coords]
+        diff_mask = self.buffer_next != self.buffer_display
+        coords = np.argwhere(diff_mask)
+        updates: list[tuple[int, int, str]] = []
+        for y, x in coords:
+            updates.append((int(y), int(x), str(self.buffer_next[y, x])))
         np.copyto(self.buffer_display, self.buffer_next)
-        return updated
+        return updates

--- a/time_sync/render_thread.py
+++ b/time_sync/render_thread.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Background thread for producing ASCII frames."""
+from __future__ import annotations
+
+try:
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    import numpy as np
+    import threading
+    import time
+    from typing import Callable
+    from .frame_buffer import AsciiFrameBuffer
+except Exception:
+    import sys
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+
+def render_loop(
+    framebuffer: AsciiFrameBuffer,
+    render_fn: Callable[[], np.ndarray],
+    fps: float,
+    stop_event: threading.Event,
+) -> None:
+    """Continuously render frames until ``stop_event`` is set."""
+    delay = 1.0 / max(fps, 0.1)
+    while not stop_event.is_set():
+        ascii_frame = render_fn()
+        framebuffer.update_render(ascii_frame)
+        time.sleep(delay)

--- a/time_sync/time_sync/__init__.py
+++ b/time_sync/time_sync/__init__.py
@@ -13,12 +13,16 @@ from .ascii_digits import (
     compose_ascii_digits,
     print_analog_clock,
     print_digital_clock,
+    render_ascii_to_array,
 )
 from .console import (
     init_colorama_for_windows,
     full_clear_and_reset_cursor,
     reset_cursor_to_top,
 )
+from ..frame_buffer import AsciiFrameBuffer
+from ..render_thread import render_loop
+from ..draw import draw_diff
 from . import _internet  # exported for tests
 
 __all__ = [
@@ -29,10 +33,14 @@ __all__ = [
     "now",
     "utcnow",
     "compose_ascii_digits",
+    "render_ascii_to_array",
     "print_analog_clock",
     "print_digital_clock",
     "init_colorama_for_windows",
     "full_clear_and_reset_cursor",
     "reset_cursor_to_top",
+    "AsciiFrameBuffer",
+    "render_loop",
+    "draw_diff",
     "_internet",
 ]

--- a/time_sync/time_sync/ascii_digits.py
+++ b/time_sync/time_sync/ascii_digits.py
@@ -8,6 +8,7 @@ from typing import List, Tuple, Optional
 # --- END HEADER ---
 
 from colorama import Fore, Style
+import numpy as np
 
 try:
     from PIL import Image, ImageDraw, ImageFont
@@ -520,3 +521,10 @@ def print_analog_clock(
         bg_alpha_threshold=10
     )
     print(ascii_art)
+
+
+def render_ascii_to_array(text: str, **kwargs) -> np.ndarray:
+    """Return ASCII art for ``text`` as a ``numpy.ndarray``."""
+    ascii_str = compose_ascii_digits(text, **kwargs)
+    rows = ascii_str.splitlines()
+    return np.array([list(row) for row in rows], dtype="<U1")


### PR DESCRIPTION
## Summary
- add render_loop helper for background frames
- add terminal diff drawer
- expose new helpers in library init
- allow ascii digit renders as arrays for frame buffers

## Testing
- `python -m py_compile time_sync/render_thread.py time_sync/draw.py time_sync/frame_buffer.py time_sync/time_sync/ascii_digits.py time_sync/time_sync/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6847981a8bc0832aa86d6fdbb636c109