### PR TITLE
Add flexible ascii kernel and pygame window

### DIFF
--- a/tests/test_draw.py
+++ b/tests/test_draw.py
@@ -1,5 +1,9 @@
 import numpy as np
-from time_sync.draw import get_changed_subunits, default_subunit_to_char_kernel
+from time_sync.draw import (
+    get_changed_subunits,
+    default_subunit_to_char_kernel,
+    flexible_subunit_kernel,
+)
 
 
 def test_get_changed_subunits_basic():
@@ -17,3 +21,18 @@ def test_default_kernel_char():
     arr = np.array([[[255, 255, 255]]], dtype=np.uint8)
     char = default_subunit_to_char_kernel(arr)
     assert isinstance(char, str) and len(char) == 1
+
+
+def test_flexible_kernel_modes():
+    arr = np.array([[[100, 150, 200]]], dtype=np.uint8)
+
+    ascii_char = flexible_subunit_kernel(arr, " .:░▒▓█", mode="ascii")
+    assert isinstance(ascii_char, str)
+
+    raw = flexible_subunit_kernel(arr, " .:░▒▓█", mode="raw")
+    assert isinstance(raw, np.ndarray)
+    assert raw.shape == arr.shape
+
+    hybrid = flexible_subunit_kernel(arr, " .:░▒▓█", mode="hybrid")
+    assert isinstance(hybrid, np.ndarray)
+    assert hybrid.shape[:2] == arr.shape[:2]

--- a/time_sync/frame_buffer.py
+++ b/time_sync/frame_buffer.py
@@ -31,7 +31,7 @@ class PixelFrameBuffer:
         self.buffer_next = np.full(self.buffer_shape, self.default_pixel, dtype=np.uint8)
         self.buffer_display = np.full(self.buffer_shape, self.default_pixel, dtype=np.uint8)
         self.diff_threshold = max(0, diff_threshold) # Ensure threshold is not negative
-        self._force_full_diff_next_call = False
+        self._force_full_diff_next_call = True
 
     def __repr__(self) -> str:
         return (
@@ -45,6 +45,7 @@ class PixelFrameBuffer:
         self.buffer_render = np.full(self.buffer_shape, self.default_pixel, dtype=np.uint8)
         self.buffer_next = np.full(self.buffer_shape, self.default_pixel, dtype=np.uint8)
         self.buffer_display = np.full(self.buffer_shape, self.default_pixel, dtype=np.uint8)
+        self._force_full_diff_next_call = True
 
     def update_render(self, new_data: np.ndarray) -> None:
         """Update the render buffer with ``new_data``.

--- a/time_sync/subunit_window.py
+++ b/time_sync/subunit_window.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Pygame window for displaying pixel subunit grids."""
+from __future__ import annotations
+
+try:
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    import numpy as np
+    import pygame
+except Exception:
+    import sys
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+class SubunitWindow:
+    """Display a grid of pixel data using Pygame."""
+
+    def __init__(self, grid_shape: tuple[int, int], subunit_size: int = 10) -> None:
+        """Create a window sized for ``grid_shape``."""
+        pygame.init()
+        self.subunit_size = max(1, subunit_size)
+        width = grid_shape[1] * self.subunit_size
+        height = grid_shape[0] * self.subunit_size
+        self.screen = pygame.display.set_mode((width, height))
+        pygame.display.set_caption("Subunit Grid")
+
+    def update_subunits(
+        self,
+        changes: list[tuple[int, int, np.ndarray]],
+    ) -> None:
+        """Update the window with ``changes`` in-place."""
+        for y, x, sub in changes:
+            surf = pygame.surfarray.make_surface(sub.swapaxes(0, 1))
+            surf = pygame.transform.scale(
+                surf,
+                (sub.shape[1] * self.subunit_size, sub.shape[0] * self.subunit_size),
+            )
+            self.screen.blit(surf, (x * self.subunit_size, y * self.subunit_size))
+        pygame.display.update()
+
+    def close(self) -> None:
+        pygame.quit()

--- a/time_sync/time_sync/__init__.py
+++ b/time_sync/time_sync/__init__.py
@@ -31,7 +31,8 @@ from .console import (
 )
 from ..frame_buffer import PixelFrameBuffer # Changed from AsciiFrameBuffer
 from ..render_thread import render_loop
-from ..draw import draw_diff
+from ..draw import draw_diff, flexible_subunit_kernel
+from ..subunit_window import SubunitWindow
 from . import _internet  # exported for tests
 from .render_backend import RenderingBackend
 
@@ -52,6 +53,8 @@ __all__ = [
     "PixelFrameBuffer", # Changed from AsciiFrameBuffer
     "render_loop",
     "draw_diff",
+    "flexible_subunit_kernel",
+    "SubunitWindow",
     "_internet",
     "RenderingBackend",
 ]

--- a/time_sync/time_sync/ascii_digits.py
+++ b/time_sync/time_sync/ascii_digits.py
@@ -404,6 +404,8 @@ def print_digital_clock(
     # The initial type-aware assignment for digits_str covers cases where
     # arbitrary_text is None and (active_units or display_format_template is not sufficient).
 
+    if theme_manager is None:
+        return digits_str if (as_array or as_pixel) else print(digits_str)
     if not PIL_AVAILABLE:
         # If not returning array/pixel, print simple text
         return digits_str if (as_array or as_pixel) else print(Fore.CYAN + digits_str + Style.RESET_ALL)


### PR DESCRIPTION
## Summary
- add `flexible_subunit_kernel` supporting ascii/raw/hybrid modes
- provide a simple `SubunitWindow` pygame viewer for diff updates
- expose new helpers in `time_sync` package
- tweak `PixelFrameBuffer` to force full diffs and handle resize
- print plain text in `print_digital_clock` when no theme
- expand tests for new kernel

## Testing
- `pytest -q tests/test_draw.py tests/test_pixel_frame_buffer.py tests/test_time_sync.py`

------
https://chatgpt.com/codex/tasks/task_e_684856fcfca0832a92059d2155924cf9