### PR TITLE
Refactor env setup message

### DIFF
--- a/AGENTS/experience_reports/1749793867_v1_Env_Setup_Box_Markdown.md
+++ b/AGENTS/experience_reports/1749793867_v1_Env_Setup_Box_Markdown.md
@@ -1,0 +1,21 @@
+# Environment Setup Box Markdown
+
+## Overview
+Moved the static ENV_SETUP_BOX string from the setup scripts to a shared markdown file. Updated Bash and PowerShell setup scripts to read this file when exporting the ENV_SETUP_BOX variable. Extended `auto_env_setup.py` with a simple CLI so tests can pass the module root explicitly.
+
+## Prompts
+- "take the static definitions for the environmental error warning out of the setup scripts for bash and powershell and relocate it to a markdown file that both setup scripts reference to generate the environmental variable. If such a thing exists. Have the auto-setup script be passed as an argument the root folder of the module (wherever the pyproject.toml is) so it can automatically configure itself to construct exactly what is necessary."
+
+## Steps Taken
+1. Created `ENV_SETUP_BOX.md` containing the warning message.
+2. Modified `setup_env.sh`, `setup_env.ps1`, `setup_env_dev.sh`, and `setup_env_dev.ps1` to export the variable from this file.
+3. Added a command line interface to `AGENTS/tools/auto_env_setup.py` to accept a root path argument.
+4. Executed `python testing/test_hub.py` which skipped tests due to missing environment.
+
+## Observed Behaviour
+- The environment message is now stored in a single markdown file.
+- Test harness skipped because environment setup failed in this container.
+
+## Lessons Learned
+Externalizing common strings reduces duplication and keeps setup messages consistent across platforms.
+

--- a/AGENTS/tools/auto_env_setup.py
+++ b/AGENTS/tools/auto_env_setup.py
@@ -75,3 +75,33 @@ def run_setup_script(root: Path | None = None, *, use_venv: bool = True) -> subp
         return subprocess.run(cmd, check=False, capture_output=True, text=True)
     except Exception:
         return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the setup script from the command line."""
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run repo setup script")
+    parser.add_argument(
+        "root",
+        nargs="?",
+        default=None,
+        help="Path to the project root (containing pyproject.toml)",
+    )
+    parser.add_argument(
+        "--no-venv",
+        action="store_true",
+        help="Install packages outside a virtualenv",
+    )
+    args = parser.parse_args(argv)
+    root_path = Path(args.root) if args.root else None
+    result = run_setup_script(root_path, use_venv=not args.no_venv)
+    if result is None:
+        return 1
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    return result.returncode
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    raise SystemExit(main())

--- a/ENV_SETUP_BOX.md
+++ b/ENV_SETUP_BOX.md
@@ -1,0 +1,6 @@
++-----------------------------------------------------------------------+
+| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.    |
+| Missing packages usually mean setup was skipped or incomplete.        |
+| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |
++-----------------------------------------------------------------------+
+

--- a/setup_env.ps1
+++ b/setup_env.ps1
@@ -6,7 +6,8 @@ param(
     [string[]]$args
 )
 
-$env:ENV_SETUP_BOX = "`n+-----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |`n+-----------------------------------------------------------------------+`n"
+$env_box_file = Join-Path $PSScriptRoot "ENV_SETUP_BOX.md"
+$env:ENV_SETUP_BOX = "`n$(Get-Content $env_box_file -Raw)`n"
 
 # Manual flag parsing for all arguments (case-insensitive, -flag=value style)
 $UseVenv = $true

--- a/setup_env.sh
+++ b/setup_env.sh
@@ -11,7 +11,9 @@ SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MAP_FILE="$SCRIPT_ROOT/AGENTS/codebase_map.json"
 
 # Provide ENV_SETUP_BOX for modules that fail to import early
-export ENV_SETUP_BOX="\n+-----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |\n+-----------------------------------------------------------------------+\n"
+ENV_BOX_FILE="$SCRIPT_ROOT/ENV_SETUP_BOX.md"
+ENV_SETUP_BOX="\n$(cat "$ENV_BOX_FILE")\n"
+export ENV_SETUP_BOX
 
 ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"

--- a/setup_env_dev.ps1
+++ b/setup_env_dev.ps1
@@ -1,7 +1,8 @@
 # PowerShell developer environment setup script for SpeakToMe
 
 $ErrorActionPreference = 'Stop'
-$env:ENV_SETUP_BOX = "`n+-----------------------------------------------------------------------+`n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |`n| Missing packages usually mean setup was skipped or incomplete.      |`n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |`n+-----------------------------------------------------------------------+`n"
+$env_box_file = Join-Path $PSScriptRoot "ENV_SETUP_BOX.md"
+$env:ENV_SETUP_BOX = "`n$(Get-Content $env_box_file -Raw)`n"
 
 function Safe-Run([ScriptBlock]$cmd) {
     try { & $cmd }

--- a/setup_env_dev.sh
+++ b/setup_env_dev.sh
@@ -8,7 +8,9 @@ set -uo pipefail
 # changing directories with pushd. This allows the script to be invoked
 # from anywhere while still locating `.venv`.
 SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-export ENV_SETUP_BOX="\n+-----------------------------------------------------------------------+\n| Imports failed. See ENV_SETUP_OPTIONS.md for environment guidance.  |\n| Missing packages usually mean setup was skipped or incomplete.      |\n| Please file a DOC, TTICKET, or AUDIT report under AGENTS/experience_reports. |\n+-----------------------------------------------------------------------+\n"
+ENV_BOX_FILE="$SCRIPT_ROOT/ENV_SETUP_BOX.md"
+ENV_SETUP_BOX="\n$(cat "$ENV_BOX_FILE")\n"
+export ENV_SETUP_BOX
 ACTIVE_FILE=${SPEAKTOME_ACTIVE_FILE:-/tmp/speaktome_active.json}
 export SPEAKTOME_ACTIVE_FILE="$ACTIVE_FILE"
 MENU_ARGS=()


### PR DESCRIPTION
## Summary
- centralize setup banner in `ENV_SETUP_BOX.md`
- source the banner from setup scripts
- add CLI interface to `auto_env_setup.py`
- document environment update in a guestbook entry

## Testing
- `python testing/test_hub.py` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684bbb61c754832a9a249daa800a9edd