### PR TITLE
Improve header tooling with failure notes

### DIFF
--- a/AGENTS/header_template.py
+++ b/AGENTS/header_template.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
+# --- BEGIN HEADER ---
 """Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX, IMPORT_FAILURE_PREFIX
     import your_modules
 except Exception:
     import sys
 
+    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/tools/header_utils.py
+++ b/AGENTS/tools/header_utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# --- BEGIN HEADER ---
 """Shared constants for header compliance utilities."""
 from __future__ import annotations
 
@@ -11,22 +12,34 @@ ENV_SETUP_BOX = (
     "+-----------------------------------------------------------------------+\n"
 )
 
+HEADER_START = "# --- BEGIN HEADER ---"
+HEADER_END = "# --- END HEADER ---"
+IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
+
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    from AGENTS.tools.header_utils import ENV_SETUP_BOX, IMPORT_FAILURE_PREFIX
     import sys
 except Exception:
     import sys
+    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
 
 HEADER_REQUIREMENTS = [
+    "'# --- BEGIN HEADER ---' sentinel after shebang",
     "shebang line '#!/usr/bin/env python3'",
     "module docstring",
     "'from __future__ import annotations' before the try block",
     "imports wrapped in a try block",
-    "except block imports sys then prints ENV_SETUP_BOX and exits",
+    "except block imports sys then prints IMPORT_FAILURE_PREFIX and ENV_SETUP_BOX and exits",
     "'# --- END HEADER ---' sentinel after the except block",
 ]
 
-__all__ = ["ENV_SETUP_BOX", "HEADER_REQUIREMENTS"]
+__all__ = [
+    "ENV_SETUP_BOX",
+    "HEADER_START",
+    "HEADER_END",
+    "IMPORT_FAILURE_PREFIX",
+    "HEADER_REQUIREMENTS",
+]

--- a/tests/test_header_guard_precommit.py
+++ b/tests/test_header_guard_precommit.py
@@ -16,9 +16,10 @@ def test_check_try_header_pass(tmp_path: Path) -> None:
     path = tmp_path / "ok.py"
     path.write_text(
         "#!/usr/bin/env python3\n"
+        "# --- BEGIN HEADER ---\n"
         '"""doc"""\n'
         "from __future__ import annotations\n"
-        "try:\n    import os\nexcept Exception:\n    import sys\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
+        "try:\n    import os\nexcept Exception:\n    import sys\n    print(f'[HEADER] import failure in {__file__}')\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
     )
     assert hg.check_try_header(path) == []
 
@@ -27,6 +28,7 @@ def test_check_try_header_fail(tmp_path: Path) -> None:
     path = tmp_path / "bad.py"
     path.write_text("import os\n# --- END HEADER ---\n")
     errors = hg.check_try_header(path)
+    assert "Missing '# --- BEGIN HEADER ---'" in errors
     assert "Missing shebang" in errors
     assert "Missing module docstring" in errors
 
@@ -35,6 +37,7 @@ def test_check_env_print_missing(tmp_path: Path) -> None:
     path = tmp_path / "noprint.py"
     path.write_text(
         "#!/usr/bin/env python3\n"
+        "# --- BEGIN HEADER ---\n"
         '"""doc"""\n'
         "from __future__ import annotations\n"
         "try:\n    import os\nexcept Exception:\n    import sys\n    sys.exit(1)\n# --- END HEADER ---\n"
@@ -47,6 +50,7 @@ def test_check_sys_import_missing(tmp_path: Path) -> None:
     path = tmp_path / "nosys.py"
     path.write_text(
         "#!/usr/bin/env python3\n"
+        "# --- BEGIN HEADER ---\n"
         '"""doc"""\n'
         "from __future__ import annotations\n"
         "try:\n    import os\nexcept Exception:\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
@@ -59,6 +63,7 @@ def test_check_sys_exit_missing(tmp_path: Path) -> None:
     path = tmp_path / "noexit.py"
     path.write_text(
         "#!/usr/bin/env python3\n"
+        "# --- BEGIN HEADER ---\n"
         '"""doc"""\n'
         "from __future__ import annotations\n"
         "try:\n    import os\nexcept Exception:\n    import sys\n    print(ENV_SETUP_BOX)\n# --- END HEADER ---\n"


### PR DESCRIPTION
## Summary
- add BEGIN header sentinel and new import failure prefix
- update header template and utils
- revise auto_fix_headers to insert failure line and start sentinel
- refresh precommit header guard and its tests

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError)*
- `pytest -q` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68499e28191c832a8324ab921e5084cd