### PR TITLE
Add doc against manual pip usage and fix env script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,9 @@ Any reusable Python scripts or binary utilities meant for agents must live in
 easy to discover and maintain.
 
 For deeper historical context, read through all prior reports. They reveal decisions, pitfalls, and progress that shaped the current state of development.
+If you are tempted to install packages manually with `pip`, stop and read
+`AGENTS_DO_NOT_PIP_MANUALLY.md` first. The provided setup scripts manage
+dependencies for you and explain how optional groups work.
 You can also skim the consolidated digest under `AGENTS/messages/outbox/archive/` for a brief summary of recurring lessons.
 
 If you crave an immediate, exhaustive overview, run this one-liner. It will

--- a/AGENTS_DO_NOT_PIP_MANUALLY.md
+++ b/AGENTS_DO_NOT_PIP_MANUALLY.md
@@ -1,0 +1,9 @@
+# **Stop Installing with `pip` Like a Caveman**
+
+The `setup_env.sh` and `setup_env_dev.sh` scripts already know how to install everything for you. Manually invoking `pip` defeats the purpose of the curated environment. Study these scripts to understand how dependencies are configured, which optional groups exist, and how editable installs are performed.
+
+Running `setup_env.sh` creates a virtual environment, installs CPU Torch by default, and launches the `AGENTS/tools/dev_group_menu.py` helper so you can pick which codebases and optional dependency groups should be installed. The developer variant, `setup_env_dev.sh`, activates the environment, installs `requirements-dev.txt`, and opens an interactive menu for documentation and stub tracking.
+
+If something is missing, re-run `setup_env_dev.sh` and select all relevant groups instead of hammering `pip install` by hand. This keeps the environment reproducible for everyone and avoids half-installed states.
+
+**In short:** read the setup scripts, don't bypass them.

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -5,6 +5,9 @@
 
 set -uo pipefail
 
+# Resolve repository root so this script works from any directory
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 


### PR DESCRIPTION
## Summary
- document new rule against manual `pip` installs
- fix unbound SCRIPT_ROOT in setup_env.sh
- mention the new doc in AGENTS.md

## Testing
- `pytest -k "not time_sync" -q` *(fails: SystemExit: 1)*

------
https://chatgpt.com/codex/tasks/task_e_68485a3e9928832aa3bcb65ac6faaa70