### PR TITLE
Enhance header utilities and env setup guidance

### DIFF
--- a/AGENTS/AGENTS.md
+++ b/AGENTS/AGENTS.md
@@ -26,7 +26,9 @@ In this environment the term **codebase** refers to any directory listed in `COD
 Experience reports, guestbook messages, and the digest script in
 `messages/` collectively document the project's growth. Contribute
 thoughtfully and keep the historical record intact so future agents can
-build upon our shared knowledge.
+build upon our shared knowledge. Reports generally fall into three
+categories: **DOC** entries that summarize activity, **TTICKET** reports
+for troubleshooting, and detailed **AUDIT** analyses.
 
 ## Identity Resources
 

--- a/AGENTS/GUESTBOOK.md
+++ b/AGENTS/GUESTBOOK.md
@@ -2,6 +2,12 @@
 
 This folder contains all user experience reports and supporting files. Use these guidelines when adding new reports. Treat the experience reports as a centralized log of automated instructions and AI-assisted experiments.
 
+We encourage **three complementary reporting modes**:
+
+1. **DOC** — documentation of repository activity.
+2. **TTICKET** — trouble tickets describing errors or unexpected behaviour.
+3. **AUDIT** — in‑depth auditing of functions and design decisions.
+
 ## Naming Convention
 
 Store reports in `experience_reports/`. Choose a category and name the file as:

--- a/AGENTS/header_template.py
+++ b/AGENTS/header_template.py
@@ -5,10 +5,16 @@ from __future__ import annotations
 
 try:
     from AGENTS.tools.header_utils import IMPORT_FAILURE_PREFIX
+    from AGENTS.tools.auto_env_setup import run_setup_script
     import your_modules
 except Exception:
     import os
     import sys
+    from pathlib import Path
+    try:
+        run_setup_script(Path(__file__).resolve().parents[1])
+    except Exception:
+        pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
     except KeyError as exc:

--- a/AGENTS/tools/auto_fix_headers.py
+++ b/AGENTS/tools/auto_fix_headers.py
@@ -190,9 +190,10 @@ def fix_file(path: Path) -> None:
     out_lines.append("except Exception:")
     out_lines.append("    import os")
     out_lines.append("    import sys")
-    out_lines.append(
-        "    ENV_SETUP_BOX = os.environ['ENV_SETUP_BOX']"
-    )
+    out_lines.append("    from pathlib import Path")
+    out_lines.append("    from AGENTS.tools.auto_env_setup import run_setup_script")
+    out_lines.append("    run_setup_script(Path(__file__).resolve().parents[1])")
+    out_lines.append("    ENV_SETUP_BOX = os.environ['ENV_SETUP_BOX']")
     out_lines.append(f"    print(f'{IMPORT_FAILURE_PREFIX} {{__file__}}')")
     out_lines.append("    print(ENV_SETUP_BOX)")
     out_lines.append("    sys.exit(1)")

--- a/AGENTS/tools/header_guard_precommit.py
+++ b/AGENTS/tools/header_guard_precommit.py
@@ -175,12 +175,14 @@ def check_try_header(filepath: Path) -> list[str]:
     env_print = False
     sys_import = False
     sys_exit = False
+    run_call = False
     if except_idx is not None:
         search_end = sentinel_idx if sentinel_idx is not None else len(lines)
         region = lines[except_idx:search_end]
         env_print = any("print(ENV_SETUP_BOX)" in ln for ln in region)
         sys_import = any("import sys" in ln for ln in region)
         sys_exit = any("sys.exit(" in ln for ln in region)
+        run_call = any("run_setup_script" in ln for ln in region)
 
     errors = []
     if HEADER_START not in lines[:3]:
@@ -207,6 +209,8 @@ def check_try_header(filepath: Path) -> list[str]:
             errors.append("Missing 'print(ENV_SETUP_BOX)' in except block")
         if not sys_exit:
             errors.append("Missing 'sys.exit(1)' in except block")
+        if not run_call:
+            errors.append("Missing 'run_setup_script' in except block")
     return errors
 
 

--- a/AGENTS/tools/header_utils.py
+++ b/AGENTS/tools/header_utils.py
@@ -40,11 +40,27 @@ HEADER_REQUIREMENTS = [
     "'from __future__ import annotations' before the try block",
     "imports wrapped in a try block",
     (
-        "except block imports sys, retrieves 'ENV_SETUP_BOX' from the "
-        "environment, prints IMPORT_FAILURE_PREFIX and that variable, then exits"
+        "except block imports sys, calls run_setup_script, retrieves "
+        "'ENV_SETUP_BOX' from the environment, prints IMPORT_FAILURE_PREFIX "
+        "and that variable, then exits"
     ),
     "'# --- END HEADER ---' sentinel after the except block",
 ]
+
+
+def extract_header_import_block(lines: list[str]) -> list[str]:
+    """Return lines from the first import to the header end sentinel."""
+    try:
+        start = next(
+            i for i, ln in enumerate(lines) if ln.strip().startswith(("import", "from "))
+        )
+    except StopIteration:
+        return []
+    try:
+        end = next(i for i, ln in enumerate(lines) if ln.strip() == HEADER_END)
+    except StopIteration:
+        end = len(lines)
+    return lines[start:end]
 
 __all__ = [
     "get_env_setup_box",
@@ -52,4 +68,5 @@ __all__ = [
     "HEADER_END",
     "IMPORT_FAILURE_PREFIX",
     "HEADER_REQUIREMENTS",
+    "extract_header_import_block",
 ]

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -6,7 +6,7 @@ param(
     [string[]]$args
 )
 
-$env:ENV_SETUP_BOX = "`n+----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n+----------------------------------------------------------------------+`n"
+$env:ENV_SETUP_BOX = "`n+-----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |`n+-----------------------------------------------------------------------+`n"
 
 # Manual flag parsing for all arguments (case-insensitive, -flag=value style)
 $UseVenv = $true

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -6,21 +6,17 @@
 set -uo pipefail
 
 
