### PR TITLE
Fix validate_headers import

### DIFF
--- a/AGENTS/tools/validate_headers.py
+++ b/AGENTS/tools/validate_headers.py
@@ -7,6 +7,7 @@ try:
     import ast
     from pathlib import Path
     from typing import Iterable
+    import sys
     from .header_utils import ENV_SETUP_BOX
 except Exception:
     import sys


### PR DESCRIPTION
## Summary
- ensure `validate_headers` imports `sys`

## Testing
- `PYTHONPATH=$PWD python -m AGENTS.tools.validate_headers && echo OK || echo FAIL`
- `PYTHONPATH=$PWD pytest tests/test_validate_headers.py -q` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6849a069b428832aa34c8e7a965dd431