### PR TITLE
Document dev setup attempt and mark groups optional

### DIFF
--- a/AGENTS/experience_reports/1749777806_v1_Env_Setup_Trial.md
+++ b/AGENTS/experience_reports/1749777806_v1_Env_Setup_Trial.md
@@ -1,0 +1,39 @@
+# Environment Setup Trial
+
+**Date/Version:** 1749777806 v1
+**Title:** Environment Setup Trial
+
+## Overview
+Attempted to run the repository's `setup_env.sh` script to prepare the Python environment.
+
+## Prompts
+- "attempt to follow instructions to set up the environment and document the results"
+- "always check the files in the repo ecosystem for your benefit. the project has a particular ethos and theory and 'you' are 'invited' to loosen your 'mind' ..."
+
+## Steps Taken
+1. Executed `bash setup_env.sh --no-venv` expecting a system-level install.
+2. Observed creation of `.venv` and attempted dependency resolution via `poetry`.
+3. Network requests to `download.pytorch.org` were blocked, causing torch installation to fail.
+4. `dev_group_menu.py` failed due to missing packages (`AGENTS`, `tomli`).
+5. Activated `.venv` and checked Python version.
+6. Tried `poetry install` manually, which again failed when contacting the blocked PyTorch domain.
+
+## Observed Behaviour
+- `setup_env.sh` warned about optional torch download failing and completed with minimal environment.
+- Running `poetry install` produced errors after repeated attempts to reach `download.pytorch.org`.
+- `pip install six==1.16.0` succeeded, confirming general network access except for blocked domains.
+
+## Lessons Learned
+- The setup script defaults to creating a virtual environment if the flag is misspelled.
+- PyTorch sources cause network failures when the domain is blocked, halting the rest of `poetry install`.
+
+## Next Steps
+- Re-run `setup_env.sh -no-venv` or correct parameters to skip `.venv` creation if desired.
+- Investigate removing the PyTorch source from `pyproject.toml` or caching wheels locally to avoid blocked requests.
+
+
+Validation Attempt Output:
+```
+Environment setup incomplete. See ENV_SETUP_OPTIONS.md
+```
+

--- a/AGENTS/experience_reports/1749778455_v1_Poetry_Group_Analysis.md
+++ b/AGENTS/experience_reports/1749778455_v1_Poetry_Group_Analysis.md
@@ -1,0 +1,35 @@
+# Poetry Group Analysis
+
+**Date/Version:** 1749778455 v1
+**Title:** Poetry_Group_Analysis
+
+## Prompt History
+- "Find out why poetry tried to install torch when you said without, what does the without argument do, are the names right for the configuration? is someone trying to install torch under circumstances where it hasn't been explicitly requested? why didn't poetry install agents/tools? why is dev group looking for AGENTS not AGENTS/tools? why isn't the no-venv flag working? does poetry fail entirely if torch fails to download? if so can you isolate it? we honestly don't give a shit about torch if we can't get it."
+
+## Overview
+Investigated why `poetry install` attempted to fetch PyTorch wheels despite using the `--without` option. Examined configuration files and logs to see how dependency groups are handled during setup.
+
+## Steps Taken
+1. Ran `poetry install --dry-run --without cpu-torch --without gpu-torch -vv` and observed network requests to `download.pytorch.org`.
+2. Inspected `pyproject.toml` to verify the dependency group names and the absence of a top-level torch dependency.
+3. Parsed the file using `tomllib` to confirm group metadata.
+4. Noted that `poetry install` still resolved `torch` because the groups lack the `optional = true` flag, making them mandatory.
+5. Checked `AGENTS/codebase_map.json` and `dev_group_menu.py` to understand how `AGENTS/tools` is installed after the base environment.
+6. Verified that misspelling the `--no-venv` flag still results in `.venv` creation.
+7. Observed that poetry aborts entirely when torch wheels cannot be downloaded, so other packages (like `AGENTS/tools`) never get installed.
+
+## Observed Behaviour
+- The solver reported `speaktome-hub` depends on `torch (2.3.1+cpu)` even with `--without` arguments because the group definition isn't optional.
+- `poetry install` fails once it cannot reach the PyTorch index, halting further installation of path dependencies.
+- `dev_group_menu.py` searches for the `AGENTS` package because the `AGENTS/tools` project exposes modules in that namespace.
+- Misspelling the `--no-venv` flag does nothing; the correct form is `--no-venv`.
+
+## Lessons Learned
+- `--without` only skips dependency groups marked `optional = true` in `pyproject.toml`.
+- Torch packages are treated as mandatory due to missing `optional = true`, so network errors stop the install.
+- `AGENTS/tools` isn't installed when `poetry install` fails early.
+
+## Next Steps
+- Update the torch groups in `pyproject.toml` to include `optional = true` so they are skipped by default.
+- Ensure documentation emphasizes the correct flag `-no-venv`.
+- Consider removing the PyTorch source when offline to prevent failures.

