### PR TITLE
Remove headless and notorch options

### DIFF
--- a/ENV_SETUP_OPTIONS.md
+++ b/ENV_SETUP_OPTIONS.md
@@ -11,9 +11,7 @@ This document details all options, flags, and usage patterns for the environment
 - [Usage Scenarios](#usage-scenarios)
   - [Basic Interactive Setup](#basic-interactive-setup)
   - [Developer Setup](#developer-setup)
-  - [Headless Setup (Non-Interactive)](#headless-setup-non-interactive)
-  - [Headless Setup Without Torch](#headless-setup-without-torch)
-- [Avoiding Torch and Torch-Dependent Codebases/Groups](#avoiding-torch-and-torch-dependent-codebasesgroups)
+  - [Torch Installation Options](#torch-installation-options)
 - [Examples](#examples)
 - [Notes](#notes)
 
@@ -21,7 +19,7 @@ This document details all options, flags, and usage patterns for the environment
 
 ## Overview
 
-The environment setup scripts automate the creation of a Python virtual environment, installation of dependencies, and selection of codebases/groups for development or testing. They support both interactive and headless (non-interactive) modes, and can be configured to skip installation of PyTorch and any codebase/group that requires it.
+The environment setup scripts automate the creation of a Python virtual environment, installation of dependencies, and selection of codebases/groups for development or testing. Torch is skipped unless requested with `-torch` or `-gpu`.
 
 **Default Behavior:** Torch groups are skipped unless explicitly requested with
 `-torch` or `-gpu`. This avoids any network access to the PyTorch wheel index on
@@ -41,7 +39,7 @@ needed.
 
 Each project root also includes quick-start wrappers `setup_env.sh` and
 `setup_env.ps1`. These wrappers change to the repository root and invoke the
-installation-choice Python tool in headless mode with default arguments.
+installation-choice Python tool with default arguments.
 
 ---
 
@@ -50,10 +48,10 @@ installation-choice Python tool in headless mode with default arguments.
 | Option/Flag         | Both PowerShell & Bash | Description                                                                                 |
 |--------------------|-------------------------|-----------------------------------------------------------------------------------------|
 | `-NoVenv`          | `-NoVenv`               | Do not create or use a Python virtual environment.                                      |
-| `-notorch`         | `-notorch`              | Skip installing PyTorch and any codebase/group that requires it.                        |
 | `-Codebases VAL`   | `-Codebases VAL`        | Specify codebases to install/select (comma-separated).                                  |
 | `-Groups VAL`      | `-Groups VAL`           | Specify groups to install/select (comma-separated).                                     |
-| `-headless`        | `-headless`             | Run in non-interactive mode.                                                            |
+| `-torch`           | `-torch`                | Install the CPU Torch optional dependency group.                                        |
+| `-gpu`             | `-gpu`                  | Install the GPU Torch optional dependency group.                                        |
 | `-FromDev`         | `-FromDev`              | Internal: Indicates script was called from a dev setup script.                          |
 
 > **Both PowerShell and Bash scripts use identical single-dash flags for consistency across operating systems.**
@@ -78,7 +76,7 @@ bash setup_env.sh
 
 - Runs in interactive mode with NO codebases/groups pre-selected.
 - User must choose from available options defined in `AGENTS/codebase_map.json`.
-- Installs torch by default unless `-notorch` is specified.
+- Torch is not installed unless `-torch` or `-gpu` is specified.
 
 ### Developer Setup
 
@@ -95,44 +93,11 @@ bash setup_env_dev.sh
 - Runs standard setup, then presents a developer menu for documentation/tools.
 - Accepts all the same flags as the main setup script.
 
-### Headless Setup (Non-Interactive)
-
-**Windows (PowerShell):**
-```powershell
-./setup_env.ps1 -headless -codebases projecta,projectb -groups groupx
-```
-
-**Linux/macOS (Bash):**
-```bash
-bash setup_env.sh -headless -codebases=projecta,projectb -groups=groupx
-```
-
-- No interactive prompts. Must specify codebases and/or groups explicitly.
-- Available codebases and groups are defined in `AGENTS/codebase_map.json`.
-
-### Headless Setup Without Torch
-
-**Windows (PowerShell):**
-```powershell
-./setup_env.ps1 -headless -notorch -codebases projectc,projectd -groups groupy
-```
-
-**Linux/macOS (Bash):**
-```bash
-bash setup_env.sh -headless -notorch -codebases=projectc,projectd -groups=groupy
-```
-
-- Skips torch installation and any codebase/group that requires torch.
-- Use with `-codebases` or `-groups` to specify what to install instead.
-
 ---
 
-## Avoiding Torch and Torch-Dependent Codebases/Groups
+## Torch Installation Options
 
-- Use the `-notorch` flag to skip torch installation.
- - Pass `-torch` for the CPU build or `-gpu` for the GPU variant. These map to optional groups defined in `pyproject.toml`.
-- In headless mode, auto-selection will avoid torch-dependent codebases/groups if `-notorch` is set.
-- Interactive menus hide those choices when torch is skipped.
+Pass `-torch` for the CPU build or `-gpu` for the GPU variant. These map to optional groups defined in `pyproject.toml`. When neither flag is provided, torch-related dependencies are skipped.
 
 ---
 
@@ -146,20 +111,12 @@ bash setup_env.sh -headless -notorch -codebases=projectc,projectd -groups=groupy
 bash setup_env.sh
 ```
 
-**Headless setup with specific codebases and groups:**
+**No venv, CPU torch, specific codebases and groups:**
 ```powershell
-./setup_env.ps1 -headless -codebases projecta,projectb -groups groupx
+./setup_env.ps1 -novenv -torch -codebases projectc,projectd -groups groupy
 ```
 ```bash
-bash setup_env.sh -headless -codebases=projecta,projectb -groups=groupx
-```
-
-**No venv, no torch, specific codebases and groups:**
-```powershell
-./setup_env.ps1 -novenv -notorch -codebases projectc,projectd -groups groupy
-```
-```bash
-bash setup_env.sh -novenv -notorch -codebases=projectc,projectd -groups=groupy
+bash setup_env.sh -novenv -torch -codebases=projectc,projectd -groups=groupy
 ```
 
 **Developer setup with specific group:**
@@ -175,9 +132,7 @@ bash setup_env_dev.sh -groups=groupx
 ## Notes
 
 - All flags use single-dash format for consistency across both PowerShell and Bash.
-- The `-notorch` flag is the authoritative way to avoid torch and torch-dependent codebases/groups.
 - For interactive setup, no codebases/groups are pre-selected - user must choose from the menu.
-- For headless setup, codebases and/or groups must be specified explicitly.
 - Available codebases and groups are defined in `AGENTS/codebase_map.json`.
 - The scripts will create a `.venv` directory by default unless `-NoVenv` is used.
 - Selections are recorded to the file specified by the `SPEAKTOME_ACTIVE_FILE` environment variable (or a default path).

--- a/archive/HEADLESS_SETUP_GUIDE.md
+++ b/archive/HEADLESS_SETUP_GUIDE.md
@@ -1,6 +1,6 @@
-# Headless Environment Setup
+# Headless Environment Setup (Deprecated)
 
-This document explains how to install codebases without interactive prompts.
+Earlier versions of the project supported a `--headless` flag for non-interactive installation. That mode has been removed. The instructions below remain for historical reference only.
 
 1. **Update the codebase map**
 
@@ -10,22 +10,21 @@ This document explains how to install codebases without interactive prompts.
 
    The JSON file lists every project directory and its optional dependency groups.
 
-2. **Run the developer setup in headless mode**
+2. **Run the developer setup**
 
-Provide the codebases you wish to install via the `CODEBASES` environment
-variable or the `--codebases` flag. When no codebases are specified,
+Specify the codebases you wish to install via the `--codebases` flag. When no codebases are specified,
 `setup_env_dev` installs every entry from the map.
 
 ```bash
 CODEBASES="speaktome laplace time_sync" \
-  bash setup_env_dev.sh --groups=gui --groups=ml --headless
+  bash setup_env_dev.sh --groups=gui --groups=ml
 ```
 
 Windows PowerShell equivalent:
 
 ```powershell
 $env:CODEBASES = 'speaktome laplace time_sync'
-powershell -ExecutionPolicy Bypass -File setup_env_dev.ps1 -groups gui -groups ml -headless
+powershell -ExecutionPolicy Bypass -File setup_env_dev.ps1 -groups gui -groups ml
 ```
 
-The headless option installs each selected codebase in editable mode based on the JSON map. Avoid manual `pip install` commands and rerun the setup script if dependencies change.
+The previous headless option installed each selected codebase in editable mode. Avoid manual `pip install` commands and rerun the setup script if dependencies change.

--- a/fontmapper/AGENTS.md
+++ b/fontmapper/AGENTS.md
@@ -23,4 +23,4 @@ The simplified rewrite of the rendering utilities now resides directly in this
 folder under `ascii_mapper.py`. The legacy implementation remains in the
 `FM16` subdirectory for historical reference. Use `ascii_preview` from
 `ascii_mapper.py` for new code paths. See `../ENV_SETUP_OPTIONS.md` for
-headless setup details.
+setup details.

--- a/fontmapper/setup_env.sh
+++ b/fontmapper/setup_env.sh
@@ -13,29 +13,28 @@ try:
     groups=data.get(name, {}).get("groups", {})
 except Exception:
     groups={}
-notorch=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
-print(','.join(notorch))
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
 print(','.join(groups))
 PY
 }
-read -r NOTORCH_GROUPS ALL_GROUPS <<< "$(get_groups)"
-MODE="notorch"
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
 for arg in "$@"; do
   case $arg in
     -full|-torch) MODE="full" ;;
     -minimal) MODE="minimal" ;;
-    -notorch) MODE="notorch" ;;
   esac
 done
 case $MODE in
   full)
-    GROUPS="$ALL_GROUPS"; NOTORCH="" ;;
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
   minimal)
-    GROUPS=""; NOTORCH="-notorch" ;;
+    GROUPS="" ;;
   *)
-    GROUPS="$NOTORCH_GROUPS"; NOTORCH="-notorch" ;;
+    GROUPS="$SAFE_GROUPS" ;;
 esac
-ARGS=(-headless -codebases="$CODEBASE")
+ARGS=(-codebases="$CODEBASE")
 [ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
 cd "$REPO_ROOT"
-bash "$REPO_ROOT/setup_env_dev.sh" $NOTORCH "${ARGS[@]}"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"

--- a/laplace/setup_env.sh
+++ b/laplace/setup_env.sh
@@ -13,29 +13,28 @@ try:
     groups=data.get(name, {}).get("groups", {})
 except Exception:
     groups={}
-notorch=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
-print(','.join(notorch))
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
 print(','.join(groups))
 PY
 }
-read -r NOTORCH_GROUPS ALL_GROUPS <<< "$(get_groups)"
-MODE="notorch"
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
 for arg in "$@"; do
   case $arg in
     -full|-torch) MODE="full" ;;
     -minimal) MODE="minimal" ;;
-    -notorch) MODE="notorch" ;;
   esac
 done
 case $MODE in
   full)
-    GROUPS="$ALL_GROUPS"; NOTORCH="" ;;
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
   minimal)
-    GROUPS=""; NOTORCH="-notorch" ;;
+    GROUPS="" ;;
   *)
-    GROUPS="$NOTORCH_GROUPS"; NOTORCH="-notorch" ;;
+    GROUPS="$SAFE_GROUPS" ;;
 esac
-ARGS=(-headless -codebases="$CODEBASE")
+ARGS=(-codebases="$CODEBASE")
 [ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
 cd "$REPO_ROOT"
-bash "$REPO_ROOT/setup_env_dev.sh" $NOTORCH "${ARGS[@]}"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -8,14 +8,12 @@ param(
 
 # Manual flag parsing for all arguments (case-insensitive, -flag=value style)
 $NoVenv = $false
-$headless = $false
 $FromDev = $false
 $Codebases = @()
 $Groups = @()
 foreach ($arg in $args) {
     $arg_lc = $arg.ToLower()
     if ($arg_lc -eq '-novenv') { $NoVenv = $true }
-    elseif ($arg_lc -eq '-headless') { $headless = $true }
     elseif ($arg_lc -eq '-fromdev') { $FromDev = $true }
     elseif ($arg_lc -like '-codebases=*') {
         $cbVal = $arg.Substring($arg.IndexOf('=')+1)
@@ -41,25 +39,8 @@ if (-not $activeFile) {
 }
 $env:SPEAKTOME_ACTIVE_FILE = $activeFile
 if (-not $Codebases) {
-    if ($headless) {
-        Write-Host "[DEBUG] No codebases specified - headless mode: auto-loading from codebase_map.json."
-        $mapFile = Join-Path $PSScriptRoot 'AGENTS\codebase_map.json'
-        if (Test-Path $mapFile) {
-            try {
-                $Codebases = (Get-Content $mapFile | ConvertFrom-Json).psobject.Properties.Name
-                # Optionally load all groups for a full install:
-                # $Groups = @( 'groupA','groupB','...' )
-            }
-            catch {
-                Write-Host "[DEBUG] Could not parse codebase_map.json; continuing empty."
-                $Codebases = $null
-            }
-        }
-    }
-    else {
-        Write-Host "[DEBUG] No codebases specified - launching interactive menu."
-        # Let dev_group_menu handle interactive selection
-    }
+    Write-Host "[DEBUG] No codebases specified - launching interactive menu."
+    # Let dev_group_menu handle interactive selection
 }
 $menuArgs = @()
 if ($Codebases) { $menuArgs += '-Codebases'; $menuArgs += ($Codebases -join ',') }
@@ -183,7 +164,7 @@ if ($argString -like '*with*torch*') {
 
 # Always run dev_group_menu.py at the end
 if ($FromDev) {
-    Write-Host "Installing AGENTS/tools in headless mode..."
+    Write-Host "Installing AGENTS/tools..."
     $env:PIP_CMD = $venvPip
     & $venvPython (Join-Path $PSScriptRoot "AGENTS\tools\dev_group_menu.py") --install --codebases 'tools' --record $activeFile
     Write-Host "Launching codebase/group selection tool for editable installs (from-dev)..."

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -15,26 +15,14 @@ ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 
 USE_VENV=1
-HEADLESS=0
 CODEBASES=""
 GROUPS=()
 for arg in "$@"; do
   arg_lc="${arg,,}"
   case $arg_lc in
     -no-venv) USE_VENV=0 ;;
-    -headless) HEADLESS=1 ;;
   esac
 done
-
-# Auto-load codebases from map file when running headless
-if [ -z "$CODEBASES" ] && [ $HEADLESS -eq 1 ] && [ -f "$MAP_FILE" ]; then
-  CODEBASES="$(python - "$MAP_FILE" <<'PY'
-import json,sys
-d=json.load(open(sys.argv[1]))
-print(",".join(d.keys()))
-PY
-)"
-fi
 
 [ -n "$CODEBASES" ] && MENU_ARGS+=("-codebases" "$CODEBASES")
 for g in "${GROUPS[@]}"; do
@@ -137,8 +125,8 @@ done
 
 # Always run dev_group_menu.py at the end
 if [ $CALLED_BY_DEV -eq 1 ]; then
-  # Headless install of AGENTS/tools
-  echo "Installing AGENTS/tools in headless mode..."
+  # Install AGENTS/tools without prompts
+  echo "Installing AGENTS/tools..."
   PIP_CMD="$VENV_PIP" "$VENV_PYTHON" "$SCRIPT_ROOT/AGENTS/tools/dev_group_menu.py" --install --codebases tools --record "$SPEAKTOME_ACTIVE_FILE"
   # Then run again with any arguments passed
   echo "Launching codebase/group selection tool for editable installs (from-dev)..."

--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -38,7 +38,6 @@ foreach ($arg in $args) {
     }
     elseif ($arg_lc -eq '-torch') { $torchChoice = 'cpu' }
     elseif ($arg_lc -eq '-gpu' -or $arg_lc -eq '-gpu-torch') { $torchChoice = 'gpu' }
-    elseif ($arg_lc -eq '-notorch' -or $arg_lc -eq '-no-torch') { $torchChoice = '' }
 }
 $poetryArgs = '--without cpu-torch --without gpu-torch'
 if ($torchChoice -eq 'cpu') { $poetryArgs = '--with cpu-torch' }
@@ -48,7 +47,7 @@ $env:SPEAKTOME_POETRY_ARGS = $poetryArgs
 $filtered = @()
 foreach ($arg in $args) {
     $arg_lc = $arg.ToLower()
-    if ($arg_lc -ne '-torch' -and $arg_lc -ne '-gpu' -and $arg_lc -ne '-gpu-torch' -and $arg_lc -ne '-notorch' -and $arg_lc -ne '-no-torch') {
+    if ($arg_lc -ne '-torch' -and $arg_lc -ne '-gpu' -and $arg_lc -ne '-gpu-torch') {
         $filtered += $arg
     }
 }

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -32,7 +32,6 @@ for arg in "$@"; do
     -groups=*|-grp=*)   MENU_ARGS+=("-groups" "${arg#*=}") ;;
     -torch) TORCH_CHOICE="cpu" ;;
     -gpu|-gpu-torch) TORCH_CHOICE="gpu" ;;
-    -notorch|-no-torch) TORCH_CHOICE="" ;;
   esac
 done
 POETRY_ARGS="--without cpu-torch --without gpu-torch"
@@ -46,7 +45,7 @@ export SPEAKTOME_POETRY_ARGS="$POETRY_ARGS"
 ARGS=()
 for arg in "$@"; do
   case "${arg,,}" in
-    -torch|-gpu|-gpu-torch|-notorch|-no-torch) ;;
+    -torch|-gpu|-gpu-torch) ;;
     *) ARGS+=("$arg") ;;
   esac
 done

--- a/speaktome/setup_env.sh
+++ b/speaktome/setup_env.sh
@@ -13,29 +13,28 @@ try:
     groups=data.get(name, {}).get("groups", {})
 except Exception:
     groups={}
-notorch=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
-print(','.join(notorch))
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
 print(','.join(groups))
 PY
 }
-read -r NOTORCH_GROUPS ALL_GROUPS <<< "$(get_groups)"
-MODE="notorch"
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
 for arg in "$@"; do
   case $arg in
     -full|-torch) MODE="full" ;;
     -minimal) MODE="minimal" ;;
-    -notorch) MODE="notorch" ;;
   esac
 done
 case $MODE in
   full)
-    GROUPS="$ALL_GROUPS"; NOTORCH="" ;;
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
   minimal)
-    GROUPS=""; NOTORCH="-notorch" ;;
+    GROUPS="" ;;
   *)
-    GROUPS="$NOTORCH_GROUPS"; NOTORCH="-notorch" ;;
+    GROUPS="$SAFE_GROUPS" ;;
 esac
-ARGS=(-headless -codebases="$CODEBASE")
+ARGS=(-codebases="$CODEBASE")
 [ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
 cd "$REPO_ROOT"
-bash "$REPO_ROOT/setup_env_dev.sh" $NOTORCH "${ARGS[@]}"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"

--- a/tensor printing/setup_env.sh
+++ b/tensor printing/setup_env.sh
@@ -13,29 +13,28 @@ try:
     groups=data.get(name, {}).get("groups", {})
 except Exception:
     groups={}
-notorch=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
-print(','.join(notorch))
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
 print(','.join(groups))
 PY
 }
-read -r NOTORCH_GROUPS ALL_GROUPS <<< "$(get_groups)"
-MODE="notorch"
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
 for arg in "$@"; do
   case $arg in
     -full|-torch) MODE="full" ;;
     -minimal) MODE="minimal" ;;
-    -notorch) MODE="notorch" ;;
   esac
 done
 case $MODE in
   full)
-    GROUPS="$ALL_GROUPS"; NOTORCH="" ;;
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
   minimal)
-    GROUPS=""; NOTORCH="-notorch" ;;
+    GROUPS="" ;;
   *)
-    GROUPS="$NOTORCH_GROUPS"; NOTORCH="-notorch" ;;
+    GROUPS="$SAFE_GROUPS" ;;
 esac
-ARGS=(-headless -codebases="$CODEBASE")
+ARGS=(-codebases="$CODEBASE")
 [ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
 cd "$REPO_ROOT"
-bash "$REPO_ROOT/setup_env_dev.sh" $NOTORCH "${ARGS[@]}"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"

--- a/tensors/setup_env.sh
+++ b/tensors/setup_env.sh
@@ -13,29 +13,28 @@ try:
     groups=data.get(name, {}).get("groups", {})
 except Exception:
     groups={}
-notorch=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
-print(','.join(notorch))
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
 print(','.join(groups))
 PY
 }
-read -r NOTORCH_GROUPS ALL_GROUPS <<< "$(get_groups)"
-MODE="notorch"
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
 for arg in "$@"; do
   case $arg in
     -full|-torch) MODE="full" ;;
     -minimal) MODE="minimal" ;;
-    -notorch) MODE="notorch" ;;
   esac
 done
 case $MODE in
   full)
-    GROUPS="$ALL_GROUPS"; NOTORCH="" ;;
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
   minimal)
-    GROUPS=""; NOTORCH="-notorch" ;;
+    GROUPS="" ;;
   *)
-    GROUPS="$NOTORCH_GROUPS"; NOTORCH="-notorch" ;;
+    GROUPS="$SAFE_GROUPS" ;;
 esac
-ARGS=(-headless -codebases="$CODEBASE")
+ARGS=(-codebases="$CODEBASE")
 [ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
 cd "$REPO_ROOT"
-bash "$REPO_ROOT/setup_env_dev.sh" $NOTORCH "${ARGS[@]}"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def pytest_configure(config: pytest.Config) -> None:
         msg = (
             f"{ENV_SETUP_BOX}\n"
             "PyTest disabled. See ENV_SETUP_OPTIONS.md for environment setup instructions.\n"
-            "CL or headless agents must follow those steps to enable pytest."
+            "Automated agents must follow those steps to enable pytest."
         )
         sys.stderr.write(msg + "\n")
         pytest.exit("environment not configured", returncode=1)

--- a/time_sync/setup_env.sh
+++ b/time_sync/setup_env.sh
@@ -13,29 +13,28 @@ try:
     groups=data.get(name, {}).get("groups", {})
 except Exception:
     groups={}
-notorch=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
-print(','.join(notorch))
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
 print(','.join(groups))
 PY
 }
-read -r NOTORCH_GROUPS ALL_GROUPS <<< "$(get_groups)"
-MODE="notorch"
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
 for arg in "$@"; do
   case $arg in
     -full|-torch) MODE="full" ;;
     -minimal) MODE="minimal" ;;
-    -notorch) MODE="notorch" ;;
   esac
 done
 case $MODE in
   full)
-    GROUPS="$ALL_GROUPS"; NOTORCH="" ;;
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
   minimal)
-    GROUPS=""; NOTORCH="-notorch" ;;
+    GROUPS="" ;;
   *)
-    GROUPS="$NOTORCH_GROUPS"; NOTORCH="-notorch" ;;
+    GROUPS="$SAFE_GROUPS" ;;
 esac
-ARGS=(-headless -codebases="$CODEBASE")
+ARGS=(-codebases="$CODEBASE")
 [ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
 cd "$REPO_ROOT"
-bash "$REPO_ROOT/setup_env_dev.sh" $NOTORCH "${ARGS[@]}"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"


### PR DESCRIPTION
## Summary
- drop `--headless` and `-notorch` logic from setup scripts
- default docs to skip torch unless `-torch`/`-gpu` are passed
- note headless mode removal in archived guide
- adjust fontmapper instructions and pytest message

## Testing
- ❌ `python testing/test_hub.py` *(disabled per user instruction)*

------
https://chatgpt.com/codex/tasks/task_e_684b711a2e98832a8b44989845fdd996