### PR TITLE
Add Rust backend skeleton

### DIFF
--- a/AGENTS/codebase_map.json
+++ b/AGENTS/codebase_map.json
@@ -82,6 +82,9 @@
         "glfw",
         "numpy>=1.26,<2.3"
       ],
+      "rust": [
+        "maturin>=1.5"
+      ],
       "dev": [
         "pytest>=8.0",
         "tools"

--- a/AGENTS/experience_reports/1750196197_DOC_Rust_Backend_Stub.md
+++ b/AGENTS/experience_reports/1750196197_DOC_Rust_Backend_Stub.md
@@ -1,0 +1,22 @@
+# Rust Backend Stub
+
+## Overview
+Added a new Rust backend skeleton under `tensors/accelerator_backends`. A Cargo project provides the Rust library and a Python wrapper exposes the stub class.
+
+## Steps Taken
+- Created `rust_backend` folder with Cargo project files.
+- Added optional `rust` dependency group in `tensors/pyproject.toml` and `AGENTS/codebase_map.json`.
+- Updated accelerator backend package to import `RustTensorOperations`.
+- Added stub test for the new backend.
+
+## Observed Behaviour
+Tests skipped due to missing environment setup as expected.
+
+## Lessons Learned
+The repository uses group-based dependency installation. New backends require updates to both `pyproject.toml` and `codebase_map.json`.
+
+## Next Steps
+- Implement real Rust tensor operations and async coordination.
+
+## Prompt History
+- "set up a rust backend in the tensors project in the accelerated backends please..."

--- a/tensors/accelerator_backends/__init__.py
+++ b/tensors/accelerator_backends/__init__.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 try:
     from .c_backend import CTensorOperations
     from .opengl_backend import OpenGLTensorOperations
+    from .rust_backend import RustTensorOperations
 except Exception:
     import sys
     print("Accelerator backends failed to import")
     sys.exit(1)
 # --- END HEADER ---
 
-__all__ = ["CTensorOperations", "OpenGLTensorOperations"]
+__all__ = ["CTensorOperations", "OpenGLTensorOperations", "RustTensorOperations"]

--- a/tensors/accelerator_backends/rust_backend.py
+++ b/tensors/accelerator_backends/rust_backend.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Rust backend stub for accelerated tensor operations."""
+from __future__ import annotations
+
+try:
+    import ctypes
+    from pathlib import Path
+    from typing import Any
+except Exception:
+    import sys
+    print("Rust backend failed to import")
+    sys.exit(1)
+# --- END HEADER ---
+
+# ########## STUB: Rust Async Backend ##########
+# PURPOSE: Provide a high-performance backend implemented in Rust.
+# EXPECTED BEHAVIOR: When compiled, functions will delegate tensor operations
+#          to a Rust library using ctypes bindings. The implementation will
+#          support asynchronous execution and buffer management.
+# INPUTS: Tensor data or Python sequences.
+# OUTPUTS: Computed results from the Rust library.
+# KEY ASSUMPTIONS/DEPENDENCIES: Requires the Rust toolchain and ``maturin`` to
+#         build ``librust_backend``. The shared library is searched relative to
+#         this file.
+# TODO:
+#   - Implement buffer creation and arithmetic dispatch.
+#   - Integrate with :class:`AcceleratorCoordinator` for async workflows.
+# NOTES: Currently all methods raise ``NotImplementedError``.
+# ###########################################################################
+
+_LIB: ctypes.CDLL | None = None
+
+
+def _load_library() -> ctypes.CDLL:
+    """Load the Rust backend shared library."""
+    global _LIB
+    if _LIB is None:
+        lib_name = {
+            "linux": "librust_backend.so",
+            "darwin": "librust_backend.dylib",
+            "win32": "rust_backend.dll",
+        }.get(sys.platform, "librust_backend.so")
+        path = Path(__file__).with_name(lib_name)
+        if not path.exists():
+            raise RuntimeError(f"Rust backend library not found: {path}")
+        _LIB = ctypes.CDLL(str(path))
+    return _LIB
+
+
+class RustTensorOperations:
+    """Stub wrapper exposing Rust tensor functions."""
+
+    def __init__(self) -> None:
+        _load_library()
+
+    def full_(self, size: tuple[int, ...], fill_value: Any, dtype: Any, device: Any):
+        raise NotImplementedError
+

--- a/tensors/accelerator_backends/rust_backend/AGENTS.md
+++ b/tensors/accelerator_backends/rust_backend/AGENTS.md
@@ -1,0 +1,9 @@
+# Rust Backend
+
+This directory contains a prototype Rust implementation for accelerated tensor operations.
+
+- `Cargo.toml` defines a `cdylib` crate built with `pyo3`.
+- `src/lib.rs` exposes minimal stub functions.
+- `setup_env.sh` installs the optional `rust` dependency group via the repository's setup script.
+
+Follow the coding standards from the parent directory. The Rust library is expected to be loaded by `rust_backend.py`.

--- a/tensors/accelerator_backends/rust_backend/Cargo.toml
+++ b/tensors/accelerator_backends/rust_backend/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "rust_backend"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+name = "rust_backend"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { version = "0.21", features = ["extension-module"] }

--- a/tensors/accelerator_backends/rust_backend/setup_env.sh
+++ b/tensors/accelerator_backends/rust_backend/setup_env.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"
+CODEBASE="$(basename "$SCRIPT_DIR")"
+MAP="$REPO_ROOT/AGENTS/codebase_map.json"
+get_groups() {
+python - "$CODEBASE" "$MAP" <<'PY'
+import json, sys
+name=sys.argv[1]; path=sys.argv[2]
+try:
+    data=json.load(open(path))
+    groups=data.get(name, {}).get("groups", {})
+except Exception:
+    groups={}
+safe=[g for g,pkgs in groups.items() if not any("torch" in p for p in pkgs)]
+print(','.join(safe))
+print(','.join(groups))
+PY
+}
+read -r SAFE_GROUPS ALL_GROUPS <<< "$(get_groups)"
+MODE="skip"
+for arg in "$@"; do
+  case $arg in
+    -full|-torch) MODE="full" ;;
+    -minimal) MODE="minimal" ;;
+  esac
+done
+case $MODE in
+  full)
+    GROUPS="$ALL_GROUPS"; TORCH_FLAG="-torch" ;;
+  minimal)
+    GROUPS="" ;;
+  *)
+    GROUPS="$SAFE_GROUPS" ;;
+esac
+ARGS=(-codebases="$CODEBASE")
+[ -n "$GROUPS" ] && ARGS+=(-groups="$CODEBASE:$GROUPS")
+cd "$REPO_ROOT"
+bash "$REPO_ROOT/setup_env_dev.sh" ${TORCH_FLAG:-} "${ARGS[@]}"

--- a/tensors/accelerator_backends/rust_backend/src/lib.rs
+++ b/tensors/accelerator_backends/rust_backend/src/lib.rs
@@ -1,0 +1,14 @@
+use pyo3::prelude::*;
+
+/// Create a buffer with the given size.
+#[pyfunction]
+fn create_buffer(_size: usize) -> PyResult<()> {
+    // Placeholder implementation
+    Err(pyo3::exceptions::PyNotImplementedError::new_err("rust backend stub"))
+}
+
+#[pymodule]
+fn rust_backend(_py: Python<'_>, m: &PyModule) -> PyResult<()> {
+    m.add_function(wrap_pyfunction!(create_buffer, m)?)?;
+    Ok(())
+}

--- a/tensors/pyproject.toml
+++ b/tensors/pyproject.toml
@@ -43,6 +43,12 @@ PyOpenGL = ">=3.1"
 glfw = "*"
 numpy = ">=1.26,<2.3"
 
+[tool.poetry.group.rust]
+optional = true
+
+[tool.poetry.group.rust.dependencies]
+maturin = ">=1.5"
+
 [tool.poetry.group.dev]
 optional = true
 
@@ -56,6 +62,7 @@ ctensor = []
 torch = []
 numpy = []
 opengl = []
+rust = []
 dev = []
 
 [build-system]

--- a/tests/test_rust_backend.py
+++ b/tests/test_rust_backend.py
@@ -1,0 +1,19 @@
+"""Rust backend stub test."""
+from __future__ import annotations
+
+try:
+    import os
+    import pytest
+    ENV_SETUP_BOX = os.environ["ENV_SETUP_BOX"]
+    from tensors.accelerator_backends import RustTensorOperations
+except Exception:
+    import sys
+    print(ENV_SETUP_BOX)
+    sys.exit(1)
+# --- END HEADER ---
+
+@pytest.mark.stub
+def test_rust_backend_placeholder():
+    backend = RustTensorOperations()
+    with pytest.raises(NotImplementedError):
+        backend.full_((2,), 0.0, None, None)


### PR DESCRIPTION
## Summary
- add optional `rust` dependency group for tensors
- wire new `RustTensorOperations` in accelerator backends
- stub out a Rust crate and Python wrapper for async tensor operations
- include a placeholder test and experience report

## Testing
- `python testing/test_hub.py` *(fails: Environment not initialized)*
- `python AGENTS/validate_guestbook.py`

------
https://chatgpt.com/codex/tasks/task_e_6851df0b1db0832a8e60824b75ff475f