### PR TITLE
Make pygame optional for clock_demo

### DIFF
--- a/time_sync/AGENTS.md
+++ b/time_sync/AGENTS.md
@@ -4,7 +4,11 @@ This project provides simple functions for adjusting system time using an enviro
 
 ## Optional Dependency Groups
 
-This codebase defines no optional dependency groups in its `pyproject.toml`.
+An optional "gui" group installs `pygame` for the demo window:
+
+```bash
+python -m pip install time_sync[gui]
+```
 
 ## Non-Interactive Setup Example
 

--- a/time_sync/README.md
+++ b/time_sync/README.md
@@ -1,3 +1,9 @@
 # Time Sync
 
 Utilities for maintaining an environment variable offset between system time and internet time.
+
+Install `pygame` if you want to run the optional clock demo window:
+
+```bash
+python -m pip install time_sync[gui]
+```

--- a/time_sync/pyproject.toml
+++ b/time_sync/pyproject.toml
@@ -16,6 +16,11 @@ dependencies = [
     "pillow",
 ]
 
+[project.optional-dependencies]
+gui = [
+    "pygame>=2",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["time_sync*"]

--- a/time_sync/subunit_window.py
+++ b/time_sync/subunit_window.py
@@ -5,18 +5,28 @@ from __future__ import annotations
 try:
     from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import numpy as np
-    import pygame
 except Exception:
     import sys
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
 
+try:  # Optional dependency
+    import pygame
+    _HAS_PYGAME = True
+except Exception:  # pragma: no cover - may be missing
+    pygame = None  # type: ignore
+    _HAS_PYGAME = False
+
 class SubunitWindow:
     """Display a grid of pixel data using Pygame."""
 
     def __init__(self, grid_shape: tuple[int, int], subunit_size: int = 10) -> None:
         """Create a window sized for ``grid_shape``."""
+        if not _HAS_PYGAME:
+            raise RuntimeError(
+                "pygame is required for SubunitWindow. Install time_sync[gui]."
+            )
         pygame.init()
         self.subunit_size = max(1, subunit_size)
         width = grid_shape[1] * self.subunit_size
@@ -29,6 +39,10 @@ class SubunitWindow:
         changes: list[tuple[int, int, np.ndarray]],
     ) -> None:
         """Update the window with ``changes`` in-place."""
+        if not _HAS_PYGAME:
+            raise RuntimeError(
+                "pygame is required for SubunitWindow. Install time_sync[gui]."
+            )
         for y, x, sub in changes:
             surf = pygame.surfarray.make_surface(sub.swapaxes(0, 1))
             surf = pygame.transform.scale(
@@ -39,4 +53,5 @@ class SubunitWindow:
         pygame.display.update()
 
     def close(self) -> None:
-        pygame.quit()
+        if _HAS_PYGAME:
+            pygame.quit()

--- a/time_sync/time_sync/__init__.py
+++ b/time_sync/time_sync/__init__.py
@@ -32,7 +32,10 @@ from .console import (
 from ..frame_buffer import PixelFrameBuffer # Changed from AsciiFrameBuffer
 from ..render_thread import render_loop
 from ..draw import draw_diff, flexible_subunit_kernel
-from ..subunit_window import SubunitWindow
+try:
+    from ..subunit_window import SubunitWindow
+except Exception:  # pragma: no cover - optional
+    SubunitWindow = None  # type: ignore
 from . import _internet  # exported for tests
 from .render_backend import RenderingBackend
 


### PR DESCRIPTION
## Summary
- document `gui` extra in time_sync docs
- allow SubunitWindow to import pygame only when installed
- fallback gracefully when SubunitWindow isn't available
- declare optional `gui` dependency in `time_sync` pyproject

## Testing
- `PYTHONPATH=. python testing/test_hub.py` *(fails: Faculty comparison errors)*

------
https://chatgpt.com/codex/tasks/task_e_684870077c10832a902eff4ef8da1fdb