### PR TITLE
Add tensor dtype conversion helpers

### DIFF
--- a/tensors/abstraction.py
+++ b/tensors/abstraction.py
@@ -162,6 +162,36 @@ class AbstractTensor(ABC):
         result.data = self.long_cast_(tensor)
         return result
 
+    def float(self, tensor: Any = None) -> "AbstractTensor":
+        tensor = self.ensure_tensor(self.data_or(tensor))
+        result = type(self)(track_time=self.track_time)
+        result.data = self.float_(tensor)
+        return result
+
+    def double(self, tensor: Any = None) -> "AbstractTensor":
+        tensor = self.ensure_tensor(self.data_or(tensor))
+        result = type(self)(track_time=self.track_time)
+        result.data = self.double_(tensor)
+        return result
+
+    def int(self, tensor: Any = None) -> "AbstractTensor":
+        tensor = self.ensure_tensor(self.data_or(tensor))
+        result = type(self)(track_time=self.track_time)
+        result.data = self.int_(tensor)
+        return result
+
+    def long(self, tensor: Any = None) -> "AbstractTensor":
+        tensor = self.ensure_tensor(self.data_or(tensor))
+        result = type(self)(track_time=self.track_time)
+        result.data = self.long_(tensor)
+        return result
+
+    def bool(self, tensor: Any = None) -> "AbstractTensor":
+        tensor = self.ensure_tensor(self.data_or(tensor))
+        result = type(self)(track_time=self.track_time)
+        result.data = self.bool_(tensor)
+        return result
+
     def not_equal(self, tensor1: Any = None, tensor2: Any = None) -> "AbstractTensor":
         t1 = self.ensure_tensor(self.data_or(tensor1))
         t2 = self.ensure_tensor(self.data_or(tensor2))

--- a/tensors/jax_backend.py
+++ b/tensors/jax_backend.py
@@ -151,6 +151,21 @@ class JAXTensorOperations(AbstractTensor):
     def long_cast_(self, tensor: Any) -> Any:
         return self._to_jnp(tensor).astype(jnp.int64)
 
+    def float_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "float")
+
+    def double_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "double")
+
+    def int_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "int")
+
+    def long_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "long")
+
+    def bool_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "bool")
+
     def not_equal_(self, tensor1: Any, tensor2: Any) -> Any:
         return jnp.not_equal(self._to_jnp(tensor1), self._to_jnp(tensor2))
 

--- a/tensors/numpy_backend.py
+++ b/tensors/numpy_backend.py
@@ -150,6 +150,21 @@ class NumPyTensorOperations(AbstractTensor):
     def long_cast_(self, tensor):
         return self._AbstractTensor__unwrap(tensor).astype(np.int64)
 
+    def float_(self, tensor):
+        return self.to_dtype_(tensor, "float")
+
+    def double_(self, tensor):
+        return self.to_dtype_(tensor, "double")
+
+    def int_(self, tensor):
+        return self.to_dtype_(tensor, "int")
+
+    def long_(self, tensor):
+        return self.to_dtype_(tensor, "long")
+
+    def bool_(self, tensor):
+        return self.to_dtype_(tensor, "bool")
+
     def not_equal_(self, tensor1, tensor2):
         return self._AbstractTensor__unwrap(tensor1) != self._AbstractTensor__unwrap(tensor2)
 

--- a/tensors/pure_backend.py
+++ b/tensors/pure_backend.py
@@ -195,6 +195,21 @@ class PurePythonTensorOperations(AbstractTensor):
             return [self.long_cast_(item) for item in tensor]
         return int(tensor)
 
+    def float_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "float")
+
+    def double_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "double")
+
+    def int_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "int")
+
+    def long_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "long")
+
+    def bool_(self, tensor: Any) -> Any:
+        return self.to_dtype_(tensor, "bool")
+
     def not_equal_(self, tensor1: Any, tensor2: Any) -> Any:
         if isinstance(tensor1, list) and isinstance(tensor2, list):
             return [self.not_equal_(t1, t2) for t1, t2 in zip(tensor1, tensor2)]

--- a/tensors/torch_backend.py
+++ b/tensors/torch_backend.py
@@ -116,6 +116,21 @@ class PyTorchTensorOperations(AbstractTensor):
     def long_cast_(self, tensor):
         return self._AbstractTensor__unwrap(tensor).long()
 
+    def float_(self, tensor):
+        return self._AbstractTensor__unwrap(tensor).float()
+
+    def double_(self, tensor):
+        return self._AbstractTensor__unwrap(tensor).double()
+
+    def int_(self, tensor):
+        return self._AbstractTensor__unwrap(tensor).int()
+
+    def long_(self, tensor):
+        return self._AbstractTensor__unwrap(tensor).long()
+
+    def bool_(self, tensor):
+        return self._AbstractTensor__unwrap(tensor).bool()
+
     def not_equal_(self, tensor1, tensor2):
         return self._AbstractTensor__unwrap(tensor1) != self._AbstractTensor__unwrap(tensor2)
 


### PR DESCRIPTION
## Summary
- implement float(), double(), int(), long(), and bool() methods in `AbstractTensor`
- implement backend hooks `float_`, `double_`, `int_`, `long_`, and `bool_` for Pure Python, NumPy, PyTorch, and JAX backends

## Testing
- `pytest -q` *(fails: environment not configured)*
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*

------
https://chatgpt.com/codex/tasks/task_e_684a06f85678832a962837eb6e92c45e