### PR TITLE
Centralize header utilities under tests and remove imports

### DIFF
--- a/AGENTS/tests/headers/__init__.py
+++ b/AGENTS/tests/headers/__init__.py
@@ -1,0 +1,27 @@
+"""Header tools and templates for tests."""
+
+from . import header_utils
+from . import header_guard_precommit
+from . import validate_headers
+from . import auto_fix_headers
+from . import dump_headers
+from . import dynamic_header_recognition
+from . import header_audit
+from . import run_header_checks
+from . import test_all_headers
+from . import header
+from . import header_template
+
+__all__ = [
+    "header_utils",
+    "header_guard_precommit",
+    "validate_headers",
+    "auto_fix_headers",
+    "dump_headers",
+    "dynamic_header_recognition",
+    "header_audit",
+    "run_header_checks",
+    "test_all_headers",
+    "header",
+    "header_template",
+]

--- a/AGENTS/tests/headers/auto_fix_headers.py
+++ b/AGENTS/tests/headers/auto_fix_headers.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Automatically ensure standard headers across the repository."""
+from __future__ import annotations
+
+try:
+    import os
+    import re
+    from pathlib import Path
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+
+EXCLUDE_DIRS = {
+    "archive",
+    "third_party",
+    "laplace",
+    "training",
+    "tensor printing",
+    "tensor_printing",
+}
+
+HEADER_START = "# --- BEGIN HEADER ---"
+HEADER_END = "# --- END HEADER ---"
+IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
+
+
+def in_tensor_printing_inspiration(path: Path) -> bool:
+    parts = path.parts
+    return "tensor printing" in parts and "inspiration" in parts
+
+
+HEADER_START_SENTINEL = HEADER_START
+HEADER_END_SENTINEL = HEADER_END
+
+IMPORT_RE = re.compile(r"^(from\s+\S+\s+import|import\s+\S+)")
+
+
+def should_skip(path: Path) -> bool:
+    parts = set(path.parts)
+    for d in EXCLUDE_DIRS:
+        if d in parts:
+            return True
+    if in_tensor_printing_inspiration(path):
+        return True
+    return False
+
+
+def iter_py_files(root: Path):
+    """Yield Python files skipping directories in ``EXCLUDE_DIRS``."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        parts = Path(dirpath).parts
+        if any(d in parts for d in EXCLUDE_DIRS):
+            dirnames[:] = []
+            continue
+        for name in filenames:
+            if name.endswith(".py"):
+                yield Path(dirpath) / name
+
+
+def fix_file(path: Path) -> None:
+    text = path.read_text(encoding="utf-8")
+    # Skip when duplicate header sentinels are present to avoid infinite loops
+    if text.count(HEADER_START_SENTINEL) > 1 or text.count(HEADER_END_SENTINEL) > 1:
+        print(f"[auto_fix_headers] duplicate header in {path}")
+        return
+    if HEADER_END_SENTINEL in text:
+        if all(
+            token in text
+            for token in (
+                "import sys",
+                "import os",
+                "ENV_SETUP_BOX = os.environ[\"ENV_SETUP_BOX\"]",
+                "print(ENV_SETUP_BOX)",
+                "sys.exit(1)",
+                IMPORT_FAILURE_PREFIX,
+                HEADER_START_SENTINEL,
+            )
+        ):
+            return
+        lines = text.splitlines()
+        sentinel_idx = next(
+            (i for i, ln in enumerate(lines) if ln.strip() == HEADER_END_SENTINEL),
+            None,
+        )
+        if sentinel_idx is None:
+            return
+        except_idx = None
+        try_idx = None
+        for i in range(sentinel_idx - 1, -1, -1):
+            if lines[i].strip().startswith("except"):
+                except_idx = i
+                break
+        for i in range(sentinel_idx):
+            if lines[i].strip().startswith("try:"):
+                try_idx = i
+                break
+        if except_idx is None:
+            return
+        insert_idx = except_idx + 1
+        indent = " " * (len(lines[except_idx]) - len(lines[except_idx].lstrip()) + 4)
+        region = lines[except_idx:sentinel_idx]
+        modified = False
+        header_lines = [
+            f"{indent}import sys",
+            f"{indent}print(f'{IMPORT_FAILURE_PREFIX} {{__file__}}')",
+            f"{indent}print(ENV_SETUP_BOX)",
+            f"{indent}sys.exit(1)",
+        ]
+        if lines[insert_idx:sentinel_idx] != header_lines:
+            lines[insert_idx:sentinel_idx] = header_lines
+            modified = True
+        if try_idx is not None:
+            try_region = lines[try_idx:except_idx]
+            if not any(
+                "ENV_SETUP_BOX = os.environ[\"ENV_SETUP_BOX\"]" in ln
+                for ln in try_region
+            ):
+                indent_try = " " * (
+                    len(lines[try_idx]) - len(lines[try_idx].lstrip()) + 4
+                )
+                lines.insert(try_idx + 1, f"{indent_try}import os")
+                lines.insert(
+                    try_idx + 2,
+                    f"{indent_try}ENV_SETUP_BOX = os.environ['ENV_SETUP_BOX']",
+                )
+                modified = True
+        if HEADER_START_SENTINEL not in lines[:3]:
+            insert_idx = 1 if lines and lines[0].startswith("#!") else 0
+            lines.insert(insert_idx, HEADER_START_SENTINEL)
+            modified = True
+        if modified:
+            Path(path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return
+
+    lines = text.splitlines()
+
+    out_lines: list[str] = []
+    idx = 0
+
+    # Preserve shebang
+    if lines and lines[0].startswith("#!"):
+        out_lines.append(lines[0])
+        idx = 1
+    out_lines.append(HEADER_START_SENTINEL)
+
+    # Capture leading comments or encoding declarations
+    while (
+        idx < len(lines)
+        and lines[idx].startswith("#")
+        and not IMPORT_RE.match(lines[idx])
+    ):
+        out_lines.append(lines[idx])
+        idx += 1
+
+    # Capture module docstring
+    if idx < len(lines) and (
+        lines[idx].startswith('"""') or lines[idx].startswith("'''")
+    ):
+        quote = lines[idx][:3]
+        out_lines.append(lines[idx])
+        idx += 1
+        while idx < len(lines):
+            out_lines.append(lines[idx])
+            if lines[idx].endswith(quote) and len(lines[idx]) >= 3:
+                idx += 1
+                break
+            idx += 1
+
+    out_lines.append("from __future__ import annotations")
+    out_lines.append("")
+    out_lines.append("try:")
+
+    # Move imports into try block
+    while idx < len(lines):
+        line = lines[idx]
+        if IMPORT_RE.match(line):
+            out_lines.append("    " + line)
+            idx += 1
+            continue
+        if not line.strip():
+            out_lines.append("    " + line)
+            idx += 1
+            continue
+        break
+
+    out_lines.append("except Exception:")
+    out_lines.append("    import os")
+    out_lines.append("    import sys")
+    out_lines.append("    from pathlib import Path")
+    out_lines.append("    def _find_repo_root(start: Path) -> Path:")
+    out_lines.append("        current = start.resolve()")
+    out_lines.append("        required = {")
+    out_lines.append("            'speaktome',")
+    out_lines.append("            'laplace',")
+    out_lines.append("            'tensor printing',")
+    out_lines.append("            'time_sync',")
+    out_lines.append("            'AGENTS',")
+    out_lines.append("            'fontmapper',")
+    out_lines.append("            'tensors',")
+    out_lines.append("        }")
+    out_lines.append("        for parent in [current, *current.parents]:")
+    out_lines.append("            if all((parent / name).exists() for name in required):")
+    out_lines.append("                return parent")
+    out_lines.append("        return current")
+    out_lines.append("    if 'ENV_SETUP_BOX' not in os.environ:")
+    out_lines.append("        root = _find_repo_root(Path(__file__))")
+    out_lines.append("        box = root / 'ENV_SETUP_BOX.md'")
+    out_lines.append("        try:")
+    out_lines.append("            os.environ['ENV_SETUP_BOX'] = f\"\\n{box.read_text()}\\n\"")
+    out_lines.append("        except Exception:")
+    out_lines.append("            os.environ['ENV_SETUP_BOX'] = 'environment not initialized'")
+    out_lines.append("        print(os.environ['ENV_SETUP_BOX'])")
+    out_lines.append("        sys.exit(1)")
+    out_lines.append("    import subprocess")
+    out_lines.append("    root = _find_repo_root(Path(__file__))")
+    out_lines.append(
+        "    subprocess.run([sys.executable, '-m', 'AGENTS.tools.auto_env_setup', str(root)], check=False)"
+    )
+    out_lines.append("    ENV_SETUP_BOX = os.environ['ENV_SETUP_BOX']")
+    out_lines.append(f"    print(f'{IMPORT_FAILURE_PREFIX} {{__file__}}')")
+    out_lines.append("    print(ENV_SETUP_BOX)")
+    out_lines.append("    sys.exit(1)")
+    out_lines.append(HEADER_END_SENTINEL)
+
+    out_lines.extend(lines[idx:])
+    Path(path).write_text("\n".join(out_lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    root = Path(".")
+    for path in iter_py_files(root):
+        if should_skip(path):
+            continue
+        fix_file(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS/tests/headers/dump_headers.py
+++ b/AGENTS/tests/headers/dump_headers.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Dump class headers across the ``speaktome`` package."""
+from __future__ import annotations
+
+try:
+    import ast
+    import json
+    import sys
+    import os
+    from pathlib import Path
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+END_MARKER = "# --- END HEADER ---"
+
+
+EXCLUDE_DIRS = {
+    "archive",
+    "third_party",
+    "laplace",
+    "training",
+    "tensor printing",
+    "tensor_printing",
+}
+
+
+def find_py_files(root: Path) -> list[Path]:
+    """Yield Python files under ``root`` ignoring ``.venv`` and ``.git``."""
+    for dirpath, dirnames, filenames in os.walk(root):
+        parts = Path(dirpath).parts
+        if any(d in parts for d in EXCLUDE_DIRS | {".venv", ".git"}):
+            dirnames[:] = []
+            continue
+        for name in filenames:
+            if name.endswith(".py"):
+                yield Path(dirpath) / name
+
+
+def collect_class_info(pyfile: Path) -> list[dict[str, object]]:
+    with pyfile.open("r", encoding="utf-8", errors="ignore") as fh:
+        source = fh.read()
+    try:
+        tree = ast.parse(source, filename=str(pyfile))
+    except Exception as exc:  # pragma: no cover - parse failure
+        print(f"[ERROR] {pyfile}: {exc}", file=sys.stderr)
+        return []
+    classes = []
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef):
+            header = ast.get_docstring(node)
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and any(isinstance(t, ast.Name) and t.id == "HEADER" for t in stmt.targets)
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                ):
+                    header = stmt.value.value
+                if isinstance(stmt, ast.FunctionDef) and stmt.name == "test":
+                    has_test = any(
+                        isinstance(deco, ast.Name) and deco.id == "staticmethod"
+                        for deco in stmt.decorator_list
+                    )
+                    break
+            else:
+                has_test = False
+            classes.append({"class": node.name, "header": header, "has_test": has_test})
+    return classes
+
+
+def dump_headers(root: Path, markdown: bool = False) -> None:
+    results = {}
+    for pyfile in sorted(find_py_files(root)):
+        module = pyfile.relative_to(root.parent).with_suffix("").as_posix().replace("/", ".")
+        info = collect_class_info(pyfile)
+        if info:
+            results[module] = info
+    print(json.dumps(results, indent=2))
+
+    if markdown:
+        for module, items in results.items():
+            print(f"\n### {module}")
+            for entry in items:
+                test = "yes" if entry["has_test"] else "no"
+                header = entry["header"] or "(none)"
+                print(f"- **{entry['class']}** – test: {test}\n  \n  {header}")
+
+
+def main() -> None:
+    root_arg = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("speaktome")
+    md = "--markdown" in sys.argv
+    dump_headers(root_arg.resolve(), markdown=md)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS/tests/headers/dynamic_header_recognition.py
+++ b/AGENTS/tests/headers/dynamic_header_recognition.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Dynamic recognition and construction helpers for SPEAKTOME headers."""
+from __future__ import annotations
+
+try:
+    import re
+    from pathlib import Path
+    from typing import Iterable, Optional
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor_printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [sys.executable, "-m", "AGENTS.tools.auto_env_setup", str(root)],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:  # pragma: no cover - env missing
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+# Regex patterns for atomic units within the standard header
+HEADER_START_REGEX = re.compile(r"^# --- BEGIN HEADER ---$", re.MULTILINE)
+HEADER_END_REGEX = re.compile(r"^# --- END HEADER ---$", re.MULTILINE)
+DOCSTRING_REGEX = re.compile(r'^"""(.*?)"""', re.DOTALL | re.MULTILINE)
+IMPORT_REGEX = re.compile(r"^import (.+)$", re.MULTILINE)
+TRY_BLOCK_REGEX = re.compile(r"^try:$", re.MULTILINE)
+EXCEPT_BLOCK_REGEX = re.compile(r"^except (.+):$", re.MULTILINE)
+
+
+class HeaderNode:
+    """Node in a tree representation of the header."""
+
+    def __init__(self, name: str, content: str = "", children: Optional[list["HeaderNode"]] = None) -> None:
+        self.name = name
+        self.content = content
+        self.children: list[HeaderNode] = children or []
+
+    def add_child(self, child: "HeaderNode") -> None:
+        self.children.append(child)
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"{self.name}: {self.content}"
+
+    def __repr__(self) -> str:  # pragma: no cover - debug
+        return f"HeaderNode(name={self.name!r}, content={self.content!r}, children={self.children!r})"
+
+
+def parse_header(text: str) -> HeaderNode:
+    """Parse ``text`` into a :class:`HeaderNode` tree. Stub implementation."""
+    root = HeaderNode("root")
+    # TODO: implement full parser
+    if HEADER_START_REGEX.search(text) and HEADER_END_REGEX.search(text):
+        root.add_child(HeaderNode("sentinel"))
+    return root
+
+
+def compare_trees(parsed_tree: HeaderNode, template_tree: HeaderNode) -> list[str]:
+    """Return a list of differences between ``parsed_tree`` and ``template_tree``."""
+    differences: list[str] = []
+    if parsed_tree.name != template_tree.name:
+        differences.append(f"Mismatch: {parsed_tree.name} != {template_tree.name}")
+    template_children = {child.name for child in template_tree.children}
+    parsed_children = {child.name for child in parsed_tree.children}
+    for name in template_children - parsed_children:
+        differences.append(f"Missing: {name}")
+    return differences
+
+
+def pretty_print_tree(node: HeaderNode, level: int = 0) -> str:
+    """Return a markdown representation of ``node`` and its children."""
+    indent = "  " * level
+    result = f"{indent}- {node.name}: {node.content}\n"
+    for child in node.children:
+        result += pretty_print_tree(child, level + 1)
+    return result
+
+
+__all__ = [
+    "HeaderNode",
+    "parse_header",
+    "compare_trees",
+    "pretty_print_tree",
+]

--- a/AGENTS/tests/headers/header.py
+++ b/AGENTS/tests/headers/header.py
@@ -1,0 +1,62 @@
+from typing import Any, Dict, List, Optional
+import re
+
+class Header:
+    """A class to represent and manipulate headers dynamically."""
+
+    def __init__(self, description: str, components: Optional[Dict[str, str]] = None, error_handling: Optional[Dict[str, str]] = None):
+        self.description = description
+        self.components = components or {}
+        self.error_handling = error_handling or {}
+
+    def __str__(self) -> str:
+        """Pretty-print the header as a markdown string."""
+        components_str = "\n".join([f"  - {key}: \"{value}\"" for key, value in self.components.items()])
+        error_handling_str = "\n".join([f"  - {key}: \"{value}\"" for key, value in self.error_handling.items()])
+        return f"""
+HEADER:
+  - Description: "{self.description}"
+  - Components:
+{components_str}
+  - Error Handling:
+{error_handling_str}
+"""
+
+    @classmethod
+    def from_markdown(cls, markdown: str) -> "Header":
+        """Parse a markdown template to create a Header object."""
+        description_match = re.search(r"Description: \"(.*?)\"", markdown)
+        components_match = re.findall(r"- (\w+): \"(.*?)\"", markdown.split("Components:")[1].split("Error Handling:")[0])
+        error_handling_match = re.findall(r"- (\w+): \"(.*?)\"", markdown.split("Error Handling:")[1])
+
+        description = description_match.group(1) if description_match else ""
+        components = {key: value for key, value in components_match}
+        error_handling = {key: value for key, value in error_handling_match}
+
+        return cls(description, components, error_handling)
+
+    def to_markdown(self) -> str:
+        """Convert the Header object back to a markdown string."""
+        return str(self)
+
+    def interpret(self, instructions: List[str]) -> None:
+        """Interpret procedural instructions for dynamic header manipulation."""
+        for instruction in instructions:
+            # Example: Add logic for GOTO-style procedural looping
+            pass
+
+# Example usage
+if __name__ == "__main__":
+    markdown_template = """
+HEADER:
+  - Description: "Template for SPEAKTOME module headers."
+  - Components:
+      - IMPORT_FAILURE_PREFIX: "Prefix for import failure messages."
+      - auto_env_setup: "Module invoked via subprocess to initialize the environment."
+      - ENV_SETUP_BOX: "Environment variable for setup box."
+  - Error Handling:
+      - KeyError: "Raised if ENV_SETUP_BOX is not set."
+      - RuntimeError: "Raised if the environment is not initialized."
+"""
+    header = Header.from_markdown(markdown_template)
+    print(header)

--- a/AGENTS/tests/headers/header_guard_precommit.py
+++ b/AGENTS/tests/headers/header_guard_precommit.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Pre-commit hook enforcing HEADER, tests, and the end sentinel."""
+
+from __future__ import annotations
+
+try:
+    import subprocess
+    import ast
+    import os
+    from pathlib import Path
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
+    HEADER_START = "# --- BEGIN HEADER ---"
+    HEADER_END = "# --- END HEADER ---"
+    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+FRIENDLY_GUIDANCE = """
+# A Gentle Guide to Code Headers
+
+Dear fellow explorer,
+
+If the pre-commit hook caught your changes, here's a friendly checklist:
+
+1. Every Python file needs:
+   - A `HEADER` (as docstring or constant)
+   - A `@staticmethod test()` method in each class
+    - `from __future__ import annotations` before the `try` block
+    - Imports wrapped in a `try` block
+    - An `except` block that imports `sys`, prints guidance to consult `ENV_SETUP_OPTIONS.md`, then calls `sys.exit(1)`
+    - A `# --- END HEADER ---` sentinel after the `except` block
+    - The `# --- BEGIN HEADER ---` sentinel after the shebang
+
+2. Example structure:
+   ```python
+   #!/usr/bin/env python3
+   # --- BEGIN HEADER ---
+   \"\"\"Optional module docstring.\"\"\"
+   from __future__ import annotations
+
+   try:
+       import your_modules
+   except Exception:
+       import sys
+       print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
+       print(ENV_SETUP_BOX)
+       sys.exit(1)
+   # --- END HEADER ---
+   ```
+
+3. Quick tips:
+   - The sentinel must be exactly `# --- END HEADER ---` (three dashes each side)
+   - Copy-paste the sentinel line to avoid sneaky whitespace issues
+   - Place it after your last import statement
+
+Need to bypass temporarily? Use:
+    SKIP_HEADER_GUARD=1 git commit -m "your message"
+
+For full standards, see the `AGENTS/` directory documentation.
+"""
+
+
+def get_staged_py_files():
+    """Return a list of staged Python files (relative paths)."""
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=ACM"],
+        stdout=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    files = [f for f in result.stdout.splitlines() if f.endswith(".py")]
+    return files
+
+
+def check_class_header_and_test(filepath):
+    """Return a list of (lineno, classname, missing) for classes missing HEADER or test()."""
+    with open(filepath, encoding="utf-8") as f:
+        source = f.read()
+    try:
+        tree = ast.parse(source, filename=filepath)
+    except Exception as e:
+        return [(-1, None, f"Could not parse file: {e}")]
+    errors = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef):
+            # Check for HEADER (either as a docstring or HEADER attribute)
+            docstring = ast.get_docstring(node)
+            has_header_attr = any(
+                isinstance(stmt, ast.Assign)
+                and any(getattr(t, "id", None) == "HEADER" for t in stmt.targets)
+                and isinstance(stmt.value, ast.Str)
+                for stmt in node.body
+            )
+            has_header = bool(docstring) or has_header_attr
+            # Check for @staticmethod test()
+            has_test = False
+            for stmt in node.body:
+                if isinstance(stmt, ast.FunctionDef) and stmt.name == "test":
+                    for deco in stmt.decorator_list:
+                        if isinstance(deco, ast.Name) and deco.id == "staticmethod":
+                            has_test = True
+            missing = []
+            if not has_header:
+                missing.append("HEADER")
+            if not has_test:
+                missing.append("@staticmethod test()")
+            if missing:
+                errors.append((node.lineno, node.name, ", ".join(missing)))
+    return errors
+
+
+def check_end_header(filepath: Path) -> list[str]:
+    """Ensure ``# --- END HEADER ---`` appears after the final global import."""
+    sentinel = HEADER_END
+    with open(filepath, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    sentinel_line = next(
+        (i + 1 for i, ln in enumerate(lines) if ln.strip() == sentinel), None
+    )
+    if sentinel_line is None:
+        return [f"Missing sentinel '{sentinel}'"]
+
+    try:
+        tree = ast.parse("".join(lines), filename=str(filepath))
+    except Exception as exc:  # pragma: no cover - parse failure
+        return [f"Parse error: {exc}"]
+
+    last_import = 0
+    for node in tree.body:
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            last_import = max(last_import, node.end_lineno or node.lineno)
+
+    if sentinel_line <= last_import:
+        return [f"Sentinel before last import (line {last_import})"]
+
+    return []
+
+
+def check_try_header(filepath: Path) -> list[str]:
+    """Verify header elements such as shebang, docstring, and ``try`` block."""
+    sentinel = HEADER_END
+    with open(filepath, encoding="utf-8") as f:
+        lines = f.readlines()
+
+    try_idx = next(
+        (i for i, ln in enumerate(lines) if ln.strip().startswith("try:")), None
+    )
+    sentinel_idx = next(
+        (i for i, ln in enumerate(lines) if ln.strip() == sentinel), None
+    )
+    future_idx = next(
+        (i for i, ln in enumerate(lines) if ln.strip().startswith("from __future__")),
+        None,
+    )
+    except_idx = next(
+        (
+            i
+            for i, ln in enumerate(lines)
+            if ln.strip().startswith("except")
+            and (sentinel_idx is None or i < sentinel_idx)
+        ),
+        None,
+    )
+
+    env_print = False
+    sys_import = False
+    sys_exit = False
+    run_call = False
+    env_check = False
+    if except_idx is not None:
+        search_end = sentinel_idx if sentinel_idx is not None else len(lines)
+        region = lines[except_idx:search_end]
+        env_print = any("print(ENV_SETUP_BOX)" in ln for ln in region)
+        sys_import = any("import sys" in ln for ln in region)
+        sys_exit = any("sys.exit(" in ln for ln in region)
+        run_call = any("auto_env_setup" in ln for ln in region)
+        env_check = any("ENV_SETUP_BOX" in ln and "not in os.environ" in ln for ln in region)
+
+    errors = []
+    if HEADER_START not in lines[:3]:
+        errors.append("Missing '# --- BEGIN HEADER ---'")
+    if not lines or not lines[0].startswith("#!"):
+        errors.append("Missing shebang")
+    try:
+        tree = ast.parse("".join(lines), filename=str(filepath))
+        if not ast.get_docstring(tree):
+            errors.append("Missing module docstring")
+    except Exception as exc:  # pragma: no cover - parse failure
+        errors.append(f"Parse error: {exc}")
+        return errors
+    if future_idx is None or (try_idx is not None and future_idx > try_idx):
+        errors.append("Missing '__future__' import before try block")
+    if try_idx is None or (future_idx is not None and try_idx <= future_idx):
+        errors.append("Missing 'try:' at start of header")
+    if except_idx is None:
+        errors.append("Missing 'except' block for header")
+    else:
+        if not sys_import:
+            errors.append("Missing 'import sys' in except block")
+        if not env_print:
+            errors.append("Missing 'print(ENV_SETUP_BOX)' in except block")
+        if not sys_exit:
+            errors.append("Missing 'sys.exit(1)' in except block")
+        if not run_call:
+            errors.append("Missing call to auto_env_setup in except block")
+        if not env_check:
+            errors.append("Missing ENV_SETUP_BOX check in except block")
+    return errors
+
+
+def main():
+    if os.getenv("SKIP_HEADER_GUARD"):
+        return
+    failed = False
+    for relpath in get_staged_py_files():
+        path = Path(relpath)
+        if not path.exists():
+            continue
+        class_errors = check_class_header_and_test(path)
+        header_errors = check_end_header(path) + check_try_header(path)
+        for lineno, classname, missing in class_errors:
+            print(
+                f"[AGENT_ACTIONABLE_ERROR] {relpath}"
+                f"{f':{lineno}' if lineno > 0 else ''} "
+                f"Class '{classname or '?'}' missing: {missing}"
+            )
+            failed = True
+        for msg in header_errors:
+            print(f"[AGENT_ACTIONABLE_ERROR] {relpath}: {msg}")
+            failed = True
+    if failed:
+        print(
+            "\nCommit blocked: ensure each file has the try/except header, "
+            "class HEADER strings, and @staticmethod test() methods."
+        )
+        print("\nNeed help? Here's a friendly guide:")
+        print(FRIENDLY_GUIDANCE)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS/tests/headers/header_template.py
+++ b/AGENTS/tests/headers/header_template.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Template for SPEAKTOME module headers."""
+from __future__ import annotations
+
+try:
+    import your_modules
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---

--- a/AGENTS/tests/headers/header_utils.py
+++ b/AGENTS/tests/headers/header_utils.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Shared constants for header compliance utilities."""
+from __future__ import annotations
+
+try:
+    import os
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:  # pragma: no cover - env missing
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+ENV_BOX_ENV = "ENV_SETUP_BOX"
+
+
+def get_env_setup_box() -> str:
+    """Return the environment setup message."""
+    try:
+        return os.environ[ENV_BOX_ENV]
+    except KeyError as exc:  # pragma: no cover - env missing
+        raise RuntimeError("environment not initialized") from exc
+
+
+ENV_SETUP_BOX = get_env_setup_box()
+
+HEADER_START = "# --- BEGIN HEADER ---"
+HEADER_END = "# --- END HEADER ---"
+IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
+
+HEADER_REQUIREMENTS = [
+    "'# --- BEGIN HEADER ---' sentinel after shebang",
+    "shebang line '#!/usr/bin/env python3'",
+    "module docstring",
+    "'from __future__ import annotations' before the try block",
+    "imports wrapped in a try block",
+    (
+        "except block imports os, sys and Path, defines _find_repo_root,"
+        " checks ENV_SETUP_BOX and prints the message when missing,"
+        " then invokes auto_env_setup via subprocess",
+    ),
+    "'# --- END HEADER ---' sentinel after the except block",
+]
+
+
+def extract_header_import_block(lines: list[str]) -> list[str]:
+    """Return lines from the first import to the header end sentinel."""
+    try:
+        start = next(
+            i for i, ln in enumerate(lines) if ln.strip().startswith(("import", "from "))
+        )
+    except StopIteration:
+        return []
+    try:
+        end = next(i for i, ln in enumerate(lines) if ln.strip() == HEADER_END)
+    except StopIteration:
+        end = len(lines)
+    return lines[start:end]
+
+__all__ = [
+    "get_env_setup_box",
+    "HEADER_START",
+    "HEADER_END",
+    "IMPORT_FAILURE_PREFIX",
+    "HEADER_REQUIREMENTS",
+    "extract_header_import_block",
+]

--- a/AGENTS/tests/headers/headers.md
+++ b/AGENTS/tests/headers/headers.md
@@ -1,0 +1,70 @@
+# Standard Header
+
+The Python module `AGENTS.tools.header.Header` defines the canonical
+header used across this repository.  Each line ends with sentinel comments
+that mark the start or end of major sections.  Tools read these comments to
+generate or validate headers programmatically.
+
+```python
+#!/usr/bin/env python3  # <shebang>
+# --- BEGIN HEADER ---  # <header:start>
+"""Template for SPEAKTOME module headers."""  # <docstring:start> <docstring:end>
+from __future__ import annotations  # <future>
+
+try:  # <try:start>
+    import your_modules  # <import>
+except Exception:  # <try:end> <except:start>
+    import os  # <import>
+    import sys  # <import>
+    from pathlib import Path  # <import>
+
+    def _find_repo_root(start: Path) -> Path:  # <find-root:start>
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:  # <env-check:start>
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])  # <print-env>
+        sys.exit(1)  # <env-check:end>
+    import subprocess  # <import>
+    try:  # <setup-call:start>
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [sys.executable, '-m', 'AGENTS.tools.auto_env_setup', str(root)],
+            check=False,
+        )  # <setup-call>
+    except Exception:  # <setup-call:end>
+        pass
+    try:  # <env-fetch:start>
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]  # <env-fetch>
+    except KeyError as exc:  # <env-fetch-error:start>
+        raise RuntimeError("environment not initialized") from exc  # <env-fetch-error:end> <env-fetch:end>
+    print(f"[HEADER] import failure in {__file__}")  # <print-failure>
+    print(ENV_SETUP_BOX)  # <print-env>
+    sys.exit(1)  # <exit> <except:end>
+# --- END HEADER ---  # <header:end>
+```
+
+## Dynamic Header Recognition
+
+The module `AGENTS.tools.dynamic_header_recognition` provides a skeleton
+implementation for parsing and comparing headers using a tree structure.
+It exposes :class:`HeaderNode` and helpers like :func:`parse_header` to
+serve as building blocks for future validation logic.

--- a/AGENTS/tests/headers/run_header_checks.py
+++ b/AGENTS/tests/headers/run_header_checks.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Run header repair, validation and tests in one step."""
+from __future__ import annotations
+
+try:
+    from pathlib import Path
+    import subprocess
+    import sys
+    import os
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+
+# ########## header_check_orchestrator ##########
+# PURPOSE: Provide a unified CLI that runs ``auto_fix_headers.py``,
+#          ``validate_headers.py`` and ``test_all_headers.py`` in
+#          sequence.
+# EXPECTED BEHAVIOR: This module executes both tools,
+#          aggregates their results, and emits a single exit code
+#          summarizing success or failure.
+# INPUTS: Optional command-line flags controlling paths and verbosity.
+# OUTPUTS: Aggregated textual report printed to stdout.
+# KEY ASSUMPTIONS/DEPENDENCIES: Assumes both helper scripts are present
+#          in ``AGENTS/tools`` and accessible via the current Python
+#          interpreter.
+# TODO:
+#   - Capture and merge stdout/stderr from the called scripts.
+# ###########################################################################
+
+def run_checks(path: Path, *, rewrite: bool = False) -> int:
+    """Run header repair, validation and header-based tests."""
+    script_dir = Path(__file__).resolve().parent
+    repair = script_dir / "auto_fix_headers.py"
+    validate = script_dir / "validate_headers.py"
+    test_all = script_dir / "test_all_headers.py"
+
+    code = 0
+    subprocess.run([sys.executable, str(repair), str(path)])
+    args = [sys.executable, str(validate), str(path)]
+    if rewrite:
+        args.append("--rewrite")
+    proc = subprocess.run(args)
+    code |= proc.returncode
+    proc = subprocess.run([sys.executable, str(test_all)])
+    code |= proc.returncode
+    return code
+
+
+class HeaderCheckRunner:
+    """CLI wrapper for :func:`run_checks`."""
+
+    @staticmethod
+    def test() -> None:
+        run_checks(Path('.'), rewrite=False)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Repair, validate and test file headers"
+    )
+    parser.add_argument("path", nargs="?", default=".", type=Path)
+    parser.add_argument(
+        "--rewrite",
+        action="store_true",
+        help="Pass --rewrite to validate_headers.py",
+    )
+    args = parser.parse_args()
+    code = run_checks(args.path, rewrite=args.rewrite)
+    sys.exit(code)
+

--- a/AGENTS/tests/headers/test_all_headers.py
+++ b/AGENTS/tests/headers/test_all_headers.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Run all class ``test()`` methods across faculty tiers."""
+
+from __future__ import annotations
+
+try:
+    import json
+    import os
+    import subprocess
+    import sys
+    from pathlib import Path
+
+    from tensors.faculty import Faculty, FORCE_ENV
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(root))
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+
+# ########## STUB: recursive test runner ##########
+# PURPOSE: Execute class level ``test()`` methods under each faculty tier.
+# EXPECTED BEHAVIOR: Import each class in a subprocess with the environment
+# variable ``SPEAKTOME_FACULTY`` set and call ``Class.test()``.
+# INPUTS: JSON data produced by ``dump_headers.py`` or scanned directly.
+# OUTPUTS: JSON summary of pass/fail results for optional markdown reporting.
+# KEY ASSUMPTIONS/DEPENDENCIES: Requires Python interpreter access and the
+# ``speaktome`` package importable in subprocesses.
+# TODO:
+#   - Capture stdout/stderr from tests for logging. [DONE]
+#   - Surface structured results for ``format_test_digest.py``. [DONE]
+# NOTES: This is a minimal scaffold and does not implement all failure modes.
+# ###########################################################################
+
+SCRIPT_PATH = Path(__file__).with_name("dump_headers.py")
+
+
+def load_headers() -> dict:
+    data = subprocess.check_output([sys.executable, str(SCRIPT_PATH)])
+    return json.loads(data)
+
+
+def run_test(mod: str, cls: str, faculty: Faculty) -> dict[str, object]:
+    """Return structured results for ``cls.test`` under ``faculty``."""
+    env = os.environ.copy()
+    env[FORCE_ENV] = faculty.name
+    code = (
+        "import importlib, sys; "
+        f"mod = importlib.import_module('{mod}'); "
+        f"cls = getattr(mod, '{cls}'); "
+        "getattr(cls, 'test', lambda: None)();"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "ok": proc.returncode == 0,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def main() -> None:
+    headers = load_headers()
+    results = {}
+    for mod, items in headers.items():
+        for item in items:
+            cls = item["class"]
+            key = f"{mod}.{cls}"
+            results[key] = {}
+            for fac in Faculty:
+                results[key][fac.name] = run_test(mod, cls, fac)
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/AGENTS/tests/headers/validate_headers.py
+++ b/AGENTS/tests/headers/validate_headers.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Static header validation utility for the SPEAKTOME project."""
+from __future__ import annotations
+
+try:
+    IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
+    import ast
+    from pathlib import Path
+    from typing import Iterable
+    import sys
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensor printing",
+            "time_sync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "AGENTS.tools.auto_env_setup",
+                str(root),
+            ],
+            check=False,
+        )
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+PACKAGE_ROOT = Path(__file__).parent / "speaktome"
+
+
+# This helper ensures each class exposes documentation and a basic test stub.
+# It recursively parses Python modules and reports missing ``HEADER`` or
+# ``test`` implementations without importing project modules.  When ``--rewrite``
+# is supplied the script will insert minimal placeholders for any missing
+# elements.  This makes it easier to bootstrap new modules and keep
+# documentation consistent.
+
+
+def collect_classes(root: Path) -> list[tuple[str, Path, ast.ClassDef]]:
+    classes: list[tuple[str, Path, ast.ClassDef]] = []
+    for path in root.rglob("*.py"):
+        if any(part in {".venv", ".git"} for part in path.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except Exception as exc:  # pragma: no cover - parse error
+            print(f"[AGENT_ACTIONABLE_ERROR] {path}: parse error {exc}")
+            continue
+        mod_name = (
+            path.relative_to(root.parent).with_suffix("").as_posix().replace("/", ".")
+        )
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef):
+                classes.append((mod_name, path, node))
+    return classes
+
+
+def check_class(cls: ast.ClassDef) -> tuple[bool, bool, str | None]:
+    doc = ast.get_docstring(cls)
+    header = None
+    has_test = False
+    if doc:
+        header = doc
+    for stmt in cls.body:
+        if isinstance(stmt, ast.Assign):
+            for target in stmt.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "HEADER"
+                    and isinstance(stmt.value, (ast.Str, ast.Constant))
+                ):
+                    header = getattr(
+                        stmt.value, "s", getattr(stmt.value, "value", None)
+                    )
+        if isinstance(stmt, ast.FunctionDef) and stmt.name == "test":
+            for deco in stmt.decorator_list:
+                if isinstance(deco, ast.Name) and deco.id == "staticmethod":
+                    has_test = True
+    return bool(header), has_test, header
+
+
+def validate(root: Path, *, rewrite: bool = False) -> int:
+    exit_code = 0
+    rewrites: dict[Path, list[tuple[ast.ClassDef, bool, bool]]] = {}
+
+    for mod_name, path, cls in collect_classes(root):
+        has_header, has_test, _header = check_class(cls)
+        missing_header = not has_header
+        missing_test = not has_test
+        if missing_header or missing_test:
+            exit_code = 1
+            parts = []
+            if missing_header:
+                parts.append("HEADER")
+            if missing_test:
+                parts.append("@staticmethod test()")
+            print(
+                f"[AGENT_ACTIONABLE_ERROR] {mod_name}:{cls.name} missing "
+                f"{', '.join(parts)}"
+            )
+            if rewrite:
+                rewrites.setdefault(path, []).append(
+                    (cls, missing_header, missing_test)
+                )
+
+    if rewrite:
+        for path, items in rewrites.items():
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for cls, miss_head, miss_test in sorted(
+                items, key=lambda t: t[0].lineno, reverse=True
+            ):
+                insert_at = cls.lineno
+                if (
+                    cls.body
+                    and isinstance(cls.body[0], ast.Expr)
+                    and isinstance(cls.body[0].value, (ast.Str, ast.Constant))
+                ):
+                    insert_at = cls.body[0].end_lineno
+                insert_idx = insert_at - 1
+                indent = " " * (cls.col_offset + 4)
+                new_lines: list[str] = []
+                if miss_head:
+                    new_lines.append(f"{indent}try:")
+                    new_lines.append(f'{indent}    HEADER = "TODO"')
+                    new_lines.append(f"{indent}except Exception:")
+                    new_lines.append(f"{indent}    import os")
+                    new_lines.append(f"{indent}    import sys")
+                    new_lines.append(
+                        f"{indent}    ENV_SETUP_BOX = os.environ['ENV_SETUP_BOX']"
+                    )
+                    new_lines.append(f"{indent}    print(ENV_SETUP_BOX)")
+                    new_lines.append(f"{indent}    sys.exit(1)")
+                if miss_test:
+                    new_lines.append(f"{indent}@staticmethod")
+                    new_lines.append(f"{indent}def test() -> None:")
+                    new_lines.append(f"{indent}    pass")
+                lines[insert_idx:insert_idx] = new_lines
+            path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+            exit_code = 0
+
+    return exit_code
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Validate class headers")
+    parser.add_argument("path", nargs="?", default=PACKAGE_ROOT, type=Path)
+    parser.add_argument(
+        "--rewrite",
+        action="store_true",
+        help="Insert missing HEADER strings and test stubs",
+    )
+    args = parser.parse_args()
+
+    try:
+        exit_code = validate(args.path, rewrite=args.rewrite)
+    except Exception as exc:  # pragma: no cover - unexpected failure
+        try:
+            env_box = os.environ["ENV_SETUP_BOX"]
+        except KeyError:
+            env_box = "environment not initialized"
+        print(
+            "[AGENT_ACTIONABLE_ERROR] validate_headers failed: "
+            f"{exc}.\n{env_box}"
+        )
+        sys.exit(1)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/fontmapper/FM16/FM38.py
+++ b/fontmapper/FM16/FM38.py
@@ -2,12 +2,6 @@
 """FontMapper FM38 utility functions."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 # --- Core Imports (always required) ---
@@ -37,9 +31,7 @@ try:
     from collections import defaultdict
 except Exception:
     import sys
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+    print(f"Optional dependencies missing in {__file__} -> {sys.exc_info()[1]}")
 # --- END HEADER ---
 
 from .optional_dependencies import (

--- a/fontmapper/FM16/FMS6.py
+++ b/fontmapper/FM16/FMS6.py
@@ -2,12 +2,6 @@
 """FontMapper FM16 utility functions."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 import json

--- a/fontmapper/FM16/modules/__init__.py
+++ b/fontmapper/FM16/modules/__init__.py
@@ -2,12 +2,6 @@
 """Helper classes for FM16."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 from .charset_ops import (

--- a/fontmapper/FM16/modules/char_sorter.py
+++ b/fontmapper/FM16/modules/char_sorter.py
@@ -2,12 +2,6 @@
 """Neural network used for character sorting."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 from torch import nn

--- a/fontmapper/FM16/modules/charset_ops.py
+++ b/fontmapper/FM16/modules/charset_ops.py
@@ -2,15 +2,9 @@
 """Charset and charmap utilities for FontMapper."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from fontTools.ttLib import TTFont
-    from PIL import Image, ImageDraw, ImageFont
-    import numpy as np
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from fontTools.ttLib import TTFont
+from PIL import Image, ImageDraw, ImageFont
+import numpy as np
 # --- END HEADER ---
 
 # --- Optional: Torch (soft fail) ---

--- a/fontmapper/FM16/modules/datasets.py
+++ b/fontmapper/FM16/modules/datasets.py
@@ -2,12 +2,6 @@
 """Dataset helpers for FontMapper."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 from PIL import Image

--- a/fontmapper/FM16/modules/model_configs.py
+++ b/fontmapper/FM16/modules/model_configs.py
@@ -2,12 +2,6 @@
 """Model configuration classes used by FM38 and FMS6."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 from dataclasses import dataclass

--- a/fontmapper/FM16/modules/model_ops.py
+++ b/fontmapper/FM16/modules/model_ops.py
@@ -2,18 +2,12 @@
 """Model loading and batch evaluation helpers."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import torch
-    from torch.utils.data import DataLoader
-    from .char_sorter import CharSorter
-    from .datasets import CustomInputDataset
-    from .model_configs import ModelConfig
-    from .transforms import ToTensorAndToDevice
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import torch
+from torch.utils.data import DataLoader
+from .char_sorter import CharSorter
+from .datasets import CustomInputDataset
+from .model_configs import ModelConfig
+from .transforms import ToTensorAndToDevice
 # --- END HEADER ---
 
 from pathlib import Path

--- a/fontmapper/FM16/modules/transforms.py
+++ b/fontmapper/FM16/modules/transforms.py
@@ -2,12 +2,6 @@
 """Transform utilities for FontMapper."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 import random

--- a/fontmapper/__init__.py
+++ b/fontmapper/__init__.py
@@ -2,12 +2,6 @@
 """FontMapper utilities package."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 from .FM16.modules import charset_ops

--- a/fontmapper/ascii_mapper.py
+++ b/fontmapper/ascii_mapper.py
@@ -2,14 +2,8 @@
 """Simplified ASCII rendering utilities for FontMapper v2."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from fontmapper import FM16
-    from fontmapper.FM16.modules import charset_ops
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from fontmapper import FM16
+from fontmapper.FM16.modules import charset_ops
 # --- END HEADER ---
 
 from typing import Iterable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,11 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.12"
+
+[tool.poetry.group.tools]
+optional = true
+
+[tool.poetry.group.tools.dependencies]
 tools = {path = "AGENTS/tools", develop = true}
 
 [tool.poetry.group.dev]

--- a/speaktome/__init__.py
+++ b/speaktome/__init__.py
@@ -2,13 +2,7 @@
 """SpeakToMe beam search package."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from tensors.faculty import Faculty, DEFAULT_FACULTY, FORCE_ENV
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from tensors.faculty import Faculty, DEFAULT_FACULTY, FORCE_ENV
 # --- END HEADER ---
 
 __all__ = ["Faculty", "DEFAULT_FACULTY", "FORCE_ENV"]

--- a/speaktome/core/abstract_linear_net.py
+++ b/speaktome/core/abstract_linear_net.py
@@ -2,16 +2,10 @@
 """Backend-agnostic linear layers for small network experiments."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from typing import Any, Iterable, Dict
+from typing import Any, Iterable, Dict
 
-    from .model_abstraction import AbstractModelWrapper
-    from tensors.abstraction import AbstractTensor
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from .model_abstraction import AbstractModelWrapper
+from tensors.abstraction import AbstractTensor
 # --- END HEADER ---
 
 

--- a/speaktome/core/beam_graph_operator.py
+++ b/speaktome/core/beam_graph_operator.py
@@ -1,22 +1,16 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    import json
-    from typing import List, Set, Optional, Tuple, Dict, Callable, TYPE_CHECKING, Union, Any
+# Standard library imports
+import json
+from typing import List, Set, Optional, Tuple, Dict, Callable, TYPE_CHECKING, Union, Any
 
-    import torch
+import torch
 
-    from tensors import (
-        AbstractTensor,
-        get_tensor_operations,
-    )
+from tensors import (
+    AbstractTensor,
+    get_tensor_operations,
+)
 
-    # Local application/library specific imports
-    from .beam_tree_node import BeamTreeNode  # Assuming BeamTreeNode is in beam_tree_node.py
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from .beam_tree_node import BeamTreeNode  # Assuming BeamTreeNode is in beam_tree_node.py
 # --- END HEADER ---
 if TYPE_CHECKING:
     from .compressed_beam_tree import CompressedBeamTree # For type hinting 'tree'

--- a/speaktome/core/beam_retirement_manager.py
+++ b/speaktome/core/beam_retirement_manager.py
@@ -1,15 +1,9 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    import queue as py_queue
-    import threading
-    from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+# Standard library imports
+import queue as py_queue
+import threading
+from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
 
-    import torch
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import torch
 # --- END HEADER ---
 
 if TYPE_CHECKING:

--- a/speaktome/core/beam_search.py
+++ b/speaktome/core/beam_search.py
@@ -1,9 +1,7 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from __future__ import annotations
-    from typing import List, Optional, Tuple, Callable, Dict, Any, TYPE_CHECKING
-    import math
+# Standard library imports
+from __future__ import annotations
+from typing import List, Optional, Tuple, Callable, Dict, Any, TYPE_CHECKING
+import math
 
     # Third-party imports
     if TYPE_CHECKING:  # pragma: no cover - type hints only
@@ -30,10 +28,6 @@ try:
         PyTorchModelWrapper,
     )
     from .lookahead_controller import LookaheadConfig, LookaheadController
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 class BeamSearch:

--- a/speaktome/core/beam_search_instruction.py
+++ b/speaktome/core/beam_search_instruction.py
@@ -1,19 +1,13 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+# Standard library imports
+from typing import Any, Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
 
-    import torch  # type: ignore
+import torch  # type: ignore
 
-    if TYPE_CHECKING:  # pragma: no cover - type hints only
-        from torch import Tensor
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from torch import Tensor
 
-    # Local application/library specific imports
-    from .scorer import Scorer  # Assuming Scorer is in scorer.py
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from .scorer import Scorer  # Assuming Scorer is in scorer.py
 # --- END HEADER ---
 
 class BeamSearchInstruction:

--- a/speaktome/core/beam_tree_node.py
+++ b/speaktome/core/beam_tree_node.py
@@ -1,18 +1,12 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from typing import List, Optional
+# Standard library imports
+from typing import List, Optional
 
-    import torch
+import torch
 
-    from tensors import (
-        AbstractTensor,
-        get_tensor_operations,
-    )
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from tensors import (
+    AbstractTensor,
+    get_tensor_operations,
+)
 # --- END HEADER ---
 
 class BeamTreeNode:

--- a/speaktome/core/beam_tree_visualizer.py
+++ b/speaktome/core/beam_tree_visualizer.py
@@ -1,17 +1,11 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    import collections
-    from typing import Optional, List, TYPE_CHECKING
+# Standard library imports
+import collections
+from typing import Optional, List, TYPE_CHECKING
 
-    if TYPE_CHECKING:
-        from transformers import PreTrainedTokenizer
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer
 
-    from ..util.lazy_loader import lazy_install
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from ..util.lazy_loader import lazy_install
 # --- END HEADER ---
 
 if TYPE_CHECKING:

--- a/speaktome/core/compressed_beam_tree.py
+++ b/speaktome/core/compressed_beam_tree.py
@@ -1,27 +1,21 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from typing import Dict, List, Optional, Tuple, Any, TYPE_CHECKING
+# Standard library imports
+from typing import Dict, List, Optional, Tuple, Any, TYPE_CHECKING
 
-    import torch
-    from ..util.lazy_loader import lazy_install
+import torch
+from ..util.lazy_loader import lazy_install
 
-    if TYPE_CHECKING:
-        from transformers import PreTrainedTokenizer  # For type hinting
+if TYPE_CHECKING:
+    from transformers import PreTrainedTokenizer  # For type hinting
 
-    if TYPE_CHECKING:
-        from torch_geometric.data import Data as PyGData  # pragma: no cover
+if TYPE_CHECKING:
+    from torch_geometric.data import Data as PyGData  # pragma: no cover
 
-    # Local application/library specific imports
-    from .beam_tree_node import BeamTreeNode  # Assuming BeamTreeNode is in beam_tree_node.py
-    from tensors import (
-        AbstractTensor,
-        get_tensor_operations,
-    )
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from .beam_tree_node import BeamTreeNode  # Assuming BeamTreeNode is in beam_tree_node.py
+from tensors import (
+    AbstractTensor,
+    get_tensor_operations,
+)
 # --- END HEADER ---
 
 class CompressedBeamTree:

--- a/speaktome/core/human_pilot_controller.py
+++ b/speaktome/core/human_pilot_controller.py
@@ -1,19 +1,13 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from typing import List, Optional, TYPE_CHECKING
+# Standard library imports
+from typing import List, Optional, TYPE_CHECKING
 
-    # Third-party imports
-    import torch  # type: ignore[import-untyped]
-    from torch_geometric.data import Data as PyGData  # type: ignore[import-untyped] # Moved for runtime availability
+# Third-party imports
+import torch  # type: ignore[import-untyped]
+from torch_geometric.data import Data as PyGData  # type: ignore[import-untyped] # Moved for runtime availability
 
-    # Local application/library specific imports
-    from .beam_search import BeamSearch
-    from .beam_search_instruction import BeamSearchInstruction
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from .beam_search import BeamSearch
+from .beam_search_instruction import BeamSearchInstruction
 # --- END HEADER ---
 
 class HumanPilotController:

--- a/speaktome/core/human_scorer_policy_manager.py
+++ b/speaktome/core/human_scorer_policy_manager.py
@@ -1,15 +1,9 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    import json
-    from typing import Dict, Callable, Optional, List, Tuple
+# Standard library imports
+import json
+from typing import Dict, Callable, Optional, List, Tuple
 
-    # Local application/library specific imports
-    from .scorer import Scorer
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from .scorer import Scorer
 # --- END HEADER ---
 
 class HumanScorerPolicyManager:

--- a/speaktome/core/lookahead_controller.py
+++ b/speaktome/core/lookahead_controller.py
@@ -1,18 +1,12 @@
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from typing import List, Tuple, Callable, Any, Set, TYPE_CHECKING
+# Standard library imports
+from typing import List, Tuple, Callable, Any, Set, TYPE_CHECKING
 
-    if TYPE_CHECKING:  # pragma: no cover - type hints only
-        from .beam_search_instruction import BeamSearchInstruction
-    from tensors import AbstractTensor
-    from .model_abstraction import AbstractModelWrapper
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+if TYPE_CHECKING:  # pragma: no cover - type hints only
+    from .beam_search_instruction import BeamSearchInstruction
+from tensors import AbstractTensor
+from .model_abstraction import AbstractModelWrapper
 # --- END HEADER ---
 
 

--- a/speaktome/core/model_abstraction.py
+++ b/speaktome/core/model_abstraction.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from abc import ABC, abstractmethod
     from typing import Any, Dict
     import torch
@@ -11,7 +10,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("Model abstraction failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/speaktome/core/scorer.py
+++ b/speaktome/core/scorer.py
@@ -1,34 +1,28 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    """Scoring utilities for beam search and research experimentation.
+# """Scoring utilities for beam search and research experimentation.
 
-    This module lazily loads GPT‑2 resources and provides a suite of batched
-    scoring functions.  The design favours vectorised tensor operations so models
-    and heuristics can scale gracefully.  Future versions will introduce a queue
-    and mailbox mechanism so that tokenisation, model inference, and scoring can be
-    scheduled in worker threads.  This will allow the scoring pipeline to operate
-    on arbitrary array types while delivering results to dynamic mailboxes for
-    maximum throughput.
-    """
+# This module lazily loads GPT‑2 resources and provides a suite of batched
+# scoring functions.  The design favours vectorised tensor operations so models
+# and heuristics can scale gracefully.  Future versions will introduce a queue
+# and mailbox mechanism so that tokenisation, model inference, and scoring can be
+# scheduled in worker threads.  This will allow the scoring pipeline to operate
+# on arbitrary array types while delivering results to dynamic mailboxes for
+# maximum throughput.
+# """
 
-    from typing import Callable, Dict
+from typing import Callable, Dict
 
-    import os
-    import torch
-    import torch.nn.functional as F
-    import queue
+import os
+import torch
+import torch.nn.functional as F
+import queue
 
-    from tensors import (
-        AbstractTensor,
-        get_tensor_operations,
-    )
+from tensors import (
+    AbstractTensor,
+    get_tensor_operations,
+)
 
-    from ..util.lazy_loader import lazy_import, optional_import
-    from .. import config
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from ..util.lazy_loader import lazy_import, optional_import
+from .. import config
 # --- END HEADER ---
 
 class Scorer:

--- a/speaktome/cpu_demo.py
+++ b/speaktome/cpu_demo.py
@@ -8,10 +8,8 @@ prints the top ``k`` results after ``d`` lookahead steps.
 """
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import argparse
-    from typing import Any, Dict
+import argparse
+from typing import Any, Dict
 
     from tensors.faculty import Faculty
 
@@ -31,10 +29,6 @@ try:
         SequentialLinearModel,
     )
     from .core.lookahead_controller import LookaheadController, LookaheadConfig
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 VOCAB = TokenVocabulary("abcdefghijklmnopqrstuvwxyz ")

--- a/speaktome/domains/geo/pyg_graph_controller.py
+++ b/speaktome/domains/geo/pyg_graph_controller.py
@@ -1,28 +1,21 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    from typing import Optional, List, TYPE_CHECKING
+# Standard library imports
+from typing import Optional, List, TYPE_CHECKING
 
-    import torch
+import torch
 
-    from ...util.lazy_loader import lazy_import
-    if TYPE_CHECKING:
-        from torch_geometric.data import Data as PyGData
+from ...util.lazy_loader import lazy_import
+if TYPE_CHECKING:
+    from torch_geometric.data import Data as PyGData
 
-    # Local application/library specific imports
-    from ...core.beam_search import BeamSearch
-    from .pygeo_mind import PyGeoMind
-    # Local application/library specific imports
-    from ...core.human_scorer_policy_manager import HumanScorerPolicyManager
-    from ...core.beam_search_instruction import BeamSearchInstruction
-    # Ensure this import points to the new location of BeamTreeVisualizer
-    # Import both visualizers from beam_tree_visualizer.py
-    from ...core.beam_tree_visualizer import BeamTreeVisualizer
-    from ...config import get_sentence_transformer_model
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from ...core.beam_search import BeamSearch
+from .pygeo_mind import PyGeoMind
+from ...core.human_scorer_policy_manager import HumanScorerPolicyManager
+from ...core.beam_search_instruction import BeamSearchInstruction
+# Ensure this import points to the new location of BeamTreeVisualizer
+# Import both visualizers from beam_tree_visualizer.py
+from ...core.beam_tree_visualizer import BeamTreeVisualizer
+from ...config import get_sentence_transformer_model
 # --- END HEADER ---
 class PyGGraphController:
     def __init__(self, beam_search: BeamSearch, pygeomind_model: Optional[PyGeoMind] = None, human_in_control: bool = False):

--- a/speaktome/domains/geo/pygeo_mind.py
+++ b/speaktome/domains/geo/pygeo_mind.py
@@ -1,30 +1,24 @@
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    # Standard library imports
-    import collections
-    from typing import Dict, List, Tuple, TYPE_CHECKING
+# Standard library imports
+import collections
+from typing import Dict, List, Tuple, TYPE_CHECKING
 
-    # Third-party imports
-    import torch
+# Third-party imports
+import torch
 
-    from tensors.faculty import Faculty
+from tensors.faculty import Faculty
 
-    FACULTY_REQUIREMENT = Faculty.PYGEO
+FACULTY_REQUIREMENT = Faculty.PYGEO
 
-    from ...util.lazy_loader import lazy_install
-    if TYPE_CHECKING:
-        from torch_geometric.data import Data as PyGData
-        import torch_geometric.nn as pyg_nn
+from ...util.lazy_loader import lazy_install
+if TYPE_CHECKING:
+    from torch_geometric.data import Data as PyGData
+    import torch_geometric.nn as pyg_nn
 
-    # Local application/library specific imports
-    from ...core.beam_search_instruction import BeamSearchInstruction
-    from ...core.compressed_beam_tree import CompressedBeamTree
-    from ...core.human_scorer_policy_manager import HumanScorerPolicyManager
-    from ...core.scorer import Scorer
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+# Local application/library specific imports
+from ...core.beam_search_instruction import BeamSearchInstruction
+from ...core.compressed_beam_tree import CompressedBeamTree
+from ...core.human_scorer_policy_manager import HumanScorerPolicyManager
+from ...core.scorer import Scorer
 # --- END HEADER ---
 
 

--- a/speaktome/speaktome.py
+++ b/speaktome/speaktome.py
@@ -5,7 +5,6 @@ import argparse
 # Third-party imports
 from tensors.faculty import Faculty, DEFAULT_FACULTY
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import torch
 except ModuleNotFoundError:  # pragma: no cover - runtime message only
     torch = None
@@ -16,10 +15,6 @@ if not TORCH_AVAILABLE:
 try:
     from transformers import PreTrainedTokenizer
     TRANSFORMERS_AVAILABLE = True
-except ModuleNotFoundError:  # pragma: no cover - runtime message only
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 

--- a/tensors/__init__.py
+++ b/tensors/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from .abstraction import (
         AbstractTensor,
         get_tensor_operations,
@@ -12,7 +11,7 @@ try:
     from .pure_backend import PurePythonTensorOperations
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("Failed to import optional tensor backends")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/abstraction.py
+++ b/tensors/abstraction.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from abc import ABC, abstractmethod
     from typing import Any, Tuple, Optional, List, Union, Callable, Dict, Deque
     import math
@@ -23,7 +22,6 @@ except Exception:
     print("Failed to import required modules for tensor operations.")
     import sys
 
-    print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/accelerator_backends/__init__.py
+++ b/tensors/accelerator_backends/__init__.py
@@ -3,12 +3,11 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from .c_backend import CTensorOperations
     from .opengl_backend import OpenGLTensorOperations
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("Accelerator backends failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/accelerator_backends/c_pipeline.py
+++ b/tensors/accelerator_backends/c_pipeline.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from typing import Any, Dict, Tuple
     from pathlib import Path
     import ctypes
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("C pipeline failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/accelerator_backends/coordinator.py
+++ b/tensors/accelerator_backends/coordinator.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from dataclasses import dataclass
     from typing import Any, Tuple
     from queue import Queue
@@ -14,7 +13,7 @@ try:
     from .opengl_backend import OpenGLTensorOperations
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("Accelerator coordinator imports failed")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/accelerator_backends/opengl_backend.py
+++ b/tensors/accelerator_backends/opengl_backend.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from typing import Any, Tuple
     from .abstraction import AbstractTensor
     import numpy as np
@@ -14,7 +13,7 @@ except ModuleNotFoundError:
     GL = None  # type: ignore
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("OpenGL backend failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/accelerator_backends/opengl_pipeline.py
+++ b/tensors/accelerator_backends/opengl_pipeline.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from typing import Any, Dict, Tuple
     from pathlib import Path
     from OpenGL import GL  # type: ignore
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("OpenGL pipeline failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/faculty.py
+++ b/tensors/faculty.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import os
     from enum import IntEnum
 except Exception:
     import sys
     print("faculty.py: Failed to import required modules.")
-    print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/jax_backend.py
+++ b/tensors/jax_backend.py
@@ -34,7 +34,6 @@ from typing import Any, Tuple, List, Optional
 from .abstraction import AbstractTensor
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import jax
     import jax.numpy as jnp
     from jax import lax
@@ -44,7 +43,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
     lax = None  # type: ignore
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("JAX backend failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/numpy_backend.py
+++ b/tensors/numpy_backend.py
@@ -32,7 +32,6 @@ from typing import Any, Tuple, List, Optional
 from .abstraction import AbstractTensor
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     import numpy as np
 except ModuleNotFoundError:  # pragma: no cover - optional dependency
     np = None  # type: ignore
@@ -43,7 +42,7 @@ except ModuleNotFoundError:  # pragma: no cover - optional dependency
     torch = None  # type: ignore
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("NumPy backend failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tensors/torch_backend.py
+++ b/tensors/torch_backend.py
@@ -28,7 +28,6 @@
 # tensor operations.
 
 try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
     from typing import Any, Tuple, List, Optional, Union
 
     from .abstraction import AbstractTensor
@@ -40,7 +39,7 @@ except ModuleNotFoundError:
     F = None  # type: ignore
 except Exception:
     import sys
-    print(ENV_SETUP_BOX)
+    print("PyTorch backend failed to import")
     sys.exit(1)
 # --- END HEADER ---
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,7 +314,7 @@ Active Faculty for this Session:
     
     root_logger.info("--------------------------------------------------------------------------------")
     # --- End Enhanced Log Header & Faculty Information ---
-    from AGENTS.tools.dump_headers import dump_headers
+    from AGENTS.tests.headers.dump_headers import dump_headers
     buf = StringIO()
     _stdout = sys.stdout
     sys.stdout = buf

--- a/tests/test_header_guard_precommit.py
+++ b/tests/test_header_guard_precommit.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 try:
     from pathlib import Path
-    import AGENTS.tools.header_guard_precommit as hg
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
+    import AGENTS.tests.headers.header_guard_precommit as hg
+    from AGENTS.tests.headers.header_utils import ENV_SETUP_BOX
 except Exception:
     print(ENV_SETUP_BOX)
     raise

--- a/tests/test_test_all_headers_runner.py
+++ b/tests/test_test_all_headers_runner.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from AGENTS.tools.test_all_headers import run_test
+from AGENTS.tests.headers.test_all_headers import run_test
 from tensors.faculty import Faculty
 
 # --- END HEADER ---

--- a/time_sync/ascii_kernel_classifier.py
+++ b/time_sync/ascii_kernel_classifier.py
@@ -2,19 +2,13 @@
 """ASCII classifier using tensor backends for parallel evaluation."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from typing import Any
-    import numpy as np
-    from PIL import Image, ImageDraw, ImageFont
-    from tensors import (
-        AbstractTensor,
-        Faculty,
-    )
-except Exception as e:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from typing import Any
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+from tensors import (
+    AbstractTensor,
+    Faculty,
+)
 # --- END HEADER ---
 
 try:

--- a/time_sync/draw.py
+++ b/time_sync/draw.py
@@ -2,16 +2,10 @@
 """Terminal drawing helpers for ASCII frame diffs."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import sys
-    import numpy as np
-    from colorama import Style, Fore, Back
-    from time_sync.ascii_kernel_classifier import AsciiKernelClassifier
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import sys
+import numpy as np
+from colorama import Style, Fore, Back
+from time_sync.ascii_kernel_classifier import AsciiKernelClassifier
 # --- END HEADER ---
 
 

--- a/time_sync/frame_buffer.py
+++ b/time_sync/frame_buffer.py
@@ -2,14 +2,8 @@
 """Triple-buffered ASCII frame diff manager."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import numpy as np
-    import threading
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import numpy as np
+import threading
 # --- END HEADER ---
 
 

--- a/time_sync/render_thread.py
+++ b/time_sync/render_thread.py
@@ -2,17 +2,11 @@
 """Background thread for producing ASCII frames."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import numpy as np
-    import threading
-    import time
-    from typing import Callable
-    from .frame_buffer import PixelFrameBuffer # Changed from AsciiFrameBuffer
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import numpy as np
+import threading
+import time
+from typing import Callable
+from .frame_buffer import PixelFrameBuffer # Changed from AsciiFrameBuffer
 # --- END HEADER ---
 
 

--- a/time_sync/subunit_window.py
+++ b/time_sync/subunit_window.py
@@ -2,13 +2,7 @@
 """Pygame window for displaying pixel subunit grids."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import numpy as np
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import numpy as np
 # --- END HEADER ---
 
 try:  # Optional dependency

--- a/time_sync/time_sync/__init__.py
+++ b/time_sync/time_sync/__init__.py
@@ -2,12 +2,6 @@
 """Time synchronization utilities."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
 # --- END HEADER ---
 
 from .core import (

--- a/time_sync/time_sync/_internet.py
+++ b/time_sync/time_sync/_internet.py
@@ -2,16 +2,10 @@
 """Fetch the current UTC time from the internet."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import datetime as _dt
-    import json
-    import urllib.request
-    import ntplib  # type: ignore
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import datetime as _dt
+import json
+import urllib.request
+import ntplib  # type: ignore
 # --- END HEADER ---
 
 

--- a/time_sync/time_sync/ascii_digits.py
+++ b/time_sync/time_sync/ascii_digits.py
@@ -2,15 +2,9 @@
 """ASCII art utilities for rendering clock faces."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import datetime as _dt
-    import math
-    from typing import List, Tuple, Optional
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import datetime as _dt
+import math
+from typing import List, Tuple, Optional
 # --- END HEADER ---
 
 from colorama import Fore, Style

--- a/time_sync/time_sync/console.py
+++ b/time_sync/time_sync/console.py
@@ -2,13 +2,7 @@
 """Console utilities for screen manipulation and color initialization."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from colorama import Cursor, ansi, just_fix_windows_console as _just_fix_windows_console
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from colorama import Cursor, ansi, just_fix_windows_console as _just_fix_windows_console
 # --- END HEADER ---
 
 # Provide no-op fallbacks if colorama is not installed. These stubs ensure the

--- a/time_sync/time_sync/core.py
+++ b/time_sync/time_sync/core.py
@@ -2,16 +2,10 @@
 """Core functions for aligning system time with internet time."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import datetime as _dt
-    import os
-    from typing import Optional
-    from . import _internet
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import datetime as _dt
+import os
+from typing import Optional
+from . import _internet
 # --- END HEADER ---
 
 OFFSET_ENV = "SPEAKTOME_TIME_OFFSET"

--- a/time_sync/time_sync/render_backend.py
+++ b/time_sync/time_sync/render_backend.py
@@ -2,15 +2,9 @@
 """Image rendering helper for theme effects and post-processing."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    from PIL import Image, ImageEnhance, ImageFilter
-    from typing import Optional
-    from .theme_manager import ThemeManager
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+from PIL import Image, ImageEnhance, ImageFilter
+from typing import Optional
+from .theme_manager import ThemeManager
 # --- END HEADER ---
 
 class RenderingBackend:

--- a/time_sync/time_sync/theme_manager.py
+++ b/time_sync/time_sync/theme_manager.py
@@ -2,17 +2,11 @@
 """Manage color themes and post-processing for clock rendering."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import json
-    import os    
-    from dataclasses import dataclass, field
-    from typing import Dict, List, Optional, Tuple
-    from PIL import Image, ImageEnhance, ImageFilter
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+from PIL import Image, ImageEnhance, ImageFilter
 # --- END HEADER ---
 from .time_units import TimeUnit # Import the new TimeUnit class
 

--- a/time_sync/time_sync/time_units.py
+++ b/time_sync/time_sync/time_units.py
@@ -2,15 +2,9 @@
 """Defines TimeUnit class and utilities for configurable clock units."""
 from __future__ import annotations
 
-try:
-    from AGENTS.tools.header_utils import ENV_SETUP_BOX
-    import datetime as _dt
-    from dataclasses import dataclass, field
-    from typing import Callable, Any, List, Tuple, Dict
-except Exception:
-    import sys
-    print(ENV_SETUP_BOX)
-    sys.exit(1)
+import datetime as _dt
+from dataclasses import dataclass, field
+from typing import Callable, Any, List, Tuple, Dict
 # --- END HEADER ---
 
 # --- Accessor Functions ---


### PR DESCRIPTION
## Summary
- add `AGENTS/tests/headers` package with copies of header utilities
- drop mandatory dependency on tools in `pyproject.toml`
- remove `header_utils` imports from packages
- update tests to use the new `AGENTS.tests.headers` path

## Testing
- `python testing/test_hub.py` *(fails: environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684c91fc2b80832a9f30aba7a16a54bd