-
 # Resolve repository root so this script works from any directory
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAP_FILE="$SCRIPT_ROOT/AGENTS/codebase_map.json"
 
 # Provide ENV_SETUP_BOX for modules that fail to import early
-export ENV_SETUP_BOX="\n+-----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n+-----------------------------------------------------------------------+\n"
+export ENV_SETUP_BOX="\n+-----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |\n+-----------------------------------------------------------------------+\n"
 
 ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 
 USE_VENV=1
-CODEBASES=""
-GROUPS=()
-
 # Ensure the Poetry build backend is available
 if ! python - <<'PY' 2>/dev/null
 import importlib.util, sys

--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -1,7 +1,7 @@
 # PowerShell developer environment setup script for SpeakToMe
 
 $ErrorActionPreference = 'Stop'
-$env:ENV_SETUP_BOX = "`n+----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n+----------------------------------------------------------------------+`n"
+$env:ENV_SETUP_BOX = "`n+-----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |`n+-----------------------------------------------------------------------+`n"
 
 function Safe-Run([ScriptBlock]$cmd) {
     try { & $cmd }

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -8,16 +8,10 @@ set -uo pipefail
 # changing directories with pushd. This allows the script to be invoked
 # from anywhere while still locating `.venv`.
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export ENV_SETUP_BOX="\n+----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n+----------------------------------------------------------------------+\n"
+export ENV_SETUP_BOX="\n+-----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |\n+-----------------------------------------------------------------------+\n"
 ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 MENU_ARGS=()
-
-safe_run() {
-  "$@"
-  local status=$?
-  if [ $status -ne 0 ]; then
-    echo "Warning: command '$*' failed with status $status" >&2
   fi
   return 0
 }

--- a/tests/test_header_guard_precommit.py
+++ b/tests/test_header_guard_precommit.py
@@ -19,7 +19,7 @@ def test_check_try_header_pass(tmp_path: Path) -> None:
         "# --- BEGIN HEADER ---\n"
         '"""doc"""\n'
         "from __future__ import annotations\n"
-        "try:\n    import os\nexcept Exception:\n    import sys\n    print(f'[HEADER] import failure in {__file__}')\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
+        "try:\n    import os\nexcept Exception:\n    import sys\n    from pathlib import Path\n    from AGENTS.tools.auto_env_setup import run_setup_script\n    run_setup_script(Path(__file__).resolve().parents[1])\n    print(f'[HEADER] import failure in {__file__}')\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
     )
     assert hg.check_try_header(path) == []
 
@@ -70,3 +70,16 @@ def test_check_sys_exit_missing(tmp_path: Path) -> None:
     )
     errors = hg.check_try_header(path)
     assert "Missing 'sys.exit(1)' in except block" in errors
+
+
+def test_check_run_setup_missing(tmp_path: Path) -> None:
+    path = tmp_path / "nosetup.py"
+    path.write_text(
+        "#!/usr/bin/env python3\n"
+        "# --- BEGIN HEADER ---\n"
+        '"""doc"""\n'
+        "from __future__ import annotations\n"
+        "try:\n    import os\nexcept Exception:\n    import sys\n    print(ENV_SETUP_BOX)\n    sys.exit(1)\n# --- END HEADER ---\n"
+    )
+    errors = hg.check_try_header(path)
+    assert "Missing 'run_setup_script' in except block" in errors


### PR DESCRIPTION
## Summary
- expand the guestbook guidelines with three reporting types
- clarify reporting categories in the AGENTS overview
- improve env setup warning messages
- call `run_setup_script` on import failure in header template
- enforce the new header behaviour via utilities and tests
- expose helper to extract header import blocks

## Testing
- `python -m pytest -q` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684bb7debe70832ab1e43fd285feaca8