### PR TITLE
Update experience report guidance

### DIFF
--- a/AGENTS/GUESTBOOK.md
+++ b/AGENTS/GUESTBOOK.md
@@ -40,7 +40,7 @@ Review earlier experiences before starting a new test. Identify unresolved quest
 
 ## Continuous Collaboration
 
-User experience reports are part of a dynamic feedback loop between developers and testers. Keep the conversation going by clearly stating next steps and open issues. The goal is incremental refinement of the project.
+User experience reports are part of a dynamic feedback loop between developers and testers. Keep the conversation going by clearly stating next steps and open issues. Whenever you outline follow-up tasks, also create a `.stub.md` file in `todo/` summarizing the action. This makes it easier for future contributors to find and implement outstanding work. The goal is incremental refinement of the project.
 
 ## Prompt History
 

--- a/AGENTS/experience_reports/AGENTS.md
+++ b/AGENTS/experience_reports/AGENTS.md
@@ -18,7 +18,7 @@ Templates for each category are available:
 
 Include a **Prompt History** section quoting any instructions or conversations that influenced the session verbatim. Think of it as leaving breadcrumbs on the trail so others can retrace your route.
 
-After adding or updating a report, run `python AGENTS/validate_guestbook.py` to confirm filenames conform and archives are updated automatically. This keeps the park map tidy and easy to read.
+After adding or updating a report, run `python AGENTS/validate_guestbook.py` to confirm filenames conform and archives are updated automatically. Capture any "Next Steps" from your report as a `.stub.md` file in `todo/` so future agents can quickly locate outstanding tasks. This keeps the park map tidy and easy to read.
 
 
 For unusually detailed analyses, create a "long documentation" report. See `1749791541_v1_Long_Documentation_Guidelines.md` for the recommended format and extended instructions.

--- a/AGENTS/experience_reports/template_audit_report.md
+++ b/AGENTS/experience_reports/template_audit_report.md
@@ -16,7 +16,7 @@ Provide an in-depth account of findings, including code references and data as n
 Discuss implications of the observations, referencing specific lines or design decisions.
 
 ## Recommendations
-List any recommended changes or next steps based on the audit.
+List any recommended changes or next steps based on the audit. Capture these in `todo/` as a `.stub.md` file so future agents can address them.
 
 ## Prompt History
 Reproduce in full all prompts or directives that initiated this audit.

--- a/AGENTS/experience_reports/template_doc_report.md
+++ b/AGENTS/experience_reports/template_doc_report.md
@@ -16,7 +16,7 @@ Describe any notable output or results.
 Key takeaways from this activity.
 
 ## Next Steps
-Follow-up actions or questions.
+Follow-up actions or questions. Record these items in `todo/` as a `.stub.md` file so contributors can easily track outstanding work.
 
 ## Prompt History
 Quote any instructions that guided this report verbatim.

--- a/AGENTS/experience_reports/template_experience_report.md
+++ b/AGENTS/experience_reports/template_experience_report.md
@@ -21,5 +21,5 @@ Summaries of outputs, errors, or unusual events.
 What did this run teach you? How does it differ from previous attempts?
 
 ## Next Steps
-Planned follow-up actions or unresolved questions.
+Planned follow-up actions or unresolved questions. Record these tasks in `todo/` as a `.stub.md` file for easy tracking.
 

--- a/AGENTS/experience_reports/template_log_report.md
+++ b/AGENTS/experience_reports/template_log_report.md
@@ -14,4 +14,4 @@ Describe the exact command used to generate the log.
 ```
 
 ## Prompt History
-Include the prompts or instructions that requested this log.
+Include the prompts or instructions that requested this log. If the output suggests follow-up actions, record them in `todo/` as a `.stub.md` file.

--- a/AGENTS/experience_reports/template_tticket_report.md
+++ b/AGENTS/experience_reports/template_tticket_report.md
@@ -17,7 +17,7 @@ Provide error messages or log excerpts demonstrating the failure.
 Document any troubleshooting steps taken and their results.
 
 ## Current Status
-Explain whether the issue is resolved or requires follow-up.
+Explain whether the issue is resolved or requires follow-up. Document any remaining tasks in `todo/` as a `.stub.md` file.
 
 ## Prompt History
 Quote all prompts or instructions that shaped this trouble ticket.

--- a/todo/AGENTS.md
+++ b/todo/AGENTS.md
@@ -1,6 +1,6 @@
 # Todo Folder
 
-This directory holds open work items and prototypes.
+This directory holds open work items and prototypes. When you write an experience report, translate any "Next Steps" into a `.stub.md` file here so tasks are not lost in the documentation.
 
 ## Stub Tracking
 


### PR DESCRIPTION
## Summary
- add instructions in the guestbook to write next steps as `.stub.md` files
- encourage todo stub creation in experience_reports/AGENTS.md
- update all experience report templates with todo stub reminders
- mention todo stubs in the todo folder guidance

## Testing
- `python AGENTS/validate_guestbook.py`
- `python testing/test_hub.py` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_684eff18f514832a81a1fe3b5a449060