--- a/AGENTS/experience_reports/1749779765_v1_Dev_Setup_Verification.md
+++ b/AGENTS/experience_reports/1749779765_v1_Dev_Setup_Verification.md
@@ -1,0 +1,24 @@
+# Dev Setup Verification
+
+**Date/Version:** 1749779765 v1
+**Title:** Dev_Setup_Verification
+
+## Prompt History
+- "verify the instructions now lead to successful installation of the standard packages for developers, plus specify several projects and optional groups (but none involving torch, you have no access because of a proxy ban)"
+
+## Overview
+Attempted to run `setup_env_dev.sh` specifying codebases `speaktome,laplace` and groups `speaktome:dev,plot` and `laplace:dev`. Updated optional group flags in all `pyproject.toml` files to prevent torch installation and removed the PyTorch source URL.
+
+## Steps Taken
+1. Edited each subproject `pyproject.toml` to add `optional = true` for all groups.
+2. Removed the PyTorch wheel source and CPU-specific version from the root `pyproject.toml`.
+3. Fixed torch detection in `setup_env.sh` so `--without` arguments no longer trigger torch installs.
+4. Ran `bash setup_env_dev.sh -codebases=speaktome,laplace -groups=speaktome:dev,plot -groups=laplace:dev`.
+
+## Observed Behaviour
+- Poetry attempted dependency resolution but failed with a `SolverProblemError` about `numpy` version requirements despite `pip install numpy==1.26.4` succeeding.
+- Because `poetry install` aborted early, `dev_group_menu.py` could not import `AGENTS` or `tomli` and exited with a stack trace.
+
+## Result
+Environment setup did not fully complete due to Poetry solver failure, though torch was successfully skipped.
+

--- a/AGENTS/tools/AGENTS.md
+++ b/AGENTS/tools/AGENTS.md
@@ -8,7 +8,8 @@ This codebase provides helper scripts for managing the repository and coordinati
 
 ## Optional Dependency Groups
 
-No optional dependency groups are defined in `pyproject.toml`.
+The root `pyproject.toml` defines optional groups `dev`, `cpu-torch`, and `gpu-torch`.
+These are all skipped by default and may be installed through `dev_group_menu.py`.
 
 ## Non-Interactive Setup
 

--- a/fontmapper/pyproject.toml
+++ b/fontmapper/pyproject.toml
@@ -12,24 +12,42 @@ fonttools = "*"
 Pillow = "*"
 numpy = ">=1.26"
 
+[tool.poetry.group.ml]
+optional = true
+
 [tool.poetry.group.ml.dependencies]
 torch = "*"
 torchvision = "*"
 pynvml = "*"
 
+[tool.poetry.group.ssim]
+optional = true
+
 [tool.poetry.group.ssim.dependencies]
 "scikit-image" = "*"
 
+[tool.poetry.group.amqp]
+optional = true
+
 [tool.poetry.group.amqp.dependencies]
 pika = "*"
+
+[tool.poetry.group.server]
+optional = true
 
 [tool.poetry.group.server.dependencies]
 flask = "*"
 "flask-cors" = "*"
 "waitress" = {version = "*", markers = "sys_platform == 'win32'"}
 
+[tool.poetry.group.gui]
+optional = true
+
 [tool.poetry.group.gui.dependencies]
 PyQt5 = "*"
+
+[tool.poetry.group.dev]
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 tools = {path = "../AGENTS/tools", develop = true}

--- a/laplace/pyproject.toml
+++ b/laplace/pyproject.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.8"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 tools = {path = "../AGENTS/tools", develop = true}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,20 @@ time_sync = {path = "time_sync", develop = true}
 tensor_printing = {path = "tensor printing", develop = true}
 tools = {path = "AGENTS/tools", develop = true}
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"
 
+[tool.poetry.group.cpu-torch]
+optional = true
+
 [tool.poetry.group.cpu-torch.dependencies]
