### PR TITLE
Use tensor interpolate in ascii classifier

### DIFF
--- a/AGENTS/experience_reports/1749615531_v1_ASCII_Interpolate_Update.md
+++ b/AGENTS/experience_reports/1749615531_v1_ASCII_Interpolate_Update.md
@@ -1,0 +1,7 @@
+# ASCII Kernel Interpolation Update
+
+## Prompt History
+- User: "finish generalizing the algorithm in ascii_kernel_classifier by using the abstract tensor class's argmin and interpolate instead of np.argmin or pillow's resize"
+
+## Notes
+Implemented tensor-based interpolation for character resizing and removed PIL dependencies in `AsciiKernelClassifier`. Updated `_prepare_reference_bitmasks` to store tensors directly.


### PR DESCRIPTION
## Summary
- drop Pillow-based resizing in `AsciiKernelClassifier`
- rely on `AbstractTensorOperations.interpolate`
- store char bitmasks as tensors
- add an experience report about finishing the tensor interpolation update

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6849030774a8832aa9840a12edc98a33