### PR TITLE
Update setup references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ Any reusable Python scripts or binary utilities meant for agents must live in `A
 
 For deeper historical context, read through all prior reports. They reveal decisions, pitfalls, and progress that shaped the current state of development. If you are tempted to install packages manually with `pip`, stop and read `AGENTS_DO_NOT_PIP_MANUALLY.md` first. The provided setup scripts manage dependencies for you and explain how optional groups work. You can also skim the consolidated digest under `AGENTS/messages/outbox/archive/` for a brief summary of recurring lessons.
 
-**CI and Headless Agents:** see `AGENTS/HEADLESS_SETUP_GUIDE.md`.
+**CI and Automated Agents:** see `ENV_SETUP_OPTIONS.md`.
 
 If you crave an immediate, exhaustive overview, run this one-liner. It will spew every markdown, script and source file to your terminal. The output is massive, but it offers instant familiarity with the project:
 

--- a/AGENTS/CODEBASES_AND_ENVIRONMENT.md
+++ b/AGENTS/CODEBASES_AND_ENVIRONMENT.md
@@ -9,4 +9,4 @@ Conflicts should be rare when tasks remain isolated. When two pull requests impl
 ## Virtual Environment Expectations
 
 All repository scripts run from the `.venv` interpreter created by the setup
-scripts. For detailed instructions see `AGENTS/HEADLESS_SETUP_GUIDE.md`.
+scripts. For detailed instructions see `ENV_SETUP_OPTIONS.md`.

--- a/AGENTS/tools/AGENTS.md
+++ b/AGENTS/tools/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-See `AGENTS/HEADLESS_SETUP_GUIDE.md` for all environment setup instructions.
+See `ENV_SETUP_OPTIONS.md` for all environment setup instructions.
 
 This codebase provides helper scripts for managing the repository and coordinating agent work.
 

--- a/AGENTS_DO_NOT_PIP_MANUALLY.md
+++ b/AGENTS_DO_NOT_PIP_MANUALLY.md
@@ -10,4 +10,4 @@ If something is missing, re-run `setup_env_dev.sh` and select all relevant group
 
 ### Headless Testing
 
-For automated environments see `AGENTS/HEADLESS_SETUP_GUIDE.md`.
+For automated environments see `ENV_SETUP_OPTIONS.md`.

--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ See `AGENTS/CODEBASE_REGISTRY.md` for the canonical list.
 
 ## Environment Setup
 
-All environment configuration is handled by the headless workflow described in
-`AGENTS/HEADLESS_SETUP_GUIDE.md`.
+All environment configuration is handled by the workflow described in
+`ENV_SETUP_OPTIONS.md`.

--- a/fontmapper/AGENTS.md
+++ b/fontmapper/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-Consult `AGENTS/HEADLESS_SETUP_GUIDE.md` for environment setup.
+Consult `../ENV_SETUP_OPTIONS.md` for environment setup.
 
 This directory contains experimental scripts for converting images to ASCII art and training related models. The subfolder `FM16` holds the current iteration including configuration files and pretrained weights.
 

--- a/laplace/AGENTS.md
+++ b/laplace/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-See `AGENTS/HEADLESS_SETUP_GUIDE.md` for environment setup instructions.
+See `../ENV_SETUP_OPTIONS.md` for environment setup instructions.
 
 This folder collects older notebook implementations of the Laplace builder and related geometry utilities. These files were copied from `training/notebook` as a point-in-time snapshot.
 

--- a/speaktome/AGENTS.md
+++ b/speaktome/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-See `AGENTS/HEADLESS_SETUP_GUIDE.md` for installation instructions.
+See `../ENV_SETUP_OPTIONS.md` for installation instructions.
 
 This directory contains the primary beam search controllers and utilities for generating text. When adding new modules or functions, accompany them with tests in `../tests` and keep all code compliant with `AGENTS/CODING_STANDARDS.md`.
 
@@ -21,7 +21,7 @@ Use standard `pip` extras syntax when needed, e.g. `pip install -e .[plot]` insi
 
 ## Non-Interactive Setup
 
-Refer to `AGENTS/HEADLESS_SETUP_GUIDE.md` for using the headless workflow.
+Refer to `../ENV_SETUP_OPTIONS.md` for non-interactive setup options.
 
 # Agents Documentation
 

--- a/speaktome/README.md
+++ b/speaktome/README.md
@@ -27,14 +27,14 @@ before attempting any network download.
 
 ## Environment Setup
 
-All environment setup is documented in `AGENTS/HEADLESS_SETUP_GUIDE.md`.
+All environment setup is documented in `../ENV_SETUP_OPTIONS.md`.
 
 
 ### Running Python Modules
 
 Always run modules from the repository root so editable imports resolve
 correctly. Ensure the virtual environment described in
-`AGENTS/HEADLESS_SETUP_GUIDE.md` is active before invoking any module.
+`../ENV_SETUP_OPTIONS.md` is active before invoking any module.
 
 
 ## Running SpeakToMe

--- a/tensor printing/AGENTS.md
+++ b/tensor printing/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-Refer to `AGENTS/HEADLESS_SETUP_GUIDE.md` for installation details.
+Refer to `../ENV_SETUP_OPTIONS.md` for installation details.
 
 This folder houses work toward a "Grand Printing Press" built on the abstract tensor operations shared by the rest of the repository.
 

--- a/tensors/AGENTS.md
+++ b/tensors/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-Refer to `AGENTS/HEADLESS_SETUP_GUIDE.md` for setup instructions.
+Refer to `../ENV_SETUP_OPTIONS.md` for setup instructions.
 
 This directory hosts the implementations of tensor operations for different numerical libraries (NumPy, PyTorch, JAX, etc.).
 

--- a/time_sync/AGENTS.md
+++ b/time_sync/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Quick Setup
 
-Refer to `AGENTS/HEADLESS_SETUP_GUIDE.md` for environment setup.
+Refer to `../ENV_SETUP_OPTIONS.md` for environment setup.
 
 This project provides simple functions for adjusting system time using an environment variable offset. All modules must follow the coding standards from `../AGENTS/CODING_STANDARDS.md`.
 

--- a/time_sync/README.md
+++ b/time_sync/README.md
@@ -2,4 +2,4 @@
 
 Utilities for maintaining an environment variable offset between system time and internet time.
 
-See `AGENTS/HEADLESS_SETUP_GUIDE.md` for environment setup instructions.
+See `../ENV_SETUP_OPTIONS.md` for environment setup instructions.


### PR DESCRIPTION
## Summary
- point docs to general `ENV_SETUP_OPTIONS.md`
- drop headless-specific language

## Testing
- `python -m pytest -q` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_e_6849ff2a3818832a802bcdb0a9b6559c