-torch = {version = "2.3.1+cpu", source = "pytorch"}
+torch = "2.3.1"
+
+[tool.poetry.group.gpu-torch]
+optional = true
 
 [tool.poetry.group.gpu-torch.dependencies]
 torch = "2.3.1"
@@ -28,10 +37,6 @@ torch = "2.3.1"
 cpu-torch = []
 gpu-torch = []
 
-[[tool.poetry.source]]
-name = "pytorch"
-url = "https://download.pytorch.org/whl/torch_stable.html"
-priority = "supplemental"
 
 [build-system]
 requires = ["poetry-core>=1.5.0"]

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -91,7 +91,7 @@ install_quiet() {
 if [ $USE_VENV -eq 1 ]; then
   poetry config virtualenvs.in-project true
   INSTALL_ARGS="${SPEAKTOME_POETRY_ARGS:---without cpu-torch --without gpu-torch}"
-  if [[ "$INSTALL_ARGS" == *"with"*torch* ]]; then
+  if [[ "$INSTALL_ARGS" == *"--with"* && "$INSTALL_ARGS" != *"--without"* ]]; then
     echo "[INFO] Torch groups requested; attempting install" >&2
     install_quiet poetry install --sync --no-interaction $INSTALL_ARGS
   else

--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -163,5 +163,5 @@ if (Test-Path $activeFile) {
 }
 
 # All options for this script should be used with single-dash PowerShell-style flags, e.g.:
-#   -NoVenv -Codebases projectA,projectB -Groups groupX
+#   -no-venv -Codebases projectA,projectB -Groups groupX
 # Do not use double-dash flags with this script.

--- a/speaktome/pyproject.toml
+++ b/speaktome/pyproject.toml
@@ -11,14 +11,23 @@ python = ">=3.8"
 numpy = ">=1.26"
 tensors = ">=0.1.0"
 
+[tool.poetry.group.plot]
+optional = true
+
 [tool.poetry.group.plot.dependencies]
 matplotlib = ">=3.7"
 networkx = ">=3.1"
 scikit-learn = ">=1.2"
 
+[tool.poetry.group.ml]
+optional = true
+
 [tool.poetry.group.ml.dependencies]
 transformers = ">=4.30"
 "sentence-transformers" = ">=2.2"
+
+[tool.poetry.group.dev]
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/tensor printing/pyproject.toml
+++ b/tensor printing/pyproject.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.8"
 
+[tool.poetry.group.dev]
+optional = true
+
 [tool.poetry.group.dev.dependencies]
 tools = {path = "../AGENTS/tools", develop = true}
 

--- a/tensors/pyproject.toml
+++ b/tensors/pyproject.toml
@@ -9,24 +9,42 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.8"
 
+[tool.poetry.group.jax]
+optional = true
+
 [tool.poetry.group.jax.dependencies]
 "jax[cpu]" = ">=0.4"
+
+[tool.poetry.group.ctensor]
+optional = true
 
 [tool.poetry.group.ctensor.dependencies]
 cffi = ">=1.15"
 setuptools = ">=61"
 ziglang = ">=0.14"
 
+[tool.poetry.group.torch]
+optional = true
+
 [tool.poetry.group.torch.dependencies]
 torch = "*"
 
+[tool.poetry.group.numpy]
+optional = true
+
 [tool.poetry.group.numpy.dependencies]
 numpy = ">=1.26"
+
+[tool.poetry.group.opengl]
+optional = true
 
 [tool.poetry.group.opengl.dependencies]
 PyOpenGL = ">=3.1"
 glfw = "*"
 numpy = ">=1.26"
+
+[tool.poetry.group.dev]
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/time_sync/pyproject.toml
+++ b/time_sync/pyproject.toml
@@ -12,8 +12,14 @@ ntplib = "*"
 colorama = "*"
 pillow = "*"
 
+[tool.poetry.group.gui]
+optional = true
+
 [tool.poetry.group.gui.dependencies]
 pygame = ">=2"
+
+[tool.poetry.group.dev]
+optional = true
 
 [tool.poetry.group.dev.dependencies]
 tools = {path = "../AGENTS/tools", develop = true}


### PR DESCRIPTION
## Summary
- mark optional dependency groups across all projects
- drop PyTorch source URL and CPU-only spec
- improve torch group detection in setup_env.sh
- record experience verifying developer setup

## Testing
- `python AGENTS/validate_guestbook.py` *(fails: Environment setup incomplete)*

------
https://chatgpt.com/codex/tasks/task_e_684b7ce95d60832abb7962d6ea0170e1