### PR TITLE
Improve quick setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,15 @@ Any reusable Python scripts or binary utilities meant for agents must live in `A
 
 For deeper historical context, read through all prior reports. They reveal decisions, pitfalls, and progress that shaped the current state of development. If you are tempted to install packages manually with `pip`, stop and read `AGENTS_DO_NOT_PIP_MANUALLY.md` first. The provided setup scripts manage dependencies for you and explain how optional groups work. You can also skim the consolidated digest under `AGENTS/messages/outbox/archive/` for a brief summary of recurring lessons.
 
+**CI and Headless Agents:** compile the codebases you intend to modify and run the developer setup script non-interactively so all required groups are installed.
+
+```bash
+bash setup_env_dev.sh --prefetch
+python AGENTS/tools/dev_group_menu.py --install --codebases <codebases> --groups <codebase:group,...>
+```
+
+Adjust the codebase and group lists to match your needs.
+
 If you crave an immediate, exhaustive overview, run this one-liner. It will spew every markdown, script and source file to your terminal. The output is massive, but it offers instant familiarity with the project:
 
 ```bash

--- a/AGENTS/tools/AGENTS.md
+++ b/AGENTS/tools/AGENTS.md
@@ -1,5 +1,11 @@
 # Agent Tools
 
+## Quick Setup
+
+```bash
+python AGENTS/tools/dev_group_menu.py --install --codebases AGENTS/tools
+```
+
 This codebase provides helper scripts for managing the repository and coordinating agent work.
 
 ## Optional Dependency Groups

--- a/fontmapper/AGENTS.md
+++ b/fontmapper/AGENTS.md
@@ -1,14 +1,15 @@
 # FontMapper Utilities
 
-This directory contains experimental scripts for converting images to ASCII art and training related models. The subfolder `FM16` holds the current iteration including configuration files and pretrained weights.
-
-These tools rely on packages such as Torch, PIL, and Flask. Prepare the environment with the standard menu helper:
+## Quick Setup
 
 ```bash
-python AGENTS/tools/dev_group_menu.py --install \
-    --codebases fontmapper \
-    --groups speaktome:dev
+python AGENTS/tools/dev_group_menu.py --install --codebases fontmapper
+python AGENTS/tools/dev_group_menu.py --install --codebases fontmapper --groups fontmapper:ml,ssim,amqp,server,gui
 ```
+
+This directory contains experimental scripts for converting images to ASCII art and training related models. The subfolder `FM16` holds the current iteration including configuration files and pretrained weights.
+
+These tools rely on packages such as Torch, PIL, and Flask. Prepare the environment with the standard menu helper.
 
 `FMS6.py` and `FM38.py` expose command line options for text-only output or a small Flask server defined by `server.yaml`. Models are experimental and may evolve quickly. Keep additions documented and follow `AGENTS/CODING_STANDARDS.md`.
 

--- a/laplace/AGENTS.md
+++ b/laplace/AGENTS.md
@@ -1,5 +1,11 @@
 # Laplace Project Archaeology
 
+## Quick Setup
+
+```bash
+python AGENTS/tools/dev_group_menu.py --install --codebases laplace
+```
+
 This folder collects older notebook implementations of the Laplace builder and related geometry utilities. These files were copied from `training/notebook` as a point-in-time snapshot.
 
 They are **not** fully integrated into the main library and may contain experimental or incomplete code. Treat them as historical references.

--- a/speaktome/AGENTS.md
+++ b/speaktome/AGENTS.md
@@ -1,5 +1,12 @@
 # SpeakToMe Source
 
+## Quick Setup
+
+```bash
+python AGENTS/tools/dev_group_menu.py --install --codebases speaktome
+python AGENTS/tools/dev_group_menu.py --install --codebases speaktome --groups speaktome:plot,ml,jax,ctensor,numpy,dev
+```
+
 This directory contains the primary beam search controllers and utilities for generating text. When adding new modules or functions, accompany them with tests in `../tests` and keep all code compliant with `AGENTS/CODING_STANDARDS.md`.
 
 ## Optional Dependency Groups

--- a/tensor printing/AGENTS.md
+++ b/tensor printing/AGENTS.md
@@ -1,5 +1,11 @@
 # Tensor Printing Experiments
 
+## Quick Setup
+
+```bash
+python AGENTS/tools/dev_group_menu.py --install --codebases tensor_printing
+```
+
 This folder houses work toward a "Grand Printing Press" built on the abstract tensor operations shared by the rest of the repository.
 
 `inspiration/` contains raw notebook snapshots copied from `training/notebook`. Future implementations should migrate useful ideas into maintainable modules.

--- a/tensors/AGENTS.md
+++ b/tensors/AGENTS.md
@@ -1,5 +1,12 @@
 # Tensor Backends
 
+## Quick Setup
+
+```bash
+python AGENTS/tools/dev_group_menu.py --install --codebases tensors
+python AGENTS/tools/dev_group_menu.py --install --codebases tensors --groups tensors:jax,ctensor,torch,numpy,dev
+```
+
 This directory hosts the implementations of tensor operations for different numerical libraries (NumPy, PyTorch, JAX, etc.).
 
 **Important:** Each backend must implement `_apply_operator` from `AbstractTensorOperations`. This single method handles all arithmetic primitives. Avoid creating additional bespoke operator helpers – Python's magic methods already route standard arithmetic through `_apply_operator`.

--- a/time_sync/AGENTS.md
+++ b/time_sync/AGENTS.md
@@ -1,5 +1,12 @@
 # Time Sync Utilities
 
+## Quick Setup
+
+```bash
+python AGENTS/tools/dev_group_menu.py --install --codebases time_sync
+python AGENTS/tools/dev_group_menu.py --install --codebases time_sync --groups time_sync:gui
+```
+
 This project provides simple functions for adjusting system time using an environment variable offset. All modules must follow the coding standards from `../AGENTS/CODING_STANDARDS.md`.
 
 ## Optional Dependency Groups


### PR DESCRIPTION
## Summary
- stress headless agent setup in the root instructions
- add dev group menu commands to each registered codebase

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68499cb64f58832a95a9f21548d477bf