### PR TITLE
Add audit for ascii oscilloscope stubs

### DIFF
--- a/AGENTS/experience_reports/1750553136_AUDIT_Asciioscilloscope_State.md
+++ b/AGENTS/experience_reports/1750553136_AUDIT_Asciioscilloscope_State.md
@@ -1,0 +1,36 @@
+# AsciiOscilloscope Audit Report
+
+**Date:** 1750553136
+**Title:** Current State of AsciiOscilloscope stubs and guidance
+
+## Scope
+Assess the existing structure of the `asciioscilliscope` project, focusing on repository guidance, stub implementation completeness, and overall project focus.
+
+## Methodology
+- Read `asciioscilliscope/AGENTS.md` and `HUMAN_GUIDANCE.md` for agent and human instructions.
+- Reviewed headers under `include/asciioscilliscope/` to understand expected APIs.
+- Inspected matching `src/` files for stub or implemented logic.
+- Surveyed prior experience reports mentioning the oscilloscope to gather historical context.
+
+## Detailed Observations
+- Guidance files emphasise that header comments form the canonical specification and must remain intact. Implementation files intentionally contain stub logic that mirrors these headers.
+- The submodule `eigen` is referenced but currently empty.
+- Most source files compile with placeholder behavior. For example, `PixelFrameBuffer` only zeros and swaps tensors while `Renderer` stubs out processing loops.
+- Some functions like `CharClassifier::classify` provide minimal functional code instead of pure stubs.
+- The project contains an example (`examples/ascii_demo.cpp`) that prints a static message using `CharDisplay`.
+- Previous reports document consolidation of older experiments and the creation of stub frameworks. Files such as `archive/combined.cpp` are archived while `main.cpp` runs a basic stubbed renderer.
+
+## Analysis
+The project is well organised with clear instructions not to modify header comments and to expand stubs carefully. Each class outlines responsibilities and TODO lists, providing good guidance for future implementations. Many methods remain unimplemented, but the scaffolding compiles. Some duplication exists, like duplicate `getFullBuffer` definitions in `CharDisplay.cpp`, hinting at leftover boilerplate.
+
+## Recommendations
+- Remove duplicate or empty methods to keep stubs tidy.
+- Document which stubs are highest priority in `todo/` to aid future contributors.
+- Consider committing the `eigen` submodule or documenting build steps requiring it.
+
+## Prompt History
+```
+System: You are ChatGPT, a large language model trained by OpenAI.
+Developer: always check the files in the repo ecosystem for your benefit... EXPLORE. LEARN.
+User: without making changes, write a detailed experience report audit on the state of the asciioscilliscope project in project focus, guidance, and completeness of structure and stubbing
+```


### PR DESCRIPTION
## Summary
- document current state of asciioscilliscope stubs and guidance

## Testing
- `python AGENTS/validate_guestbook.py`
- `python testing/test_hub.py` *(fails: Environment not initialized)*

------
https://chatgpt.com/codex/tasks/task_e_6857512ee080832a88f380db97f96614