### PR TITLE
Clarify dev setup flags

### DIFF
--- a/AGENTS/CODEBASES_AND_ENVIRONMENT.md
+++ b/AGENTS/CODEBASES_AND_ENVIRONMENT.md
@@ -31,7 +31,7 @@ package selection. Provide `--codebases` and `--groups` to that helper to skip
 all prompts when scripting installs:
 
 ```bash
-bash setup_env_dev.sh --extras --prefetch --from-dev
+bash setup_env_dev.sh --prefetch
 python AGENTS/tools/dev_group_menu.py --install \
     --codebases speaktome \
     --groups speaktome:dev

--- a/AGENTS/experience_reports/1749636030_v1_Environment_Setup_Attempt.md
+++ b/AGENTS/experience_reports/1749636030_v1_Environment_Setup_Attempt.md
@@ -1,0 +1,37 @@
+# Environment Setup Attempt
+
+**Date/Version:** 1749636030 v1
+**Title:** Environment Setup Attempt
+
+## Overview
+Attempted to follow project guidelines to create the virtual environment and run the pytest suite.
+
+## Prompts
+- "See if you can figure out setting up the environment for yourself well enough and by the rules enough to run pytests"
+
+## Steps Taken
+1. Executed `bash setup_env_dev.sh --prefetch` with `CODEBASES=""` to avoid an unbound variable error.
+2. The script created `.venv` but failed to install dependencies due to network restrictions (403 errors from PyTorch URL).
+3. Activated the environment and ran `python testing/test_hub.py`.
+
+## Observed Behaviour
+- `setup_env.sh` reported repeated `ProxyError` messages and could not download `torch`.
+- Running tests failed immediately because `pytest` was not installed and `ENV_SETUP_BOX` was undefined.
+
+## Lessons Learned
+The setup scripts expect network access to fetch packages. Without it, they leave the environment incomplete, so tests cannot run. Manual `pip` use is discouraged, so a cached wheel archive or offline installer might be needed.
+
+## Next Steps
+Look for instructions or tools that allow installing dependencies in an offline environment. Consider filing an issue about `setup_env.sh` referencing `CODEBASES` before initialization.
+
+## Follow‑Up
+Discovered that `AGENTS_DO_NOT_PIP_MANUALLY.md` suggested using
+`setup_env.sh --from-dev` when running headless. This was misleading.
+Updated the document to instead recommend:
+
+```bash
+bash setup_env_dev.sh --prefetch
+python AGENTS/tools/dev_group_menu.py --install --codebases speaktome --groups speaktome:dev
+```
+
+Refer to `AGENTS/CODEBASE_REGISTRY.md` for available codebase names.

--- a/AGENTS_DO_NOT_PIP_MANUALLY.md
+++ b/AGENTS_DO_NOT_PIP_MANUALLY.md
@@ -7,13 +7,16 @@ Running `setup_env.sh` creates a virtual environment, installs CPU Torch by defa
 To run either script non-interactively, invoke the menu tool yourself with explicit selections:
 
 ```bash
-# create the environment without prompts
-bash setup_env.sh --from-dev --extras --prefetch
+# create the environment without prompts using the developer script
+bash setup_env_dev.sh --prefetch
 # choose codebases and groups headlessly
 python AGENTS/tools/dev_group_menu.py --install \
     --codebases speaktome \
     --groups speaktome:dev
 ```
+
+Refer to `AGENTS/CODEBASE_REGISTRY.md` for a complete list of available codebase
+s.
 
 `--codebases` specifies which project folders to install and `--groups` lists the optional dependency groups. Passing these arguments bypasses every menu prompt so the environment can be prepared automatically.
 


### PR DESCRIPTION
## Summary
- remove deprecated `--extras` from environment docs and experience report
- suggest using `setup_env_dev.sh --prefetch` for headless installs
- update environment setup report accordingly

## Testing
- `python AGENTS/validate_guestbook.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_684953475ec4832a9cd319334f87292a