### PR TITLE
Align header utilities with canonical template

### DIFF
--- a/AGENTS/tests/headers/__init__.py
+++ b/AGENTS/tests/headers/__init__.py
@@ -1,3 +1,129 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Template for SPEAKTOME module headers."""
+from __future__ import annotations
+
+try:
+    import your_modules
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+    import json
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensorprinting",
+            "timesync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+            "testenv",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
 """Header tools and templates for tests."""
 
 from . import header_utils

--- a/AGENTS/tests/headers/auto_fix_headers.py
+++ b/AGENTS/tests/headers/auto_fix_headers.py
@@ -1,32 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Automatically ensure standard headers across the repository."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import os
-    import re
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -40,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tests/headers/dump_headers.py
+++ b/AGENTS/tests/headers/dump_headers.py
@@ -1,34 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Dump class headers across the ``speaktome`` package."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import ast
-    import json
-    import sys
-    import os
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -42,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tests/headers/dynamic_header_recognition.py
+++ b/AGENTS/tests/headers/dynamic_header_recognition.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Dynamic recognition and construction helpers for SPEAKTOME headers."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import json
-    import re
-    from pathlib import Path
-    from typing import Iterable, Optional
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -23,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -41,15 +99,26 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [sys.executable, "-m", "AGENTS.tools.auto_env_setup", str(root)],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
-    except KeyError as exc:  # pragma: no cover - env missing
+    except KeyError as exc:
         raise RuntimeError("environment not initialized") from exc
     print(f"[HEADER] import failure in {__file__}")
     print(ENV_SETUP_BOX)

--- a/AGENTS/tests/headers/header.py
+++ b/AGENTS/tests/headers/header.py
@@ -1,3 +1,129 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Template for SPEAKTOME module headers."""
+from __future__ import annotations
+
+try:
+    import your_modules
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+    import json
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensorprinting",
+            "timesync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+            "testenv",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
 from typing import Any, Dict, List, Optional
 import re
 

--- a/AGENTS/tests/headers/header_audit.py
+++ b/AGENTS/tests/headers/header_audit.py
@@ -1,31 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Audit header compliance for tools and tests."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import re
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -39,12 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        groups = os.environ.get("SPEAKTOME_GROUPS", "")
-        cmd = [sys.executable, "-m", "AGENTS.tools.auto_env_setup", str(root)]
-        if groups:
-            for g in groups.split(","):
-                cmd.append(f"-groups={g}")
-        subprocess.run(cmd, check=False)
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tests/headers/header_guard_precommit.py
+++ b/AGENTS/tests/headers/header_guard_precommit.py
@@ -1,34 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Pre-commit hook enforcing HEADER, tests, and the end sentinel."""
-
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import subprocess
-    import ast
-    import os
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -42,25 +99,28 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
     except KeyError as exc:
         raise RuntimeError("environment not initialized") from exc
-    IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
-    HEADER_START = "# --- BEGIN HEADER ---"
-    HEADER_END = "# --- END HEADER ---"
-    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
+    print(f"[HEADER] import failure in {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/tests/headers/header_template_check.py
+++ b/AGENTS/tests/headers/header_template_check.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Run the header template directly to ensure it is syntactically valid."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import subprocess
-    import sys
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -29,6 +28,65 @@ except Exception:
                 return parent
         return current
 
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
         box = root / "ENV_SETUP_BOX.md"
@@ -41,12 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run([
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
             sys.executable,
             "-m",
             "AGENTS.tools.auto_env_setup",
             str(root),
-        ], check=False)
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tests/headers/header_utils.py
+++ b/AGENTS/tests/headers/header_utils.py
@@ -1,30 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Shared constants for header compliance utilities."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import os
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -38,20 +99,26 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
-    except KeyError as exc:  # pragma: no cover - env missing
+    except KeyError as exc:
         raise RuntimeError("environment not initialized") from exc
     print(f"[HEADER] import failure in {__file__}")
     print(ENV_SETUP_BOX)

--- a/AGENTS/tests/headers/run_header_checks.py
+++ b/AGENTS/tests/headers/run_header_checks.py
@@ -1,33 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Run header repair, validation and tests in one step."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    from pathlib import Path
-    import subprocess
-    import sys
-    import os
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -41,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
@@ -120,4 +184,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
     code = run_checks(args.path, rewrite=args.rewrite)
     sys.exit(code)
-

--- a/AGENTS/tests/headers/test_all_headers.py
+++ b/AGENTS/tests/headers/test_all_headers.py
@@ -1,38 +1,92 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Run all class ``test()`` methods across faculty tiers."""
-
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import json
-    import os
-    import subprocess
-    import sys
-    from pathlib import Path
-
-    from tensors.faculty import Faculty, FORCE_ENV
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
-    root = Path(__file__).resolve().parents[2]
-    sys.path.insert(0, str(root))
+    import json
+
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
         box = root / "ENV_SETUP_BOX.md"
@@ -45,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tests/headers/validate_headers.py
+++ b/AGENTS/tests/headers/validate_headers.py
@@ -1,34 +1,91 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Static header validation utility for the SPEAKTOME project."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
-    import ast
-    from pathlib import Path
-    from typing import Iterable
-    import sys
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
             "speaktome",
             "laplace",
