### PR TITLE
Implement colored AbstractTensor datastring

### DIFF
--- a/AGENTS/experience_reports/1749692786_v1_AbstractTensor_Datastring.md
+++ b/AGENTS/experience_reports/1749692786_v1_AbstractTensor_Datastring.md
@@ -1,0 +1,10 @@
+# Advanced datastring
+
+## Overview
+Implemented a formatted console output for `AbstractTensor.datastring`.
+
+## Prompt History
+- "I would like to make a rather advanced AbstractTensor.datastring method..."
+
+## Notes
+Updated `tensors/abstraction.py` with color-aware table rendering.


### PR DESCRIPTION
## Summary
- enhance `AbstractTensor.datastring` with a color-aware table printer
- log the change in an experience report

## Testing
- `python testing/test_hub.py` *(fails: ModuleNotFoundError: No module named 'AGENTS')*
- `pytest -v` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_e_684a30dc32a8832aa7fcfcdf8085323c