### PR TITLE
Fix header utilities

### DIFF
--- a/AGENTS/tools/headers/auto_fix_headers.py
+++ b/AGENTS/tools/headers/auto_fix_headers.py
@@ -133,7 +133,6 @@ EXCLUDE_DIRS = {
     "laplace",
     "training",
     "tensorprinting",
-    "tensorprinting",
 }
 
 HEADER_START = "# --- BEGIN HEADER ---"

--- a/AGENTS/tools/headers/header_utils.py
+++ b/AGENTS/tools/headers/header_utils.py
@@ -150,7 +150,7 @@ HEADER_REQUIREMENTS = [
     "'from __future__ import annotations' before the try block",
     "imports wrapped in a try block",
     (
-        "except block imports os, sys and Path, defines _find_repo_root,"
+        "except block imports os, sys, Path and json, defines _find_repo_root,"
         " checks ENV_SETUP_BOX and prints the message when missing,"
         " then invokes auto_env_setup via subprocess",
     ),


### PR DESCRIPTION
## Summary
- fix duplicate string in `auto_fix_headers.EXCLUDE_DIRS`
- update header requirements text to match template

## Testing
- `pytest AGENTS/tools/headers/tests -q` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684df01a5994832a958451d6443aea58