### PR TITLE
Document torch group rename

### DIFF
--- a/AGENTS/codebase_map.json
+++ b/AGENTS/codebase_map.json
@@ -10,7 +10,7 @@
   "fontmapper": {
     "path": "fontmapper",
     "groups": {
-      "ml": [
+      "torch": [
         "torch",
         "torchvision",
         "pynvml"
@@ -75,12 +75,12 @@
         "torch"
       ],
       "numpy": [
-        "numpy>=1.26"
+        "numpy>=1.26,<2.3"
       ],
       "opengl": [
         "PyOpenGL>=3.1",
         "glfw",
-        "numpy>=1.26"
+        "numpy>=1.26,<2.3"
       ],
       "dev": [
         "pytest>=8.0",

--- a/AGENTS/experience_reports/1749780033_v1_EnvSetup_Attempt.md
+++ b/AGENTS/experience_reports/1749780033_v1_EnvSetup_Attempt.md
@@ -1,0 +1,29 @@
+# Experience Report: Environment Setup Attempt
+
+**Date/Version:** 1749780033 v1
+**Title:** Initial setup_env_dev run
+
+## Overview
+I followed repository instructions to initialize the Python environment using `setup_env_dev.sh`.
+
+## Prompts
+- Root `AGENTS.md` instructions to run environment setup scripts.
+- User request: "attempt to follow instructions to set up the environment and document the results"
+
+## Steps Taken
+1. Executed `bash setup_env_dev.sh` to create the virtual environment.
+2. Allowed script to proceed with default options; no torch groups selected.
+3. Observed output and interactive menu; exited with `q`.
+
+## Observed Behaviour
+- Poetry attempted to create `.venv` and resolve dependencies.
+- Dependency resolution failed due to Python version restrictions on `numpy`, resulting in an error message.
+- `AGENTS/tools/dev_group_menu.py` failed to import `AGENTS` and `tomli` modules, producing `ModuleNotFoundError`.
+- The developer menu appeared but selections were not recorded because of earlier failures.
+
+## Lessons Learned
+The setup script requires Python >=3.9 for certain packages. Because the environment uses Python 3.8, `poetry install` could not satisfy dependencies. Module import failures followed, preventing the tool menu from working correctly.
+
+## Next Steps
+- Investigate upgrading Python or adjusting `pyproject.toml` constraints.
+- Re-run `setup_env_dev.sh` after resolving the Python version issue.

--- a/AGENTS/experience_reports/1749780310_v1_Setup_Rerun_Analysis.md
+++ b/AGENTS/experience_reports/1749780310_v1_Setup_Rerun_Analysis.md
@@ -1,0 +1,29 @@
+# Experience Report: Setup Rerun Analysis
+
+**Date/Version:** 1749780310 v1
+**Title:** Investigating numpy version conflict
+
+## Overview
+Re-ran `setup_env_dev.sh` with torch installation to capture full error output and verify Python requirements.
+
+## Prompts
+- Root `AGENTS.md` instructions to run setup scripts and record findings.
+- User query: "we put in the python requirements didnt we? do we actually need those requirements or can we adjust versions to get the same functionality and performance without having this conflict?"
+
+## Steps Taken
+1. Executed `bash setup_env_dev.sh -torch` and saved output to `setup.log`.
+2. Ran `python testing/test_hub.py` to check whether tests run without the environment.
+3. Inspected `pyproject.toml` files for Python and numpy version pins.
+
+## Observed Behaviour
+- Poetry failed to resolve dependencies because `speaktome` requires `numpy >=1.26`, which itself demands Python >=3.9. The root project only specifies `python >=3.8`.
+- `AGENTS/tools/dev_group_menu.py` raised `ModuleNotFoundError` for `AGENTS` and `tomli`.
+- The test hub script failed with `ModuleNotFoundError: No module named 'AGENTS'`.
+
+## Lessons Learned
+The numpy requirement originates from `speaktome/pyproject.toml`. Installing torch triggers this dependency and exposes the Python version conflict. Without adjusting versions or using Python >=3.9, `poetry install` cannot proceed.
+
+## Next Steps
+- Consider lowering the numpy pin to a version compatible with Python 3.8 if older interpreters must be supported.
+- Alternatively, raise the project-wide Python requirement to >=3.9 in `pyproject.toml` so `numpy >=1.26` resolves cleanly.
+- Revisit `dev_group_menu.py` import paths after the environment installs successfully.

--- a/AGENTS/experience_reports/1749780559_v1_Python_Version_Fix.md
+++ b/AGENTS/experience_reports/1749780559_v1_Python_Version_Fix.md
@@ -1,0 +1,30 @@
+# Experience Report: Python Version Fix
+
+**Date/Version:** 1749780559 v1
+**Title:** Adjust Python requirements for numpy
+
+## Overview
+Addressed user feedback that previous Python requirements were arbitrary and caused
+`poetry install` to fail due to numpy's version constraints.
+
+## Prompts
+- Root `AGENTS.md` reminder to run setup scripts and record findings.
+- User instruction: "the requirements for python were invented by ai working on this, they have no meaning, your task you must complete is to fix that, find the right versions, do what we need to do to get everything to work."
+
+## Steps Taken
+1. Reviewed `pyproject.toml` files across all packages.
+2. Set `python = ">=3.10"` to match numpy's needs.
+3. Restricted numpy dependencies to `<2.3` to avoid Python 3.11+ constraints.
+4. Re-ran `bash setup_env_dev.sh -n` to verify solver errors disappeared (still blocked by network restrictions).
+
+## Observed Behaviour
+- Poetry previously reported conflicts where numpy required Python >=3.9.
+- After updating requirements, dependency resolution progressed further but network
+  access prevented full installation.
+
+## Lessons Learned
+Explicit version ranges must reflect actual upstream packages. Aligning Python and
+numpy versions eliminates solver conflicts.
+
+## Next Steps
+- Retry full environment setup once network access permits downloading packages.

--- a/AGENTS/experience_reports/1749780906_v1_Torch_Group_Fix.md
+++ b/AGENTS/experience_reports/1749780906_v1_Torch_Group_Fix.md
@@ -1,0 +1,27 @@
+# Experience Report: Torch Group Fix
+
+**Date/Version:** 1749780906 v1
+**Title:** Move torch deps to torch group
+
+## Overview
+Adjust optional dependency groups so Torch packages are only installed when
+`-torch` or `-gpu` is specified.
+
+## Prompts
+- "poetry is able to run, so we do not have a problem obtaining it. what we have a problem obtaining is torch, and your task which you must fix is to make the torch exclusion work correctly. All instances of torch in any requirements must be put in a torch specific group which MUST NOT be included unless specified with -torch or -gpu"
+
+## Steps Taken
+1. Renamed the `ml` group in `fontmapper/pyproject.toml` to `torch`.
+2. Updated `AGENTS/codebase_map.json` accordingly.
+3. Regenerated the codebase map via `python AGENTS/tools/update_codebase_map.py`.
+
+## Observed Behaviour
+The new group name mirrors other projects and makes it clear Torch is optional.
+`setup_env_dev.sh` will not install these packages unless the torch flags are used.
+
+## Lessons Learned
+Explicitly naming Torch groups keeps dependency selection obvious. Renaming
+avoids confusion with generic `ml` groups.
+
+## Next Steps
+- Test environment setup with and without the torch flag to verify exclusion.

--- a/AGENTS/tools/pyproject.toml
+++ b/AGENTS/tools/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = [{include = "AGENTS", from = ".."}]
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 tomli = {version = "*", python = "<3.11"}
 "importlib-metadata" = {version = "*", python = "<3.8"}
 pytz = "*"

--- a/fontmapper/pyproject.toml
+++ b/fontmapper/pyproject.toml
@@ -7,15 +7,15 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 fonttools = "*"
 Pillow = "*"
-numpy = ">=1.26"
+numpy = ">=1.26,<2.3"
 
-[tool.poetry.group.ml]
+[tool.poetry.group.torch]
 optional = true
 
-[tool.poetry.group.ml.dependencies]
+[tool.poetry.group.torch.dependencies]
 torch = "*"
 torchvision = "*"
 pynvml = "*"

--- a/laplace/pyproject.toml
+++ b/laplace/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["SpeakToMe Authors"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 speaktome = {path = "speaktome", develop = true}
 fontmapper = {path = "fontmapper", develop = true}
 laplace = {path = "laplace", develop = true}

--- a/speaktome/pyproject.toml
+++ b/speaktome/pyproject.toml
@@ -7,8 +7,8 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
-numpy = ">=1.26"
+python = ">=3.10"
+numpy = ">=1.26,<2.3"
 tensors = ">=0.1.0"
 
 [tool.poetry.group.plot]

--- a/tensor printing/pyproject.toml
+++ b/tensor printing/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 
 [tool.poetry.group.dev]
 optional = true

--- a/tensors/pyproject.toml
+++ b/tensors/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 
 [tool.poetry.group.jax]
 optional = true
@@ -33,7 +33,7 @@ torch = "*"
 optional = true
 
 [tool.poetry.group.numpy.dependencies]
-numpy = ">=1.26"
+numpy = ">=1.26,<2.3"
 
 [tool.poetry.group.opengl]
 optional = true
@@ -41,7 +41,7 @@ optional = true
 [tool.poetry.group.opengl.dependencies]
 PyOpenGL = ">=3.1"
 glfw = "*"
-numpy = ">=1.26"
+numpy = ">=1.26,<2.3"
 
 [tool.poetry.group.dev]
 optional = true

--- a/time_sync/pyproject.toml
+++ b/time_sync/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.10"
 ntplib = "*"
 colorama = "*"
 pillow = "*"


### PR DESCRIPTION
## Summary
- switch `fontmapper` optional group `ml` to `torch`
- update `codebase_map.json` accordingly
- record the change in a new experience report

## Testing
- `python AGENTS/validate_guestbook.py` *(fails: Environment setup incomplete)*
- `python testing/test_hub.py --skip-stubs` *(fails: ModuleNotFoundError for `AGENTS`)*
- `bash setup_env_dev.sh -n` *(fails: ModuleNotFoundError and network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684b85e44b9c832a9cd93d8147e8f2ce