### PR TITLE
Standardize tensor methods to operate on instances

### DIFF
--- a/speaktome/core/beam_search.py
+++ b/speaktome/core/beam_search.py
@@ -325,7 +325,7 @@ class BeamSearch:
         score_matrix = self.tensor_ops.stack(
             [self.scorer.bins[name]['scores'] for name in bin_names], dim=0
         )
-        num_candidates = self.tensor_ops.shape(score_matrix)[1]
+        num_candidates = score_matrix.shape()[1]
         k = min(self.gpu_limit, num_candidates)
         top_scores, top_idx = self.tensor_ops.topk(score_matrix, k=k, dim=1)
 

--- a/speaktome/cpu_demo.py
+++ b/speaktome/cpu_demo.py
@@ -90,7 +90,7 @@ class RandomModel(AbstractModelWrapper):
             width = len(input_ids[0]) if batch > 0 else 0
             flat_ids = [tok for row in input_ids for tok in row]
 
-        one_hot = ops.index_select(self.embed, 0, flat_ids)
+        one_hot = self.embed[flat_ids]
         logits_flat = self.model.forward(one_hot, None)["logits"]
 
         if NUMPY_AVAILABLE:

--- a/tensor printing/tensor_printing/press.py
+++ b/tensor printing/tensor_printing/press.py
@@ -39,8 +39,8 @@ class GrandPrintingPress:
     ) -> Any:
         """Apply a glyph tensor at the given position."""
         y_idx, x_idx = self.ruler.coordinates_to_tensor(position[0], position[1], unit)
-        g_height, g_width = self.tensor_ops.shape(glyph)
-        c_height, c_width = self.tensor_ops.shape(self.canvas)
+        g_height, g_width = glyph.shape()
+        c_height, c_width = self.canvas.shape()
 
         end_y = min(y_idx + g_height, c_height)
         end_x = min(x_idx + g_width, c_width)
@@ -48,10 +48,10 @@ class GrandPrintingPress:
             return self.canvas
 
         sub_glyph = glyph[: end_y - y_idx, : end_x - x_idx]
-        for row in range(self.tensor_ops.shape(sub_glyph)[0]):
+        for row in range(sub_glyph.shape()[0]):
             indices_dim0 = [y_idx + row] * (end_x - x_idx)
             indices_dim1 = list(range(x_idx, end_x))
-            values = self.tensor_ops.tolist(sub_glyph[row])
+            values = sub_glyph[row].tolist()
             self.tensor_ops.assign_at_indices(
                 self.canvas, indices_dim0, indices_dim1, values
             )
@@ -121,7 +121,7 @@ class GrandPrintingPress:
         for ch in text:
             if ch == "\n":
                 sample = next(iter(library.values()))
-                g_height = self.tensor_ops.shape(sample)[0]
+                g_height = sample.shape()[0]
                 # move down by glyph height in tensor units
                 y -= self.ruler.tensor_to_coordinates(0, g_height, unit)[1]
                 x = position[0]
@@ -130,7 +130,7 @@ class GrandPrintingPress:
             if glyph is None:
                 continue
             self.print_glyph(glyph, (x, y), unit=unit)
-            g_width = self.tensor_ops.shape(glyph)[1]
+            g_width = glyph.shape()[1]
             x += self.ruler.tensor_to_coordinates(g_width, 0, unit)[0]
         return self.canvas
 

--- a/tensors/abstraction.py
+++ b/tensors/abstraction.py
@@ -341,18 +341,13 @@ class AbstractTensor(ABC):
         """Return the number of dimensions (property, numpy style)."""
         return self.get_ndims(self.data)
 
-    @property
-    def ndims(self):
-        """Return the number of dimensions (property, project style)."""
+    def dim(self) -> int:
+        """Return the number of dimensions (method, torch style)."""
         return self.get_ndims(self.data)
 
