### PR TITLE
Centralize environment setup docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ A helper script `AGENTS/validate_guestbook.py` will scan the guest book and enfo
 
 Any reusable Python scripts or binary utilities meant for agents must live in `AGENTS/tools/` or `AGENTS/tools/bin/`. Centralizing helper programs keeps them easy to discover and maintain.
 
-For deeper historical context, read through all prior reports. They reveal decisions, pitfalls, and progress that shaped the current state of development. If you are tempted to install packages manually with `pip`, stop and read `AGENTS_DO_NOT_PIP_MANUALLY.md` first. The provided setup scripts manage dependencies for you and explain how optional groups work. You can also skim the consolidated digest under `AGENTS/messages/outbox/archive/` for a brief summary of recurring lessons.
+For deeper historical context, read through all prior reports. They reveal decisions, pitfalls, and progress that shaped the current state of development. If you are tempted to install packages manually with `pip`, read `AGENTS_DO_NOT_PIP_MANUALLY.md` and then consult `ENV_SETUP_OPTIONS.md` for the official setup guide. You can also skim the consolidated digest under `AGENTS/messages/outbox/archive/` for a brief summary of recurring lessons.
 
 **CI and Automated Agents:** see `ENV_SETUP_OPTIONS.md`.
 

--- a/AGENTS/OBSOLETE_SETUP_GUIDE.md
+++ b/AGENTS/OBSOLETE_SETUP_GUIDE.md
@@ -1,4 +1,5 @@
 # Deprecated Environment Setup
 
-Previous documentation recommended running `setup_env_dev.sh --extras --prefetch` and manually invoking `AGENTS/tools/dev_group_menu.py`. Those steps are obsolete and may leave the repository in a broken state. Use `setup_env.sh` or `setup_env_dev.sh` with no extra flags instead.
+This page is retained only for reference. All environment setup instructions are
+now consolidated in `ENV_SETUP_OPTIONS.md`.
 

--- a/AGENTS_DO_NOT_PIP_MANUALLY.md
+++ b/AGENTS_DO_NOT_PIP_MANUALLY.md
@@ -1,13 +1,10 @@
 # **Stop Installing with `pip` Like a Caveman**
 
-The `setup_env.sh` and `setup_env_dev.sh` scripts already know how to install everything for you. Manually invoking `pip` **or** `poetry` defeats the purpose of the curated environment. Study these scripts to understand how dependencies are configured, which optional groups exist, and how editable installs are performed.
+Use `setup_env.sh` or `setup_env_dev.sh` to configure the repository. Manual
+`pip` or `poetry` commands lead to inconsistent environments and should be
+avoided.
 
-Running `setup_env.sh` creates a virtual environment and installs CPU Torch by default.
-
-Refer to `AGENTS/OBSOLETE_SETUP_GUIDE.md` for details.
-
-If something is missing, re-run `setup_env_dev.sh` and select all relevant groups instead of hammering `pip install` by hand. This keeps the environment reproducible for everyone and avoids half-installed states.
-
-### Headless Testing
-
-For automated environments see `ENV_SETUP_OPTIONS.md`.
+All setup options and troubleshooting notes now live in
+`ENV_SETUP_OPTIONS.md`.  Older instructions in this file, including the claim
+that CPU Torch installs by default, are obsolete and have been removed so that
+`ENV_SETUP_OPTIONS.md` remains the single source of truth.


### PR DESCRIPTION
## Summary
- mention ENV_SETUP_OPTIONS.md as the canonical guide in AGENTS.md
- remove outdated torch advice from AGENTS_DO_NOT_PIP_MANUALLY.md
- shorten OBOSLETE_SETUP_GUIDE to point to ENV_SETUP_OPTIONS.md

## Testing
- `python testing/test_hub.py` *(fails: ModuleOrPackageNotFoundError: No file/folder found for package tensors)*

------
https://chatgpt.com/codex/tasks/task_e_684c49ec9680832ab30d92084b09cdad