### PR TITLE
Add fontmapper packaging and optional backend imports

### DIFF
--- a/fontmapper/FM16/modules/__init__.py
+++ b/fontmapper/FM16/modules/__init__.py
@@ -10,15 +10,6 @@ except Exception:
     sys.exit(1)
 # --- END HEADER ---
 
-from .model_configs import ModelCompatConfig, ModelConfig
-from .char_sorter import CharSorter
-from .transforms import (
-    AddRandomNoise,
-    DistortionChain,
-    RandomGaussianBlur,
-    ToTensorAndToDevice,
-)
-from .datasets import CustomDataset, CustomInputDataset
 from .charset_ops import (
     list_printable_characters,
     generate_checkerboard_pattern,
@@ -26,23 +17,43 @@ from .charset_ops import (
     bytemaps_as_ascii,
     obtain_charset,
 )
-from .model_ops import load_char_sorter, evaluate_batch
+
+try:  # optional ML stack
+    import torch  # pragma: no cover - optional backend
+
+    from .model_configs import ModelCompatConfig, ModelConfig
+    from .char_sorter import CharSorter
+    from .transforms import (
+        AddRandomNoise,
+        DistortionChain,
+        RandomGaussianBlur,
+        ToTensorAndToDevice,
+    )
+    from .datasets import CustomDataset, CustomInputDataset
+    from .model_ops import load_char_sorter, evaluate_batch
+    TORCH_AVAILABLE = True
+except ModuleNotFoundError:  # pragma: no cover - torch not installed
+    TORCH_AVAILABLE = False
 
 __all__ = [
-    "ModelCompatConfig",
-    "ModelConfig",
-    "CharSorter",
-    "AddRandomNoise",
-    "DistortionChain",
-    "RandomGaussianBlur",
-    "ToTensorAndToDevice",
-    "CustomDataset",
-    "CustomInputDataset",
     "list_printable_characters",
     "generate_checkerboard_pattern",
     "generate_variants",
     "bytemaps_as_ascii",
     "obtain_charset",
-    "load_char_sorter",
-    "evaluate_batch",
 ]
+
+if TORCH_AVAILABLE:
+    __all__ += [
+        "ModelCompatConfig",
+        "ModelConfig",
+        "CharSorter",
+        "AddRandomNoise",
+        "DistortionChain",
+        "RandomGaussianBlur",
+        "ToTensorAndToDevice",
+        "CustomDataset",
+        "CustomInputDataset",
+        "load_char_sorter",
+        "evaluate_batch",
+    ]

--- a/fontmapper/__init__.py
+++ b/fontmapper/__init__.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""FontMapper utilities package."""
+from __future__ import annotations
+
+try:
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+except Exception:
+    import sys
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+from .FM16.modules import charset_ops
+
+from .FM16.modules.charset_ops import (
+    list_printable_characters,
+    generate_checkerboard_pattern,
+    generate_variants,
+    bytemaps_as_ascii,
+    obtain_charset,
+)
+
+__all__ = [
+    "charset_ops",
+    "list_printable_characters",
+    "generate_checkerboard_pattern",
+    "generate_variants",
+    "bytemaps_as_ascii",
+    "obtain_charset",
+]

--- a/fontmapper/pyproject.toml
+++ b/fontmapper/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fontmapper"
+version = "0.1.0"
+description = "ASCII rendering and font mapping utilities"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { text = "MIT" }
+authors = [{ name = "FontMapper Authors" }]
+
+# Baseline dependencies -- no heavy ML stack
+dependencies = [
+    "fonttools",
+    "Pillow",
+    "numpy>=1.26",
+]
+
+[project.optional-dependencies]
+ml = [
+    "torch",
+    "torchvision",
+    "pynvml",
+]
+ssim = [
+    "scikit-image",
+]
+amqp = [
+    "pika",
+]
+server = [
+    "flask",
+    "flask-cors",
+    "waitress; sys_platform == 'win32'",
+]
+gui = [
+    "PyQt5",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["fontmapper*"]

--- a/tensors/__init__.py
+++ b/tensors/__init__.py
@@ -1,0 +1,3 @@
+"""Namespace package for tensors."""
+# --- END HEADER ---
+from .tensors import *

--- a/tensors/pyproject.toml
+++ b/tensors/pyproject.toml
@@ -20,6 +20,9 @@ ctensor = [
   "setuptools>=61",
   "ziglang>=0.14"
 ]
+torch = [
+  "torch",
+]
 numpy = [
   "numpy>=1.26"
 ]

--- a/tensors/tensors/__init__.py
+++ b/tensors/tensors/__init__.py
@@ -9,23 +9,36 @@ try:
         get_tensor_operations,
     )
     from .faculty import Faculty, DEFAULT_FACULTY, FORCE_ENV, detect_faculty
-    from .torch_backend import PyTorchTensorOperations
-    from .numpy_backend import NumPyTensorOperations
     from .pure_backend import PurePythonTensorOperations
-
-    try:
-        from .jax_backend import JAXTensorOperations
-    except Exception:  # pragma: no cover - optional backend
-        JAXTensorOperations = None  # type: ignore
-    try:
-        from .c_backend import CTensorOperations
-    except Exception:  # pragma: no cover - optional backend
-        CTensorOperations = None  # type: ignore
 except Exception:
     import sys
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
+
+PyTorchTensorOperations = None
+try:  # optional torch backend
+    from .torch_backend import PyTorchTensorOperations  # type: ignore
+except Exception:  # pragma: no cover - torch missing
+    PyTorchTensorOperations = None  # type: ignore
+
+NumPyTensorOperations = None
+try:  # optional numpy backend
+    from .numpy_backend import NumPyTensorOperations  # type: ignore
+except Exception:  # pragma: no cover - numpy missing
+    NumPyTensorOperations = None  # type: ignore
+
+JAXTensorOperations = None
+try:  # optional jax backend
+    from .jax_backend import JAXTensorOperations  # type: ignore
+except Exception:  # pragma: no cover - jax missing
+    JAXTensorOperations = None  # type: ignore
+
+CTensorOperations = None
+try:  # optional C backend
+    from .c_backend import CTensorOperations  # type: ignore
+except Exception:  # pragma: no cover - c backend missing
+    CTensorOperations = None  # type: ignore
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- package fontmapper with minimal dependencies and extras for ML, AMQP, and GUI features
- expose charset utilities even when torch is missing
- make tensors backends optional and add a torch extras group
- provide namespace packages for `fontmapper` and `tensors`

## Testing
- `PYTHONPATH=. python testing/test_hub.py` *(fails: Imports failed. Run setup_env or setup_env_dev and select every project and module you plan to use. Missing packages mean setup was skipped or incomplete.)*

------
https://chatgpt.com/codex/tasks/task_e_6848dfe7ee9c832a97f0988f702963b4