### PR TITLE
Enforce venv setup before tests

### DIFF
--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -113,3 +113,23 @@ function Show-Menu {
 Show-Menu
 Write-Host "For advanced codebase/group selection, run: python AGENTS/tools/dev_group_menu.py"
 Write-Host "Selections recorded to $activeFile"
+
+# Mark the environment so pytest knows setup completed with at least one codebase
+$marker = Join-Path $scriptDir '.venv\pytest_enabled'
+if (Test-Path $activeFile) {
+    try {
+        $data = Get-Content $activeFile | ConvertFrom-Json
+        if ($data.codebases.Count -gt 0) {
+            New-Item $marker -ItemType File -Force | Out-Null
+        } else {
+            Remove-Item $marker -ErrorAction SilentlyContinue
+            Write-Warning "No codebases recorded; pytest will remain disabled."
+        }
+    } catch {
+        Remove-Item $marker -ErrorAction SilentlyContinue
+        Write-Warning "Unable to read selections; pytest will remain disabled."
+    }
+} else {
+    Remove-Item $marker -ErrorAction SilentlyContinue
+    Write-Warning "Active selection file not found; pytest will remain disabled."
+}

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -129,3 +129,28 @@ dev_menu() {
 dev_menu
 echo "For advanced codebase/group selection, run: python AGENTS/tools/dev_group_menu.py"
 echo "Selections recorded to $SPEAKTOME_ACTIVE_FILE"
+
+# Mark the environment so pytest knows setup completed with at least one codebase
+PYTEST_MARKER="$SCRIPT_ROOT/.venv/pytest_enabled"
+if [ -f "$SPEAKTOME_ACTIVE_FILE" ]; then
+  if "$VENV_PYTHON" - <<'PY'
+import json, os, sys
+path = os.environ.get("SPEAKTOME_ACTIVE_FILE")
+try:
+    data = json.load(open(path))
+    if data.get("codebases"):
+        sys.exit(0)
+except Exception:
+    pass
+sys.exit(1)
+PY
+  then
+    touch "$PYTEST_MARKER"
+  else
+    rm -f "$PYTEST_MARKER"
+    echo "Warning: No codebases recorded; pytest will remain disabled." >&2
+  fi
+else
+  rm -f "$PYTEST_MARKER"
+  echo "Warning: Active selection file not found; pytest will remain disabled." >&2
+fi


### PR DESCRIPTION
## Summary
- check for `.venv/pytest_enabled` in `pytest_configure`
- drop a marker after running `setup_env_dev` scripts

## Testing
- `python -m pytest tests/test_header_guard_precommit.py::test_check_try_header_pass -vv` *(fails: Imports failed)*

------
https://chatgpt.com/codex/tasks/task_e_68488e8c9280832a9c16d0836aab54a9