### PR TITLE
Add non-interactive mode for dev group menu

### DIFF
--- a/tests/test_dev_group_menu.py
+++ b/tests/test_dev_group_menu.py
@@ -1,0 +1,36 @@
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_menu(args, env=None):
+    return subprocess.run(
+        [sys.executable, 'AGENTS/tools/dev_group_menu.py', *args],
+        capture_output=True, text=True, env=env
+    )
+
+
+def test_list_option() -> None:
+    result = run_menu(['--list'])
+    assert 'speaktome' in result.stdout
+
+
+def test_noninteractive_json(tmp_path) -> None:
+    active = tmp_path / 'active.json'
+    result = run_menu([
+        '--codebases', 'speaktome',
+        '--groups', 'speaktome:dev',
+        '--json', '--record', str(active)
+    ])
+    data = json.loads(result.stdout)
+    assert data['codebases'] == ['speaktome']
+    assert 'dev' in data['packages']['speaktome']
+    assert active.exists()
+
+
+def test_show_active(tmp_path) -> None:
+    env = {**os.environ, 'SPEAKTOME_ACTIVE_FILE': str(tmp_path / 'active.json')}
+    result = run_menu(['--show-active'], env=env)
+    assert str(tmp_path / 'active.json') in result.stdout


### PR DESCRIPTION
## Summary
- extend `AGENTS/tools/dev_group_menu.py` with command line options for
  non-interactive usage
- add helper to parse codebase and group selections
- support listing available codebases/groups and showing the active record file
- add tests covering the new behaviour

## Testing
- `bash setup_env.sh` *(fails: Could not find a version that satisfies the requirement torch==2.3.1+cpu)*
- `PYTHONPATH=. python testing/test_hub.py --skip-stubs` *(fails: INTERNALERROR in time_sync due to SystemExit)*

------
https://chatgpt.com/codex/tasks/task_e_6848585e1570832a89fc813fd0a56d28