### PR TITLE
Remove editorconfig symlink changes

### DIFF
--- a/AGENTS/experience_reports/1749829491_DOC_Fixed_Editorconfig_Symlinks.md
+++ b/AGENTS/experience_reports/1749829491_DOC_Fixed_Editorconfig_Symlinks.md
@@ -1,0 +1,24 @@
+# Documentation Report
+
+**Date:** 1749829491
+**Title:** Fixed Editorconfig Symlinks
+
+## Overview
+Corrected broken `.editorconfig` symlinks across codebases and added one for `AGENTS/tools`.
+
+## Steps Taken
+- Removed existing symlinks with erroneous newline targets.
+- Created new symlinks pointing to `../.editorconfig`.
+- Added missing symlink in `AGENTS/tools`.
+
+## Observed Behaviour
+EditorConfig settings are now readable from each project directory.
+
+## Lessons Learned
+Be careful when generating symlinks within scripts to avoid stray newline characters.
+
+## Next Steps
+None.
+
+## Prompt History
+The user asked: "explain what editorconfig is and produce them for all projects and the root".

--- a/AGENTS/experience_reports/1749830124_DOC_Revert_Symlink_Changes.md
+++ b/AGENTS/experience_reports/1749830124_DOC_Revert_Symlink_Changes.md
@@ -1,0 +1,24 @@
+# Documentation Report
+
+**Date:** 1749830124
+**Title:** Revert Symlink Changes and Supplement Report
+
+## Overview
+Removed `.editorconfig` symlink adjustments from previous attempt and added this supplementary documentation.
+
+## Steps Taken
+- Restored each project symlink using `git checkout` to the state before patch
+- Removed the new symlink in `AGENTS/tools`
+- Prepared this experience report
+
+## Observed Behaviour
+Symlink targets again include the trailing newline as before.
+
+## Lessons Learned
+Minor symlink tweaks can hinder repository merges. It's best to discuss such changes before committing.
+
+## Next Steps
+Monitor whether PR submission succeeds without symlink edits.
+
+## Prompt History
+The user wrote: "it's unclear to me why but your changes are unable to be made into a pull request. Try removing changes to any editorconfig symlink/file and then compiling a larger  or supplementary experience report and we'll see if that can get through"


### PR DESCRIPTION
## Summary
- revert .editorconfig symlink modifications across projects
- remove link under `AGENTS/tools`
- add a documentation report about undoing the symlink tweaks

## Testing
- `python AGENTS/validate_guestbook.py`
- `python testing/test_hub.py` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684c46f1b750832a820602dd3ff636b6