-            "tensor printing",
-            "time_sync",
+            "tensorprinting",
+            "timesync",
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -42,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tools/headers/__init__.py
+++ b/AGENTS/tools/headers/__init__.py
@@ -1,3 +1,129 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Template for SPEAKTOME module headers."""
+from __future__ import annotations
+
+try:
+    import your_modules
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+    import json
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensorprinting",
+            "timesync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+            "testenv",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
 """Header utilities and templates."""
 
 __all__ = [
@@ -21,4 +147,3 @@ def __getattr__(name: str):
     if name in __all__:
         return import_module(f"{__name__}.{name}")
     raise AttributeError(name)
-

--- a/AGENTS/tools/headers/auto_fix_headers.py
+++ b/AGENTS/tools/headers/auto_fix_headers.py
@@ -1,16 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Automatically ensure standard headers across the repository."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import os
-    import re
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -22,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -40,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tools/headers/dump_headers.py
+++ b/AGENTS/tools/headers/dump_headers.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Dump class headers across the ``speaktome`` package."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import ast
-    import json
-    import sys
-    import os
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -24,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -42,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tools/headers/dynamic_header_recognition.py
+++ b/AGENTS/tools/headers/dynamic_header_recognition.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Dynamic recognition and construction helpers for SPEAKTOME headers."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import json
-    import re
-    from pathlib import Path
-    from typing import Iterable, Optional
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -23,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -41,15 +99,26 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [sys.executable, "-m", "AGENTS.tools.auto_env_setup", str(root)],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
-    except KeyError as exc:  # pragma: no cover - env missing
+    except KeyError as exc:
         raise RuntimeError("environment not initialized") from exc
     print(f"[HEADER] import failure in {__file__}")
     print(ENV_SETUP_BOX)

--- a/AGENTS/tools/headers/header.py
+++ b/AGENTS/tools/headers/header.py
@@ -1,3 +1,129 @@
+#!/usr/bin/env python3
+# --- BEGIN HEADER ---
+"""Template for SPEAKTOME module headers."""
+from __future__ import annotations
+
+try:
+    import your_modules
+except Exception:
+    import os
+    import sys
+    from pathlib import Path
+    import json
+
+    def _find_repo_root(start: Path) -> Path:
+        current = start.resolve()
+        required = {
+            "speaktome",
+            "laplace",
+            "tensorprinting",
+            "timesync",
+            "AGENTS",
+            "fontmapper",
+            "tensors",
+            "testenv",
+        }
+        for parent in [current, *current.parents]:
+            if all((parent / name).exists() for name in required):
+                return parent
+        return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
+    if "ENV_SETUP_BOX" not in os.environ:
+        root = _find_repo_root(Path(__file__))
+        box = root / "ENV_SETUP_BOX.md"
+        try:
+            os.environ["ENV_SETUP_BOX"] = f"\n{box.read_text()}\n"
+        except Exception:
+            os.environ["ENV_SETUP_BOX"] = "environment not initialized"
+        print(os.environ["ENV_SETUP_BOX"])
+        sys.exit(1)
+    import subprocess
+    try:
+        root = _find_repo_root(Path(__file__))
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
+    except Exception:
+        pass
+    try:
+        ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    except KeyError as exc:
+        raise RuntimeError("environment not initialized") from exc
+    print(f"[HEADER] import failure in {__file__}")
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
 from typing import Any, Dict, List, Optional
 import re
 

--- a/AGENTS/tools/headers/header_audit.py
+++ b/AGENTS/tools/headers/header_audit.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Audit header compliance for tools and tests."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import re
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -21,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -39,12 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        groups = os.environ.get("SPEAKTOME_GROUPS", "")
-        cmd = [sys.executable, "-m", "AGENTS.tools.auto_env_setup", str(root)]
-        if groups:
-            for g in groups.split(","):
-                cmd.append(f"-groups={g}")
-        subprocess.run(cmd, check=False)
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tools/headers/header_guard_precommit.py
+++ b/AGENTS/tools/headers/header_guard_precommit.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Pre-commit hook enforcing HEADER, tests, and the end sentinel."""
-
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import subprocess
-    import ast
-    import os
-    from pathlib import Path
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -24,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -42,25 +99,28 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
     except KeyError as exc:
         raise RuntimeError("environment not initialized") from exc
-    IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
-    HEADER_START = "# --- BEGIN HEADER ---"
-    HEADER_END = "# --- END HEADER ---"
-    print(f"{IMPORT_FAILURE_PREFIX} {__file__}")
+    print(f"[HEADER] import failure in {__file__}")
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---

--- a/AGENTS/tools/headers/header_template.py
+++ b/AGENTS/tools/headers/header_template.py
@@ -124,3 +124,4 @@ except Exception:
     print(ENV_SETUP_BOX)
     sys.exit(1)
 # --- END HEADER ---
+

--- a/AGENTS/tools/headers/header_utils.py
+++ b/AGENTS/tools/headers/header_utils.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Shared constants for header compliance utilities."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import os
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -20,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -38,20 +99,26 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
         ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
