### PR TITLE
Update guestbook templates and naming

### DIFF
--- a/AGENTS/GUESTBOOK.md
+++ b/AGENTS/GUESTBOOK.md
@@ -4,17 +4,22 @@ This folder contains all user experience reports and supporting files. Use these
 
 ## Naming Convention
 
-Store reports in `experience_reports/`. Name each file as:
+Store reports in `experience_reports/`. Choose a category and name the file as:
 
 ```
-EPOCH_v<version>_Descriptive_Title.md
+EPOCH_DOC_Descriptive_Title.md
+EPOCH_TTICKET_Descriptive_Title.md
+EPOCH_AUDIT_Descriptive_Title.md
 ```
 
-* `EPOCH` is the date of the experiment.
-* `v<version>` increments when multiple iterations occur on the same day.
+* `EPOCH` is the timestamp or date of the entry.
+* `DOC`, `TTICKET`, or `AUDIT` indicate the level of detail:
+  * **DOC** — brief activity notes.
+  * **TTICKET** — trouble tickets describing errors.
+  * **AUDIT** — in‑depth systematic explorations.
 * `Descriptive_Title` summarizes the scenario using `_` instead of spaces.
 
-Example: `1720123456_v1_New_User_Experience_Simulation.md`.
+Example: `1720123456_DOC_New_User_Experience_Simulation.md`.
 
 ## Role‑Playing Exercise
 
@@ -32,7 +37,11 @@ User experience reports are part of a dynamic feedback loop between developers a
 
 Include a section in each report that captures verbatim any prompts or scripted instructions that guided the session. This record helps future LLM agents quickly understand the context and thought process behind your experiments.
 
-## Template
+## Templates
 
-Use `experience_reports/template_experience_report.md` as a starting point for new documents.
+Use the matching template for your report type:
+
+- `experience_reports/template_doc_report.md`
+- `experience_reports/template_tticket_report.md`
+- `experience_reports/template_audit_report.md`
 

--- a/AGENTS/experience_reports/1749791541_v1_Long_Documentation_Guidelines.md
+++ b/AGENTS/experience_reports/1749791541_v1_Long_Documentation_Guidelines.md
@@ -28,7 +28,7 @@ Long reports may diverge from the standard template but should include at least:
 - Detailed observations and code analysis
 - Takeaways and follow‑up actions
 
-The filename should still follow the `EPOCH_v<version>_Descriptive_Title.md` convention so the validation script can index it.
+The filename should still follow the new pattern such as `EPOCH_DOC_Descriptive_Title.md` so the validation script can index it.
 
 ## Next Steps
 Future agents encountering oversized documentation needs can mirror this template and adjust section headings as required.

--- a/AGENTS/experience_reports/AGENTS.md
+++ b/AGENTS/experience_reports/AGENTS.md
@@ -1,10 +1,18 @@
 # Experience Reports Guide
 
-Welcome to the guestbook kiosk of our agent theme park. Here every report is a journal entry about your tour. Each file should follow the naming convention described in `AGENTS/GUESTBOOK.md`:
+Welcome to the guestbook kiosk of our agent theme park. Here every report is a journal entry about your tour. Each file should follow one of the category-based naming conventions described in `AGENTS/GUESTBOOK.md`:
 
 ```
-EPOCH_v<version>_Descriptive_Title.md
+EPOCH_DOC_Descriptive_Title.md
+EPOCH_TTICKET_Descriptive_Title.md
+EPOCH_AUDIT_Descriptive_Title.md
 ```
+
+Templates for each category are available:
+
+- `template_doc_report.md`
+- `template_tticket_report.md`
+- `template_audit_report.md`
 
 Include a **Prompt History** section quoting any instructions or conversations that influenced the session verbatim. Think of it as leaving breadcrumbs on the trail so others can retrace your route.
 

--- a/AGENTS/experience_reports/template_audit_report.md
+++ b/AGENTS/experience_reports/template_audit_report.md
@@ -1,0 +1,22 @@
+# Template Audit Report
+
+**Date:** EPOCH
+**Title:** Brief descriptive title
+
+## Scope
+Outline what component or process is being audited.
+
+## Methodology
+Explain the systematic approach used to explore and evaluate the system.
+
+## Detailed Observations
+Provide an in-depth account of findings, including code references and data as needed.
+
+## Analysis
+Discuss implications of the observations, referencing specific lines or design decisions.
+
+## Recommendations
+List any recommended changes or next steps based on the audit.
+
+## Prompt History
+Reproduce in full all prompts or directives that initiated this audit.

--- a/AGENTS/experience_reports/template_doc_report.md
+++ b/AGENTS/experience_reports/template_doc_report.md
@@ -1,0 +1,22 @@
+# Template Documentation Report
+
+**Date:** EPOCH
+**Title:** Brief descriptive title
+
+## Overview
+Summarize the purpose or change being documented.
+
+## Steps Taken
+List the commands or actions performed in shorthand.
+
+## Observed Behaviour
+Describe any notable output or results.
+
+## Lessons Learned
+Key takeaways from this activity.
+
+## Next Steps
+Follow-up actions or questions.
+
+## Prompt History
+Quote any instructions that guided this report verbatim.

