### PR TITLE
Update clock_demo to use keymap

### DIFF
--- a/AGENTS/experience_reports/1749585538_v1_Remove_Manual_Config_Menu.md
+++ b/AGENTS/experience_reports/1749585538_v1_Remove_Manual_Config_Menu.md
@@ -1,0 +1,22 @@
+# Clock Demo Menu Simplification
+
+## Overview
+Updated `clock_demo` so configuration mode uses the JSON keymap and removed hardcoded key handling. This keeps a single menu system.
+
+## Prompts
+- "make sure the only menu in clock_demo is the one that uses keymap, and in that menu, if anything is presently hardcoded, fix it by putting it in the keymap instead"
+
+## Steps Taken
+1. Added configuration actions to `key_mappings.json`.
+2. Refactored `interactive_configure_mode` to read those mappings.
+3. Updated calls to pass `key_mappings`.
+4. Ran `python testing/test_hub.py` (failed due to missing environment).
+
+## Observed Behaviour
+The demo now pulls configuration controls from the keymap. Automated tests failed to run in this environment.
+
+## Lessons Learned
+Centralising key bindings simplifies future changes and reduces duplicated instructions.
+
+## Next Steps
+Investigate environment setup for running tests successfully.

--- a/time_sync/time_sync/key_mappings.json
+++ b/time_sync/time_sync/key_mappings.json
@@ -142,5 +142,69 @@
   "enter_config_mode": {
     "keys": ["c"],
     "description": "Enter Config Mode (for active clock)"
+  },
+  "config_quit": {
+    "keys": ["q"],
+    "description": "Exit configuration mode"
+  },
+  "config_save": {
+    "keys": ["s"],
+    "description": "Save configuration"
+  },
+  "config_left": {
+    "keys": ["LEFT"],
+    "description": "Move left / width -"
+  },
+  "config_right": {
+    "keys": ["RIGHT"],
+    "description": "Move right / width +"
+  },
+  "config_up": {
+    "keys": ["UP"],
+    "description": "Move up / height -"
+  },
+  "config_down": {
+    "keys": ["DOWN"],
+    "description": "Move down / height +"
+  },
+  "config_width_increase": {
+    "keys": ["L"],
+    "description": "Increase analog width"
+  },
+  "config_width_decrease": {
+    "keys": ["J"],
+    "description": "Decrease analog width"
+  },
+  "config_height_increase": {
+    "keys": ["K"],
+    "description": "Increase analog height"
+  },
+  "config_height_decrease": {
+    "keys": ["I"],
+    "description": "Decrease analog height"
+  },
+  "config_ascii_diameter_increase": {
+    "keys": ["+"],
+    "description": "Increase ASCII diameter"
+  },
+  "config_ascii_diameter_decrease": {
+    "keys": ["-"],
+    "description": "Decrease ASCII diameter"
+  },
+  "config_canvas_increase": {
+    "keys": ["C"],
+    "description": "Increase canvas size"
+  },
+  "config_canvas_decrease": {
+    "keys": ["c"],
+    "description": "Decrease canvas size"
+  },
+  "config_font_increase": {
+    "keys": ["+"],
+    "description": "Increase font size"
+  },
+  "config_font_decrease": {
+    "keys": ["-"],
+    "description": "Decrease font size"
   }
 }


### PR DESCRIPTION
## Summary
- move configuration controls into key_mappings.json
- use new mapping entries inside `interactive_configure_mode`
- pass keymap to configuration mode calls
- log experience report

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*
- `python AGENTS/validate_guestbook.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*

------
https://chatgpt.com/codex/tasks/task_e_68488d1c5968832a911a2916e6479090