### PR TITLE
Allow optional tensor backends

### DIFF
--- a/tensors/tensors/jax_backend.py
+++ b/tensors/tensors/jax_backend.py
@@ -37,6 +37,10 @@ try:
     import jax.numpy as jnp
     from jax import lax
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    jax = None  # type: ignore
+    jnp = None  # type: ignore
+    lax = None  # type: ignore
+except Exception:
     import sys
     print(ENV_SETUP_BOX)
     sys.exit(1)

--- a/tensors/tensors/numpy_backend.py
+++ b/tensors/tensors/numpy_backend.py
@@ -38,6 +38,8 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
 try:
     import torch
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
+    torch = None  # type: ignore
+except Exception:
     import sys
     print(ENV_SETUP_BOX)
     sys.exit(1)


### PR DESCRIPTION
## Summary
- stop exiting when torch or jax are unavailable

## Testing
- `pip install numpy pytest`
- `pytest -k numpy_backend tests/test_tensor_backends.py` *(fails: imports failed)*


------
https://chatgpt.com/codex/tasks/task_e_68497b16e788832aa4f22a6771484bf8