### PR TITLE
Improve setup menu defaults

### DIFF
--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -10,6 +10,12 @@ param(
     [string[]]$Codebases = @("speaktome", "AGENTS/tools", "time_sync")
 )
 
+$activeFile = $env:SPEAKTOME_ACTIVE_FILE
+if (-not $activeFile) {
+    $activeFile = Join-Path ([System.IO.Path]::GetTempPath()) 'speaktome_active.json'
+}
+$env:SPEAKTOME_ACTIVE_FILE = $activeFile
+
 # Always include the time_sync codebase
 if (-not ($Codebases -contains 'time_sync')) {
     $Codebases += 'time_sync'
@@ -70,8 +76,9 @@ foreach ($arg in $args) {
 if (-not $calledByDev) {
     Write-Host "Launching codebase/group selection tool for editable installs..."
     $env:PIP_CMD = $venvPip
-    & $venvPython (Join-Path $PSScriptRoot "AGENTS\tools\dev_group_menu.py") --install
+    & $venvPython (Join-Path $PSScriptRoot "AGENTS\tools\dev_group_menu.py") --install --record $activeFile
     Remove-Item Env:PIP_CMD
 }
 
 Write-Host "Environment setup complete. Activate with '.venv\Scripts\Activate.ps1' on Windows or 'source .venv/bin/activate' on Unix-like systems"
+Write-Host "Selections recorded to $activeFile"

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -5,6 +5,9 @@
 
 set -uo pipefail
 
+ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
+export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
+
 USE_VENV=1
 for arg in "$@"; do
   case $arg in
@@ -73,9 +76,10 @@ done
 
 if [ $CALLED_BY_DEV -eq 0 ]; then
   echo "Launching codebase/group selection tool for editable installs..."
-  PIP_CMD="$VENV_PIP" "$VENV_PYTHON" "$SCRIPT_ROOT/AGENTS/tools/dev_group_menu.py" --install
+  PIP_CMD="$VENV_PIP" "$VENV_PYTHON" "$SCRIPT_ROOT/AGENTS/tools/dev_group_menu.py" --install --record "$SPEAKTOME_ACTIVE_FILE"
 fi
 
 echo "Environment setup complete."
 echo "[OK] Environment ready. Activate with 'source .venv/bin/activate'."
 echo "   * Torch = $(python -c 'import torch; print(torch.__version__, torch.version.cuda if torch.cuda.is_available() else "N/A")')"
+echo "Selections recorded to $SPEAKTOME_ACTIVE_FILE"

--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -11,6 +11,9 @@ function Safe-Run([ScriptBlock]$cmd) {
 
 # Run the regular setup script with forwarded arguments
 $scriptRoot = $PSScriptRoot
+$activeFile = $env:SPEAKTOME_ACTIVE_FILE
+if (-not $activeFile) { $activeFile = Join-Path ([System.IO.Path]::GetTempPath()) 'speaktome_active.json' }
+$env:SPEAKTOME_ACTIVE_FILE = $activeFile
 $useVenv = $true
 foreach ($arg in $args) {
     if ($arg -eq '--no-venv' -or $arg -eq '-no-venv') { $useVenv = $false }
@@ -99,7 +102,7 @@ function Show-Menu {
             '6' { Write-Host "Preview CODING_STANDARDS.md"; Safe-Run { & $venvPython AGENTS/tools/preview_doc.py AGENTS/CODING_STANDARDS.md }; $Timeout = 10 }
             '7' { Write-Host "Preview CONTRIBUTING.md"; Safe-Run { & $venvPython AGENTS/tools/preview_doc.py AGENTS/CONTRIBUTING.md }; $Timeout = 10 }
             '8' { Write-Host "Preview PROJECT_OVERVIEW.md"; Safe-Run { & $venvPython AGENTS/tools/preview_doc.py AGENTS/PROJECT_OVERVIEW.md }; $Timeout = 10 }
-            '9' { Write-Host "Launching dev group menu"; Safe-Run { & $venvPython AGENTS/tools/dev_group_menu.py }; $Timeout = 10 }
+            '9' { Write-Host "Launching dev group menu"; Safe-Run { & $venvPython AGENTS/tools/dev_group_menu.py --record $activeFile }; $Timeout = 10 }
             'q' { Write-Host "Exiting."; break }
             default { Write-Host "Unknown choice: $choice" }
         }
@@ -109,3 +112,4 @@ function Show-Menu {
 
 Show-Menu
 Write-Host "For advanced codebase/group selection, run: python AGENTS/tools/dev_group_menu.py"
+Write-Host "Selections recorded to $activeFile"

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -8,6 +8,8 @@ set -uo pipefail
 # changing directories with pushd. This allows the script to be invoked
 # from anywhere while still locating `.venv`.
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
+export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 
 safe_run() {
   "$@"
@@ -89,7 +91,7 @@ install_speaktome_extras() {
   cd "$OLD_DIR"
 
   echo "Launching codebase/group selection tool..."
-  PIP_CMD="$VENV_PIP" "$VENV_PYTHON" "$SCRIPT_ROOT/AGENTS/tools/dev_group_menu.py" --install
+  PIP_CMD="$VENV_PIP" "$VENV_PYTHON" "$SCRIPT_ROOT/AGENTS/tools/dev_group_menu.py" --install --record "$SPEAKTOME_ACTIVE_FILE"
 }
 install_speaktome_extras
 
@@ -126,3 +128,4 @@ dev_menu() {
 }
 dev_menu
 echo "For advanced codebase/group selection, run: python AGENTS/tools/dev_group_menu.py"
+echo "Selections recorded to $SPEAKTOME_ACTIVE_FILE"


### PR DESCRIPTION
## Summary
- default to installing all optional groups in `dev_group_menu.py`
- allow recording chosen codebases and groups via `--record`
- track selections via `SPEAKTOME_ACTIVE_FILE` in setup scripts
- log and skip tests for inactive codebases based on recorded selections

## Testing
- `python -m py_compile AGENTS/tools/dev_group_menu.py tests/conftest.py`
- `python testing/test_hub.py --skip-stubs` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684855eb37a0832a89d3c2926890441a