### PR TITLE
Thread-safe framebuffer resize

### DIFF
--- a/AGENTS/experience_reports/1749585678_v1_Framebuffer_Resize_Fix.md
+++ b/AGENTS/experience_reports/1749585678_v1_Framebuffer_Resize_Fix.md
@@ -1,0 +1,25 @@
+# Framebuffer Resize Fix
+
+## Overview
+Addressed crash when adjusting pixel buffer scale during clock_demo.
+Implemented thread-safe resize in `PixelFrameBuffer` and updated callers.
+
+## Prompts
+- "something in the clock_demo sizing logic is nonsensical..." (user)
+
+## Steps Taken
+1. Investigated scaling logic in `clock_demo.py` and `frame_buffer.py`.
+2. Added `resize` method with locking around buffer reallocation.
+3. Replaced direct `_resize` calls with new `resize` method.
+4. Clarified comment about pixel-to-character mapping.
+5. Attempted environment setup and test execution (failed due to network restrictions).
+
+## Observed Behaviour
+- Previous crash `ValueError: could not broadcast input array from shape ...` traced to concurrent resize operations.
+- After modifications, thread safety ensured; tests could not run due to missing dependencies.
+
+## Lessons Learned
+Proper locking around buffer resizing prevents race conditions between render and display threads.
+
+## Next Steps
+- Revisit test execution after environment dependencies are available.

--- a/time_sync/clock_demo.py
+++ b/time_sync/clock_demo.py
@@ -861,7 +861,7 @@ def main() -> None:
             framebuffer_ref.buffer_shape[0] != new_fb_rows
             or framebuffer_ref.buffer_shape[1] != new_fb_cols
         ):
-            framebuffer_ref._resize((new_fb_rows, new_fb_cols))  # Use internal resize
+            framebuffer_ref.resize((new_fb_rows, new_fb_cols))
 
         frame = compose_full_frame(system, internet, stopwatch_td, offset)
         img = Image.fromarray(frame, mode="RGB")
@@ -937,10 +937,10 @@ def main() -> None:
             # These should correspond to the pixel dimensions of a single character cell
             # as used by the rendering functions (print_analog_clock, print_digital_clock).
             # This is complex because different elements might use different effective pixel sizes per char.
-            # For simplicity, let's assume a base 1:1 mapping for now, or derive from scale.
-            # A better approach might be to have render_fn return the rendered pixel array AND the effective
-            # pixel dimensions per character cell for the main clock area.
-            # For now, let's assume 1:1 pixel to char cell mapping for the main buffer drawing.
+            # In practice ``get_char_cell_dims`` derives the pixel size of a
+            # character cell based on ``PIXEL_BUFFER_SCALE``.  Avoid assuming
+            # a hard 1:1 mapping so diff calculations continue to work on
+            # sub-character pixel regions.
             cell_h, cell_w = get_char_cell_dims()
             draw_diff(
                 changed,


### PR DESCRIPTION
## Summary
- fix race condition when changing render scale
- update comment about pixel<->char mapping
- note framebuffer resize fix in experience report

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*
- `python AGENTS/validate_guestbook.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*


------
https://chatgpt.com/codex/tasks/task_e_68488d8dba94832a9eb803c5ef50d7a0