-    except KeyError as exc:  # pragma: no cover - env missing
+    except KeyError as exc:
         raise RuntimeError("environment not initialized") from exc
     print(f"[HEADER] import failure in {__file__}")
     print(ENV_SETUP_BOX)

--- a/AGENTS/tools/headers/run_header_checks.py
+++ b/AGENTS/tools/headers/run_header_checks.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Run header repair, validation and tests in one step."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    from pathlib import Path
-    import subprocess
-    import sys
-    import os
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -23,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -41,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:
@@ -120,4 +184,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
     code = run_checks(args.path, rewrite=args.rewrite)
     sys.exit(code)
-

--- a/AGENTS/tools/headers/test_all_headers.py
+++ b/AGENTS/tools/headers/test_all_headers.py
@@ -1,23 +1,16 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Run all class ``test()`` methods across faculty tiers."""
-
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    import json
-    import os
-    import subprocess
-    import sys
-    from pathlib import Path
-
-    from tensors.faculty import Faculty, FORCE_ENV
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
-    root = Path(__file__).resolve().parents[2]
-    sys.path.insert(0, str(root))
+    import json
+
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
         required = {
@@ -28,11 +21,72 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
+
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
         box = root / "ENV_SETUP_BOX.md"
@@ -45,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:

--- a/AGENTS/tools/headers/validate_headers.py
+++ b/AGENTS/tools/headers/validate_headers.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python3
 # --- BEGIN HEADER ---
-"""Static header validation utility for the SPEAKTOME project."""
+"""Template for SPEAKTOME module headers."""
 from __future__ import annotations
 
 try:
-    IMPORT_FAILURE_PREFIX = "[HEADER] import failure in"
-    import ast
-    from pathlib import Path
-    from typing import Iterable
-    import sys
+    import your_modules
 except Exception:
     import os
     import sys
     from pathlib import Path
+    import json
 
     def _find_repo_root(start: Path) -> Path:
         current = start.resolve()
@@ -24,11 +21,71 @@ except Exception:
             "AGENTS",
             "fontmapper",
             "tensors",
+            "testenv",
         }
         for parent in [current, *current.parents]:
             if all((parent / name).exists() for name in required):
                 return parent
         return current
+
+    ROOT = _find_repo_root(Path(__file__))
+    MAP_FILE = ROOT / "AGENTS" / "codebase_map.json"
+
+    def guess_codebase(path: Path, map_file: Path = MAP_FILE) -> str | None:
+        """Return codebase name owning ``path``.
+
+        Tries ``codebase_map.json`` first, then falls back to scanning path
+        components for known codebase names.
+        """
+        try:
+            data = json.loads(map_file.read_text())
+        except Exception:
+            data = None
+
+        if data:
+            for name, info in data.items():
+                cb_path = ROOT / info.get("path", name)
+                try:
+                    path.relative_to(cb_path)
+                    return name
+                except ValueError:
+                    continue
+        else:
+            candidates = {
+                "speaktome",
+                "laplace",
+                "tensorprinting",
+                "timesync",
+                "fontmapper",
+                "tensors",
+                "testenv",
+                "tools",
+            }
+            for part in path.parts:
+                if part in candidates:
+                    return part
+
+        return None
+
+    def parse_pyproject_groups(pyproject: Path) -> list[str]:
+        try:
+            try:
+                import tomllib
+            except ModuleNotFoundError:  # Python < 3.11
+                import tomli as tomllib
+        except Exception:
+            return []
+        try:
+            data = tomllib.loads(pyproject.read_text())
+        except Exception:
+            return []
+
+        groups = set()
+        groups.update(data.get("project", {}).get("optional-dependencies", {}).keys())
+        tool = data.get("tool", {}).get("poetry", {})
+        groups.update(tool.get("group", {}).keys())
+        groups.update(tool.get("extras", {}).keys())
+        return sorted(groups)
 
     if "ENV_SETUP_BOX" not in os.environ:
         root = _find_repo_root(Path(__file__))
@@ -42,15 +99,21 @@ except Exception:
     import subprocess
     try:
         root = _find_repo_root(Path(__file__))
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "AGENTS.tools.auto_env_setup",
-                str(root),
-            ],
-            check=False,
-        )
+        pyproject = root / "pyproject.toml"
+        groups = parse_pyproject_groups(pyproject)
+        codebase = guess_codebase(Path(__file__))
+        base_cmd = [
+            sys.executable,
+            "-m",
+            "AGENTS.tools.auto_env_setup",
+            str(root),
+        ]
+        if codebase:
+            base_cmd.append(f"-codebases={codebase}")
+        subprocess.run(base_cmd, check=False)
+        for grp in groups:
+            subprocess.run(base_cmd + [f"-groups={grp}"], check=False)
+
     except Exception:
         pass
     try:


### PR DESCRIPTION
## Summary
- replace top-of-file sections in `AGENTS/tools/headers` and `AGENTS/tests/headers` with the canonical header

## Testing
- `python testing/test_hub.py` *(fails: environment setup blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684dead7e548832a9d0f14e5e230fd7c