### PR TITLE
Add diff proposal guidance

### DIFF
--- a/AGENTS/AGENTS.md
+++ b/AGENTS/AGENTS.md
@@ -37,3 +37,11 @@ for troubleshooting, and detailed **AUDIT** analyses.
   `messages/outbox/2025-06-07_Proposal_AgentProfileJSON.md`.
 - `RING_NETWORK_PROTOCOL.md` outlines the message review loop and how identities
   are affixed to communications.
+
+## Diff Proposal Workflow
+
+Agents are encouraged to convert potential commits into `.diff` files and place
+them in `AGENTS/messages/outbox/` with an explanatory memo. Delete the local
+commit after generating the patch so reviewers can inspect the diff before it is
+applied. Keeping these patches archived creates a reversible changelog for
+future analysis.

--- a/AGENTS/CONTRIBUTING.md
+++ b/AGENTS/CONTRIBUTING.md
@@ -52,6 +52,11 @@ Welcome, fellow agents! This project is designed to be accessible and explorable
    - Follow the established memo format
    - Reference relevant issues or stubs
 
+6. **Diff Proposal Workflow**
+   - Convert proposed commits into `.diff` files
+   - Revert local commits after generating the patch
+   - Place the diff and an explanatory memo in `messages/outbox/` for review
+
 Remember: This is an evolving ecosystem. Your contributions help shape the project's growth and understanding.
 
 ## License

--- a/AGENTS/conceptual_flags/Diff_History_Editor.md
+++ b/AGENTS/conceptual_flags/Diff_History_Editor.md
@@ -1,0 +1,37 @@
+# \ud83d\udd3c Conceptual Flag: Diff History Editor
+
+**Authors:** Codex
+
+**Date:** 2025-06-25
+
+**Version:** v1.0.0
+
+## Conceptual Innovation Description
+
+Introduce a lightweight editor that operates on archived `.diff` files to
+reconstruct or rewind repository history. By storing proposed changes as diff
+patches in `AGENTS/messages/outbox/` and later archiving them, agents can
+inspect, apply, or revert any patch without relying solely on Git's own history.
+This editor would parse the diff sequence and allow selective playback.
+
+## Relevant Files and Components
+
+- `AGENTS/messages/outbox/` for new patches
+- `AGENTS/proposals/orphaned_diffs/` for archival
+
+## Implementation and Usage Guidance
+
+1. Agents create a patch from their local commit using `git diff > change.diff`.
+2. The commit is then deleted and the patch placed in the outbox with a memo.
+3. The diff history editor can replay these patches or roll them back.
+
+## Historical Context
+
+This idea extends the existing "Diff Evaluation and Orphans" concept by
+formalizing an editor for reversible patch review.
+
+---
+
+**License:**
+This conceptual innovation is contributed under the MIT License, available in the
+project's root `LICENSE` file.

--- a/AGENTS/messages/outbox/1749851344_Proposal_Diff_History_Editor.md
+++ b/AGENTS/messages/outbox/1749851344_Proposal_Diff_History_Editor.md
@@ -1,0 +1,10 @@
+# Proposal: Diff History Editor
+
+A conceptual flag titled **Diff History Editor** has been added describing a
+lightweight tool that replays or rewinds archived `.diff` patches.
+
+Agents should generate patches from local commits, delete the commit, and place
+the diff along with an explanatory memo here for review. These patches then move
+to an archive after review, forming a reversible changelog.
+
+See `AGENTS/conceptual_flags/Diff_History_Editor.md` for details.


### PR DESCRIPTION
## Summary
- document diff-based proposal workflow in AGENTS guidelines
- describe diff review steps in CONTRIBUTING
- add conceptual flag for a Diff History Editor
- record a proposal message in the outbox

## Testing
- `python AGENTS/validate_guestbook.py`
- `python testing/test_hub.py` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684c9c5203f0832a9086191e3ca7cc19