### PR TITLE
Document non-interactive environment setup

### DIFF
--- a/AGENTS/CODEBASES_AND_ENVIRONMENT.md
+++ b/AGENTS/CODEBASES_AND_ENVIRONMENT.md
@@ -22,3 +22,19 @@ lack a required library. When a package truly seems absent, verify that
 `setup_env.sh` does not already install it, then add the dependency to
 `pyproject.toml` so future setups fetch it automatically. (For example, `torch`
 is installed by default and should never be missing.)
+
+### Automated Setup
+
+Both setup scripts rely on `AGENTS/tools/dev_group_menu.py` for optional
+package selection. Provide `--codebases` and `--groups` to that helper to skip
+all prompts when scripting installs:
+
+```bash
+bash setup_env_dev.sh --extras --prefetch --from-dev
+python AGENTS/tools/dev_group_menu.py --install \
+    --codebases speaktome \
+    --groups speaktome:dev
+```
+
+This approach allows CI pipelines to create a fully configured virtual
+environment without human input.

--- a/AGENTS_DO_NOT_PIP_MANUALLY.md
+++ b/AGENTS_DO_NOT_PIP_MANUALLY.md
@@ -4,6 +4,19 @@ The `setup_env.sh` and `setup_env_dev.sh` scripts already know how to install ev
 
 Running `setup_env.sh` creates a virtual environment, installs CPU Torch by default, and launches the `AGENTS/tools/dev_group_menu.py` helper so you can pick which codebases and optional dependency groups should be installed. The developer variant, `setup_env_dev.sh`, activates the environment, installs `requirements-dev.txt`, and opens an interactive menu for documentation and stub tracking.
 
+To run either script non-interactively, invoke the menu tool yourself with explicit selections:
+
+```bash
+# create the environment without prompts
+bash setup_env.sh --from-dev --extras --prefetch
+# choose codebases and groups headlessly
+python AGENTS/tools/dev_group_menu.py --install \
+    --codebases speaktome \
+    --groups speaktome:dev
+```
+
+`--codebases` specifies which project folders to install and `--groups` lists the optional dependency groups. Passing these arguments bypasses every menu prompt so the environment can be prepared automatically.
+
 If something is missing, re-run `setup_env_dev.sh` and select all relevant groups instead of hammering `pip install` by hand. This keeps the environment reproducible for everyone and avoids half-installed states.
 
 **In short:** read the setup scripts, don't bypass them.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,19 @@ On Windows run:
 powershell -ExecutionPolicy Bypass -File setup_env_dev.ps1 -extras -prefetch
 ```
 
+### Non-Interactive Setup
+For headless automation or CI environments, bypass the menus by invoking the
+group selection tool directly:
+
+```bash
+# create the environment
+bash setup_env_dev.sh --extras --prefetch --from-dev
+# install selected codebases and groups without prompts
+python AGENTS/tools/dev_group_menu.py --install \
+    --codebases speaktome \
+    --groups speaktome:dev
+```
+
 
 ## Running SpeakToMe
 


### PR DESCRIPTION
## Summary
- note how to call `setup_env_dev` without prompts in README
- outline automated setup steps in CODEBASES_AND_ENVIRONMENT.md
- expand AGENTS_DO_NOT_PIP_MANUALLY with non-interactive example

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*

------
https://chatgpt.com/codex/tasks/task_e_68486a2534a4832a91b1136c5650f6b6