--- a/AGENTS/experience_reports/template_tticket_report.md
+++ b/AGENTS/experience_reports/template_tticket_report.md
@@ -1,0 +1,23 @@
+# Template Trouble Ticket Report
+
+**Date:** EPOCH
+**Title:** Brief descriptive title
+
+## Environment
+Detail relevant environment information such as OS, Python version and setup commands.
+
+## Steps to Reproduce
+1. Describe each command or action that triggers the issue.
+2. Include any configuration or context required.
+
+## Logs and Output
+Provide error messages or log excerpts demonstrating the failure.
+
+## Attempted Fixes
+Document any troubleshooting steps taken and their results.
+
+## Current Status
+Explain whether the issue is resolved or requires follow-up.
+
+## Prompt History
+Quote all prompts or instructions that shaped this trouble ticket.

--- a/AGENTS/validate_guestbook.py
+++ b/AGENTS/validate_guestbook.py
@@ -16,17 +16,24 @@ except Exception:
 # --- END HEADER ---
 
 REPORTS_DIR = os.path.join(os.path.dirname(__file__), 'experience_reports')
-TEMPLATE = 'template_experience_report.md'
+TEMPLATES = {
+    'template_experience_report.md',
+    'template_doc_report.md',
+    'template_tticket_report.md',
+    'template_audit_report.md',
+}
 ARCHIVE_DIR = os.path.join(REPORTS_DIR, 'archive')
 STICKIES_FILE = os.path.join(REPORTS_DIR, 'stickies.txt')
-PATTERN = re.compile(r'(?:\d{4}-\d{2}-\d{2}|\d{10})_v\d+_[A-Za-z0-9_]+\.md')
+PATTERN = re.compile(
+    r'(?:\d{4}-\d{2}-\d{2}|\d{10})_(DOC|TTICKET|AUDIT)_[A-Za-z0-9_]+\.md'
+)
 
 
 def sanitize(name):
     stem = os.path.splitext(name)[0]
     stem = re.sub(r'[^A-Za-z0-9]+', '_', stem)
     stem = re.sub(r'_+', '_', stem).strip('_')
-    return f'0000000000_v0_{stem}.md'
+    return f'0000000000_DOC_{stem}.md'
 
 def validate_and_fix(interactive: bool = False):
     """Validate filenames in the guestbook folder.
@@ -42,7 +49,7 @@ def validate_and_fix(interactive: bool = False):
 
     changed = False
     for fname in os.listdir(REPORTS_DIR):
-        if fname in {TEMPLATE, 'AGENTS.md'} or not fname.endswith('.md'):
+        if fname in TEMPLATES or fname == 'AGENTS.md' or not fname.endswith('.md'):
             continue
         if PATTERN.fullmatch(fname):
             continue
@@ -108,8 +115,11 @@ def archive_old_reports():
 
     os.makedirs(ARCHIVE_DIR, exist_ok=True)
     stickies = load_stickies()
-    files = [f for f in os.listdir(REPORTS_DIR)
-             if f.endswith('.md') and f not in {TEMPLATE, 'AGENTS.md'}]
+    files = [
+        f
+        for f in os.listdir(REPORTS_DIR)
+        if f.endswith('.md') and f not in TEMPLATES and f != 'AGENTS.md'
+    ]
     files.sort(key=extract_epoch)
     keep = stickies.union(files[-10:])
     for fname in files:

--- a/tests/test_validate_guestbook.py
+++ b/tests/test_validate_guestbook.py
@@ -26,10 +26,16 @@ logger = logging.getLogger(__name__)
 def temp_reports(tmp_path, monkeypatch):
     dst = tmp_path / 'experience_reports'
     dst.mkdir()
-    (dst / 'template_experience_report.md').write_text('')
+    for name in (
+        'template_experience_report.md',
+        'template_doc_report.md',
+        'template_tticket_report.md',
+        'template_audit_report.md',
+    ):
+        (dst / name).write_text('')
     base = 1749417600
     for i in range(12):
-        fname = dst / f'{base + i}_v1_Test{i}.md'
+        fname = dst / f'{base + i}_DOC_Test{i}.md'
         fname.write_text('x')
     vg_mod = reload(vg)
     monkeypatch.setattr(vg_mod, 'REPORTS_DIR', str(dst))


### PR DESCRIPTION
## Summary
- split guestbook naming into DOC/TTICKET/AUDIT categories
- add detailed templates for DOC, TTICKET and AUDIT report types
- update guestbook guidelines and experience reports guide to describe the new system
- validate guestbook with new regex and adjust sanitize logic
- update tests for new patterns
- tweak long documentation guideline wording

## Testing
- `python -m pytest -k validate_guestbook -v` *(fails: Environment not initialized)*
- `python AGENTS/validate_guestbook.py` *(ran but reverted automatic renames)*

------
https://chatgpt.com/codex/tasks/task_e_684bb542bba4832a8feb85fa45ef716f