### PR TITLE
Refactor header utilities

### DIFF
--- a/AGENTS/__init__.py
+++ b/AGENTS/__init__.py
@@ -3,14 +3,15 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    from AGENTS.tools.header_utils import IMPORT_FAILURE_PREFIX
 except Exception:
     import os
     import sys
-    ENV_SETUP_BOX = os.environ.get(
-        "SPEAKTOME_ENV_SETUP_BOX",
-        "Environment setup incomplete. See ENV_SETUP_OPTIONS.md",
-    )
+    try:
+        ENV_SETUP_BOX = os.environ["SPEAKTOME_ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/header_template.py
+++ b/AGENTS/header_template.py
@@ -4,11 +4,15 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX, IMPORT_FAILURE_PREFIX
+    from AGENTS.tools.header_utils import IMPORT_FAILURE_PREFIX
     import your_modules
 except Exception:
+    import os
     import sys
-
+    try:
+        ENV_SETUP_BOX = os.environ["SPEAKTOME_ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
     print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)

--- a/AGENTS/tools/header_utils.py
+++ b/AGENTS/tools/header_utils.py
@@ -3,33 +3,35 @@
 """Shared constants for header compliance utilities."""
 from __future__ import annotations
 
-import os
+try:
+    import os
+except Exception:
+    import os
+    import sys
+    try:
+        ENV_SETUP_BOX = os.environ["SPEAKTOME_ENV_SETUP_BOX"]
+    except KeyError as exc:  # pragma: no cover - env missing
+        raise RuntimeError("environment not initialized") from exc
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
 
 ENV_BOX_ENV = "SPEAKTOME_ENV_SETUP_BOX"
-ENV_SETUP_BOX = os.environ.get(
-    ENV_BOX_ENV,
-    (
-        "\n"
-        "+-----------------------------------------------------------------------+\n"
-        "| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n"
-        "| Missing packages usually mean setup was skipped or incomplete.      |\n"
-        "+-----------------------------------------------------------------------+\n"
-    ),
-)
+
+
+def get_env_setup_box() -> str:
+    """Return the environment setup message."""
+    try:
+        return os.environ[ENV_BOX_ENV]
+    except KeyError as exc:  # pragma: no cover - env missing
+        raise RuntimeError("environment not initialized") from exc
+
+
+ENV_SETUP_BOX = get_env_setup_box()
 
 HEADER_START = "# --- BEGIN HEADER ---"
 HEADER_END = "# --- END HEADER ---"
 IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
-
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX, IMPORT_FAILURE_PREFIX
-    import sys
-except Exception:
-    import sys
-    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
-# --- END HEADER ---
 
 HEADER_REQUIREMENTS = [
     "'# --- BEGIN HEADER ---' sentinel after shebang",
@@ -37,12 +39,15 @@ HEADER_REQUIREMENTS = [
     "module docstring",
     "'from __future__ import annotations' before the try block",
     "imports wrapped in a try block",
-    "except block imports sys then prints IMPORT_FAILURE_PREFIX and ENV_SETUP_BOX and exits",
+    (
+        "except block imports sys, retrieves 'SPEAKTOME_ENV_SETUP_BOX' from the "
+        "environment, prints IMPORT_FAILURE_PREFIX and that variable, then exits"
+    ),
     "'# --- END HEADER ---' sentinel after the except block",
 ]
 
 __all__ = [
-    "ENV_SETUP_BOX",
+    "get_env_setup_box",
     "HEADER_START",
     "HEADER_END",
     "IMPORT_FAILURE_PREFIX",

--- a/AGENTS/tools/validate_headers.py
+++ b/AGENTS/tools/validate_headers.py
@@ -3,14 +3,18 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    from AGENTS.tools.header_utils import IMPORT_FAILURE_PREFIX
     import ast
     from pathlib import Path
     from typing import Iterable
-    import sys
-    from .header_utils import ENV_SETUP_BOX
 except Exception:
+    import os
     import sys
+    try:
+        ENV_SETUP_BOX = os.environ["SPEAKTOME_ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
@@ -112,8 +116,12 @@ def validate(root: Path, *, rewrite: bool = False) -> int:
                 if miss_head:
                     new_lines.append(f"{indent}try:")
                     new_lines.append(f'{indent}    HEADER = "TODO"')
-                    new_lines.append(f"{indent}except Exception as exc:")
+                    new_lines.append(f"{indent}except Exception:")
+                    new_lines.append(f"{indent}    import os")
                     new_lines.append(f"{indent}    import sys")
+                    new_lines.append(
+                        f"{indent}    ENV_SETUP_BOX = os.environ['SPEAKTOME_ENV_SETUP_BOX']"
+                    )
                     new_lines.append(f"{indent}    print(ENV_SETUP_BOX)")
                     new_lines.append(f"{indent}    sys.exit(1)")
                 if miss_test:
@@ -142,9 +150,13 @@ def main() -> None:
     try:
         exit_code = validate(args.path, rewrite=args.rewrite)
     except Exception as exc:  # pragma: no cover - unexpected failure
+        try:
+            env_box = os.environ["SPEAKTOME_ENV_SETUP_BOX"]
+        except KeyError:
+            env_box = "environment not initialized"
         print(
             "[AGENT_ACTIONABLE_ERROR] validate_headers failed: "
-            f"{exc}.\n{ENV_SETUP_BOX}"
+            f"{exc}.\n{env_box}"
         )
         sys.exit(1)
     sys.exit(exit_code)

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -6,6 +6,8 @@ param(
     [string[]]$args
 )
 
+$env:SPEAKTOME_ENV_SETUP_BOX = "`n+----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n+----------------------------------------------------------------------+`n"
+
 # Manual flag parsing for all arguments (case-insensitive, -flag=value style)
 $UseVenv = $true
 $FromDev = $false

--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -1,6 +1,7 @@
 # PowerShell developer environment setup script for SpeakToMe
 
 $ErrorActionPreference = 'Stop'
+$env:SPEAKTOME_ENV_SETUP_BOX = "`n+----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n+----------------------------------------------------------------------+`n"
 
 function Safe-Run([ScriptBlock]$cmd) {
     try { & $cmd }

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -8,6 +8,7 @@ set -uo pipefail
 # changing directories with pushd. This allows the script to be invoked
 # from anywhere while still locating `.venv`.
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export SPEAKTOME_ENV_SETUP_BOX="\n+----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n+----------------------------------------------------------------------+\n"
 ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 MENU_ARGS=()

--- a/tests/test_validate_headers.py
+++ b/tests/test_validate_headers.py
@@ -10,9 +10,13 @@ try:
     import pytest
 
     import AGENTS.tools.validate_headers as vh
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    from AGENTS.tools.header_utils import get_env_setup_box
 except Exception:
-    print(ENV_SETUP_BOX)
+    import os
+    try:
+        print(os.environ["SPEAKTOME_ENV_SETUP_BOX"])
+    except KeyError:
+        print("env missing")
     raise
 # --- END HEADER ---
 


### PR DESCRIPTION
## Summary
- fetch SPEAKTOME_ENV_SETUP_BOX directly in the header template and utilities
- drop fallback message from `header_utils`
- update validate_headers to use env lookup
- adjust tests accordingly

## Testing
- `python -m pytest tests/test_validate_headers.py -q` *(fails: environment not configured)*

------
https://chatgpt.com/codex/tasks/task_e_684b8b978ff4832a9b12e375673d01e2