-    def dim(self, tensor=None):
-        """Return the number of dimensions (method, torch style)."""
-        return self.get_ndims(self.data_or(tensor))
-
-    def ndims(self, tensor=None):
+    def ndims(self) -> int:
         """Return the number of dimensions (method, project style)."""
-        return self.get_ndims(self.data_or(tensor))
+        return self.get_ndims(self.data)
 
     # Lightweight helper to coerce arbitrary input to this backend's tensor type
     def to_backend(
@@ -649,18 +644,19 @@ class AbstractTensor(ABC):
         return obj
 
     @abstractmethod
-    def get_shape(self, tensor=None):
-        """Return the shape of the tensor as a tuple."""
+    def get_shape(self) -> Tuple[int, ...]:
+        """Return the shape of ``self`` as a tuple."""
         pass
 
     @abstractmethod
-    def get_ndims(self, tensor=None):
-        """Return the number of dimensions of the tensor."""
+    def get_ndims(self) -> int:
+        """Return the number of dimensions of ``self``."""
         pass
 
 
-    def repeat(self, tensor: Any = None, repeats: Any = None, dim: int = 0) -> "AbstractTensor":
-        return self.repeat_(tensor if tensor is not None else self, repeats, dim)
+    def repeat(self, repeats: Any = None, dim: int = 0) -> "AbstractTensor":
+        """Repeat ``self`` along ``dim`` ``repeats`` times."""
+        return self.repeat_(repeats, dim)
     @staticmethod
     def get_tensor(data=None, faculty: 'Faculty' = None, *, track_time: bool = False) -> 'AbstractTensor':
         """

--- a/tensors/c_backend.py
+++ b/tensors/c_backend.py
@@ -686,14 +686,14 @@ class CTensorOperations(AbstractTensor):
         return CTensor
 
     # Implementation hooks required by AbstractTensor
-    def get_shape(self, tensor=None):
-        t = tensor if tensor is not None else self.data
+    def get_shape(self) -> tuple[int, ...]:
+        t = self.data
         if not isinstance(t, CTensor):
             t = CTensor.from_list(t, _get_shape(t))
         return t.shape
 
-    def get_ndims(self, tensor=None):
-        return len(self.get_shape(tensor))
+    def get_ndims(self) -> int:
+        return len(self.get_shape())
 
     def to_dtype_(self, tensor, dtype: str = "float"):
         """Simple dtype conversion placeholder."""

--- a/tensors/jax_backend.py
+++ b/tensors/jax_backend.py
@@ -394,10 +394,8 @@ class JAXTensorOperations(AbstractTensor):
             # Default to float32
             return jnp.asarray(tensor, dtype=jnp.float32)
 
-    def get_shape(self, tensor=None):
-        t = self._AbstractTensor__unwrap(tensor) if tensor is not None else self.data
-        return tuple(t.shape)
+    def get_shape(self) -> tuple[int, ...]:
+        return tuple(self.data.shape)
 
-    def get_ndims(self, tensor=None):
-        t = self._AbstractTensor__unwrap(tensor) if tensor is not None else self.data
-        return t.ndim
+    def get_ndims(self) -> int:
+        return self.data.ndim

--- a/tensors/numpy_backend.py
+++ b/tensors/numpy_backend.py
@@ -384,10 +384,8 @@ class NumPyTensorOperations(AbstractTensor):
         result.data = np.array(data)
         return result
 
-    def get_shape(self, tensor=None):
-        t = self._AbstractTensor__unwrap(tensor) if tensor is not None else self.data
-        return tuple(t.shape)
+    def get_shape(self) -> tuple[int, ...]:
+        return tuple(self.data.shape)
 
-    def get_ndims(self, tensor=None):
-        t = self._AbstractTensor__unwrap(tensor) if tensor is not None else self.data
-        return t.ndim
+    def get_ndims(self) -> int:
+        return self.data.ndim

--- a/tensors/pure_backend.py
+++ b/tensors/pure_backend.py
@@ -559,13 +559,11 @@ class PurePythonTensorOperations(AbstractTensor):
         result.data = data
         return result
 
-    def get_shape(self, tensor=None):
-        t = self._AbstractTensor__unwrap(tensor) if tensor is not None else self.data
-        return _get_shape(t)
+    def get_shape(self) -> tuple[int, ...]:
+        return _get_shape(self.data)
 
-    def get_ndims(self, tensor=None):
-        t = self._AbstractTensor__unwrap(tensor) if tensor is not None else self.data
-        return len(_get_shape(t))
+    def get_ndims(self) -> int:
+        return len(_get_shape(self.data))
 
     def to_dtype_(self, tensor, dtype: str = "float"):
         # For pure Python, just convert all elements recursively

--- a/tests/test_lookahead_controller.py
+++ b/tests/test_lookahead_controller.py
@@ -49,7 +49,7 @@ class DummyModel(AbstractModelWrapper):
             width = len(input_ids[0]) if batch else 0
             flat_ids = [tok for row in input_ids for tok in row]
 
-        one_hot = ops.index_select(self.embed, 0, flat_ids)
+        one_hot = self.embed[flat_ids]
         logits_flat = self.model.forward(one_hot, None)["logits"]
 
         if hasattr(input_ids, "shape"):
@@ -120,8 +120,8 @@ def test_lookahead_across_backends(faculty, caplog):
     with caplog.at_level(logging.INFO):
         result = ops.benchmark(lambda: controller.run(ptoks, pscores, plens, pidx))
     tokens, _, lengths, *_ = result
-    assert ops.shape(tokens)[0] > 0
-    assert ops.shape(lengths)[0] > 0
+    assert tokens.shape()[0] > 0
+    assert lengths.shape()[0] > 0
     if ops.last_op_time is not None:
         logger.info("%s backend lookahead time: %.6f", faculty.name, ops.last_op_time)
 
@@ -155,5 +155,5 @@ def test_lookahead_default_backend(steps):
 
     result = ops.benchmark(lambda: controller.run(ptoks, pscores, plens, pidx))
     tokens, _, _, *_ = result
-    assert ops.shape(tokens)[0] > 0
+    assert tokens.shape()[0] > 0
     assert ops.last_op_time is not None

--- a/tests/test_tensor_backends.py
+++ b/tests/test_tensor_backends.py
@@ -45,22 +45,22 @@ def available_backends():
 def run_checks(ops):
     t = ops.tensor_from_list([[1, 2], [3, 4]], dtype=ops.float_dtype, device=None)
     stacked0 = ops.benchmark(lambda: ops.stack([t, t], dim=0))
-    assert ops.tolist(stacked0) == [[[1, 2], [3, 4]], [[1, 2], [3, 4]]]
+    assert stacked0.tolist() == [[[1, 2], [3, 4]], [[1, 2], [3, 4]]]
     stacked1 = ops.benchmark(lambda: ops.stack([t, t], dim=1))
-    assert ops.tolist(stacked1) == [[[1, 2], [1, 2]], [[3, 4], [3, 4]]]
+    assert stacked1.tolist() == [[[1, 2], [1, 2]], [[3, 4], [3, 4]]]
 
     rng = list(range(3))
     data = ops.tensor_from_list(
         [[i + j for j in rng] for i in rng], dtype=ops.float_dtype, device=None
     )
     stacked0 = ops.benchmark(lambda: ops.stack([data, data], dim=0))
-    assert ops.tolist(stacked0) == [ops.tolist(data), ops.tolist(data)]
+    assert stacked0.tolist() == [data.tolist(), data.tolist()]
     stacked1 = ops.benchmark(lambda: ops.stack([data, data], dim=1))
-    data_list = ops.tolist(data)
-    assert ops.tolist(stacked1) == [[row, row] for row in data_list]
+    data_list = data.tolist()
+    assert stacked1.tolist() == [[row, row] for row in data_list]
 
     padded = ops.benchmark(lambda: ops.pad(t, (1, 1, 1, 1), value=0))
-    assert ops.tolist(padded) == [
+    assert padded.tolist() == [
         [0, 0, 0, 0],
         [0, 1, 2, 0],
         [0, 3, 4, 0],
@@ -71,44 +71,44 @@ def run_checks(ops):
         [[i for i in range(3)] for _ in range(2)], dtype=ops.float_dtype, device=None
     )
     padded = ops.benchmark(lambda: ops.pad(base, (0, 2, 1, 0), value=9))
-    padded_list = ops.tolist(padded)
+    padded_list = padded.tolist()
     assert len(padded_list) == 3
     assert all(len(row) == 5 for row in padded_list)
 
     topk_input = ops.tensor_from_list([1, 3, 2, 4], dtype=ops.float_dtype, device=None)
-    values, indices = ops.benchmark(lambda: ops.topk(topk_input, k=2, dim=-1))
-    assert ops.tolist(values) == [4, 3]
-    assert ops.tolist(indices) == [3, 1]
+    values, indices = ops.benchmark(lambda: topk_input.topk(k=2, dim=-1))
+    assert values.tolist() == [4, 3]
+    assert indices.tolist() == [3, 1]
 
     seq_list = [7, 1, 4, 9, 2, 6]
     seq = ops.tensor_from_list(seq_list, dtype=ops.float_dtype, device=None)
-    vals, idxs = ops.benchmark(lambda: ops.topk(seq, k=3, dim=-1))
+    vals, idxs = ops.benchmark(lambda: seq.topk(k=3, dim=-1))
     expect_vals = sorted(seq_list, reverse=True)[:3]
     expect_inds = [seq_list.index(v) for v in expect_vals]
-    assert ops.tolist(vals) == expect_vals
-    assert ops.tolist(idxs) == expect_inds
+    assert vals.tolist() == expect_vals
+    assert idxs.tolist() == expect_inds
 
     # Multi-dimensional topk
     matrix = ops.tensor_from_list(
         [[1, 5, 3], [4, 2, 6]], dtype=ops.float_dtype, device=None
     )
-    tvals, tidxs = ops.benchmark(lambda: ops.topk(matrix, k=2, dim=1))
-    assert ops.tolist(tvals) == [[5, 3], [6, 4]]
-    assert ops.tolist(tidxs) == [[1, 2], [2, 0]]
+    tvals, tidxs = ops.benchmark(lambda: matrix.topk(k=2, dim=1))
+    assert tvals.tolist() == [[5, 3], [6, 4]]
+    assert tidxs.tolist() == [[1, 2], [2, 0]]
 
     # Argmin tests
-    amin_idx = ops.argmin(seq)
+    amin_idx = seq.argmin()
     assert _norm(amin_idx) == seq_list.index(min(seq_list))
-    amin_rows = ops.argmin(matrix, dim=1)
-    assert ops.tolist(amin_rows) == [0, 1]
+    amin_rows = matrix.argmin(dim=1)
+    assert amin_rows.tolist() == [0, 1]
 
     # Interpolation tests
     base_1d = ops.tensor_from_list([0.0, 10.0], dtype=ops.float_dtype, device=None)
     interp = ops.interpolate(base_1d, (5,))
-    assert pytest.approx(ops.tolist(interp)) == [0.0, 2.5, 5.0, 7.5, 10.0]
+    assert pytest.approx(interp.tolist()) == [0.0, 2.5, 5.0, 7.5, 10.0]
     base_2d = ops.tensor_from_list([[0.0, 10.0], [10.0, 20.0]], dtype=ops.float_dtype, device=None)
     interp2d = ops.interpolate(base_2d, (3, 4))
-    assert ops.shape(interp2d) == (3, 4)
+    assert interp2d.shape() == (3, 4)
 
     # Test operators on tensors created by the backend
     try:
@@ -117,10 +117,10 @@ def run_checks(ops):
 
         data_sub = ops.tensor_from_list([2.0, 4.0, 6.0], dtype=dtype, device=None)
         # Python float scalar, relying on backend's operator broadcasting/handling
-        assert ops.tolist(data_sub - 1.0) == [1.0, 3.0, 5.0]
+        assert (data_sub - 1.0).tolist() == [1.0, 3.0, 5.0]
 
         data_div = ops.tensor_from_list([2.0, 4.0], dtype=dtype, device=None)  # type: ignore
-        assert ops.tolist(data_div / 2.0) == [1.0, 2.0]
+        assert (data_div / 2.0).tolist() == [1.0, 2.0]
     except (TypeError, NotImplementedError, AttributeError) as exc:
         pytest.skip(f"Operator dispatch not supported: {exc}")
 
@@ -176,19 +176,19 @@ def test_basic_operator_dispatch(backend_cls):
         b_int = ops.tensor_from_list(b_list_int, dtype=long_dtype, device=None)
 
         # Test operators on these tensors
-        assert _norm(ops.tolist(a_float + b_float)) == [4.0, 6.0]
-        assert _norm(ops.tolist(b_float - a_float)) == [2.0, 2.0]
-        assert _norm(ops.tolist(a_float * b_float)) == [3.0, 8.0]
-        assert _norm(ops.tolist(b_float / a_float)) == [3.0, 2.0]
+        assert _norm((a_float + b_float).tolist()) == [4.0, 6.0]
+        assert _norm((b_float - a_float).tolist()) == [2.0, 2.0]
+        assert _norm((a_float * b_float).tolist()) == [3.0, 8.0]
+        assert _norm((b_float / a_float).tolist()) == [3.0, 2.0]
 
         # For floor division and modulo, integer-like inputs are typical
-        assert _norm(ops.tolist(b_int // a_int)) == [3, 2]
-        assert _norm(ops.tolist(b_int % a_int)) == [0, 0]
+        assert _norm((b_int // a_int).tolist()) == [3, 2]
+        assert _norm((b_int % a_int).tolist()) == [0, 0]
 
         # Power can use float or int base/exponent depending on desired outcome
         # Using a_float for potentially float results (e.g. non-integer exponents)
         # Here, a_float ** a_float (e.g., 1.0**1.0, 2.0**2.0)
-        assert _norm(ops.tolist(a_float**a_float)) == [1.0, 4.0]
+        assert _norm((a_float**a_float).tolist()) == [1.0, 4.0]
 
     except (TypeError, NotImplementedError, AttributeError):
 
@@ -206,9 +206,9 @@ def test_to_backend_roundtrip(src_cls, tgt_cls):
     data = [[1, 2], [3, 4]]
     tensor = src_ops.tensor_from_list(data, dtype=src_ops.float_dtype, device=None)
     converted = tensor.to_backend(tgt_ops)
-    assert tgt_ops.tolist(converted) == data
+    assert converted.tolist() == data
     roundtrip = converted.to_backend(src_ops)
-    assert src_ops.tolist(roundtrip) == data
+    assert roundtrip.tolist() == data
         
 
 
@@ -231,4 +231,4 @@ def test_stack_mixed_inputs():
     arr = np.array([1, 2])
     lst = [1, 2]
     stacked = ops.stack([arr, lst], dim=0)
-    assert ops.tolist(stacked) == [[1, 2], [1, 2]]
+    assert stacked.tolist() == [[1, 2], [1, 2]]


### PR DESCRIPTION
## Summary
- remove optional tensor arguments in `AbstractTensor`
- adjust backend implementations for new shape/ndims API
- update demos, controllers, and printing utilities to call tensor instance methods
- refactor tensor backend tests to use instance-style operations
- use indexing syntax instead of `index_select`

## Testing
- `python testing/test_hub.py` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_e_684a81321860832a81aff496c04daad7