### PR TITLE
Fix path to job description directory

### DIFF
--- a/AGENTS/tools/prioritize_jobs.py
+++ b/AGENTS/tools/prioritize_jobs.py
@@ -26,7 +26,7 @@ def _find_repo_root(start: Path) -> Path:
             return parent
     return current
 
-JOB_DIR = _find_repo_root(Path(__file__)) / "job_descriptions"
+JOB_DIR = _find_repo_root(Path(__file__)) / "AGENTS" / "job_descriptions"
 OUT_FILE = JOB_DIR / "job_priority.json"
 # --- END HEADER ---
 


### PR DESCRIPTION
## Summary
- point `prioritize_jobs` to the correct `AGENTS/job_descriptions` folder

## Testing
- `pytest -q tests/test_job_prioritization.py` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684d1ae55fb8832aba038c071088b75a