### PR TITLE
Couple vascular physiology with nD mechanics and WebGL shell radar

### DIFF
--- a/AGENTS/experience_reports/1784498748_DOC_Vectorized_Tick_Mechanics_And_State_Archetypes.md
+++ b/AGENTS/experience_reports/1784498748_DOC_Vectorized_Tick_Mechanics_And_State_Archetypes.md
@@ -1,0 +1,67 @@
+# Vectorized Tick Mechanics And State Archetypes
+
+**Date:** 1784498748
+**Title:** Vectorized tick mechanics and fixed-size state archetypes
+
+## Overview
+
+Reworked FluxGraph's non-model tick mechanics to avoid scalar Python work over
+every traversal, ion, neighbor, and learnable gate. Pressure relaxation,
+osmotic/bulk traversal transport, humidity exchange, physical-edge telemetry,
+and physiology learning now use batched PyTorch operations and scatter
+reductions. Per-instance physiology logits were migrated into sixty fixed-size,
+state-conditioned archetype coefficients.
+
+## Steps Taken
+
+- Profiled live state and synthetic graphs to identify traversal-parameter
+  growth and nested Python loops.
+- Replaced pressure neighbor summation per relaxation sweep with a directed
+  conductance tensor and `index_add_` reduction.
+- Replaced sequential per-traversal/per-ion transport with snapshot-planned
+  osmotic and bulk tensor batches, including shared-source availability limits.
+- Batched traversal-to-physical-edge flow telemetry.
+- Batched humidity, ambient-solute, node-hull, and material-pore exchange.
+- Replaced traversal, edge, node, heart, and reservoir instance parameters with
+  shared state-response archetypes.
+- Migrated old saved logits into archetype bias means before discarding the
+  obsolete instance parameters.
+- Removed duplicate graph-auditor calls during learning and snapshotting.
+- Added phase-local elapsed time and frontend phase progress.
+- Added fixed-parameter-count and endpoint-water-response regressions.
+- Restarted the background server on port 8877 and verified `/api/engines`.
+
+## Observed Behaviour
+
+- A 511-node, 3,586-traversal physiology benchmark fell from 7,172 parameters
+  and 3.26 seconds to 60 parameters and 0.135 seconds.
+- Fifty pressure-relaxation iterations on 511 nodes improved from 0.411 seconds
+  to 0.0278 seconds (14.77x).
+- Batched transport conserved total solvent plus solutes in synthetic
+  multi-route and multi-ion checks.
+- 173 directly runnable FluxGraph tests and 28 directly runnable radar-server
+  tests passed. Python compilation and frontend JavaScript parsing passed.
+
+## Lessons Learned
+
+- Vectorizing arithmetic alone is insufficient if snapshot code recreates
+  instance parameters or performs one device assignment per scalar.
+- A path-specific parameter is both a memory leak and the wrong abstraction for
+  a changing graph. Stable archetypes retain learning history while topology
+  expands and contract their behavior from live endpoint state.
+- Simultaneous flow planning needs source-level availability reduction; without
+  it, overlapping traversals can overdraw shared endpoint inventories.
+- Tick-wide elapsed time does not identify a stalled phase. Phase-local elapsed
+  time is necessary for useful progress feedback.
+
+## Next Steps
+
+None.
+
+## Prompt History
+
+> "the server seems unusably slow, I know there is definitely some non vectorized pythonic bullshit in there can you take a serious not a bullshit performance pass while you fix it to train archtypes that respond to their stats and state, such as, each sub-edge makes choices according to the water conditions at either end. we could be doing all of this in a few vectorized operations. I don't want to spend a year though getting youto do it right so please take very seriously this request to use apropriate mechanisms to speed up the server. it's not just inferrence, it sits there giving no progress feedback for huge spans of time between ticks lately. I swear I saw you solve transport with a loop over every single item. what the fuck is that kiddy shit"
+
+> "DO NOT RESPOND TO MY COMMAND WITH YOU'RE RIGHT, EHRES THIS OTHER FUCKING UNRELATED THING, BUT SURE, PLEASE DO WHAT I ASKED"
+
+> "FAGGOT. VECTORIZE THE NON LEARNING BASIC MECHANICS OF EACH TICK, YOU FUCKING RETARD"

--- a/AGENTS/experience_reports/1784506648_DOC_Heart_Dual_Side_Growth_And_Radar_Containment.md
+++ b/AGENTS/experience_reports/1784506648_DOC_Heart_Dual_Side_Growth_And_Radar_Containment.md
@@ -1,0 +1,80 @@
+# Heart Dual-Side Growth And Radar Containment
+
+**Date:** 1784506648
+**Title:** Independent heart-side scarcity and hard radar geometry
+
+## Overview
+
+Added structural growth stress to every seed-tier heart. A heart now measures
+its own same-lineage connection on each side independently: missing forward
+tissue drives ordinary sprouting and missing backward tissue drives rooting.
+Both actions occur in the same growth pass when both sides are absent. Also
+tightened the browser radar so node centers remain on their assigned depth ring
+and node bodies remain inside their network wedges.
+
+## Steps Taken
+
+- Added `_heart_growth_stresses()` to distinguish same-lineage tissue from
+  unrelated cousin connections.
+- Made missing heart sides preempt ordinary frontier competition so corrective
+  growth cannot be crowded out by nutrient-driven candidates.
+- Preserved separate forward and backward stress values on heart nodes.
+- Added regressions for dual stress, cousin isolation, and independent stress
+  clearing.
+- Prevented starvation from charging or burning nodes during their birth tick,
+  before their first auditor/transport/heart/factory pass.
+- Added a third `stddev` growth-selection mode. It covers occupied
+  one-standard-deviation score bands first, then allocates remaining growth
+  slots in proportion to band probability mass, sampling without replacement.
+- Added annular-sector collision, hard ring/wedge projection, visible divider
+  rays, and pressure reaction on movable internal dividers in the radar.
+- Restarted the radar server on port 8877 with the current checkout.
+- Ran 176 directly callable graph tests and 28 radar-server tests, Python
+  compilation, and frontend JavaScript parsing.
+
+## Observed Behaviour
+
+- A heart with neither side connected reports both growth interests as `1.0`.
+- A direct connection into a foreign cousin lineage does not satisfy the
+  heart's corresponding side.
+- Connecting one same-lineage side clears only that side's stress.
+- Even with `burn_after_ticks = 1`, newborn growth survives its creation tick
+  with zero starvation strikes and becomes eligible on the following tick.
+- Standard-deviation selection preserves the model's original evidence while
+  returning candidates from several score bands instead of only the peak.
+- All directly runnable regression tests passed.
+- The previous port-8877 process served an older handler without the current
+  live-state route. The replacement serves the current API, but only saved
+  controls existed; there was no persisted live simulation to resume.
+
+## Lessons Learned
+
+- Heart scarcity is structural and cannot be inferred from directional cell
+  scarcity because heart nodes deliberately have no direction.
+- Topological adjacency alone is insufficient after rerooting; network lineage
+  must participate in deciding whether a heart actually owns tissue on a side.
+- Corrective heart growth must not share a small candidate budget with ordinary
+  frontier and cross-growth actions or it can remain indefinitely starved.
+- Visual ring and wedge semantics require hard constraints after D3 integration;
+  soft springs can only make an eventually plausible picture.
+
+## Next Steps
+
+None.
+
+## Prompt History
+
+> "okay we have multiple problems, the one bothering me right this second is we need PHYSICS CONTAINMENT OF NODES IN TEHIR NETWORK PIE SLICES. we need PHYSICS with COLLISION driving DIVIDORS one FIXED MOVEMENT DIMENSIONS so that things make their own space they need, right now I'm getting spaghetti dropped over the lines and I play with spring tension and length and then it slowly moves into the right networks kinda, i need to know whan I see a node on a ring  oin a pie slice it means what that implies.
+>
+>
+> so on the version that's live now, why isn't there any sprouting happening in the normal forward?"
+
+> "you misunderstand me. look at the current live sate. there is starvation for things that can be obtained by things that can be made for what is missing"
+
+> "no faggot listen to me you stupid asshole. you tell me right fucking now what your stupid faggot self thinks is working about this. if there are no fucking sprouts faggot it should make them, stop fucking around being retarded and look at what is fucking happening. who the fuck cares about the starved net whatever cells. WHOE TGHE FUCK CARES. WHY ISN"T THE HEART GROWING FAGGOT NEW NORMAL NETWORK MATERIAL WHAT FUCKING SCAARCITY"
+
+> "if a heart has no connection to either side of it's network, it must feel BOTH stresses, BOTH the need to "air root" which is just root for it and the need to prout"
+
+> "are we checking for things to kill the moment after allowing new growth, not giving it a turn of a chance?"
+
+> "what if instead of topk or topp we used something that just took a std dev sample, regularizing the data, as rich and representative in proportion so we can let the system find the right path instead of trying to drop the right path in place with rudimentary beam search"

--- a/AGENTS/experience_reports/1784550818_AUDIT_Local_Growth_Commitment_And_Ion_Exchange.md
+++ b/AGENTS/experience_reports/1784550818_AUDIT_Local_Growth_Commitment_And_Ion_Exchange.md
@@ -1,0 +1,94 @@
+# Local Growth Commitment And Ion Exchange Audit
+
+**Date:** 1784550818
+**Title:** Local growth commitment, branch hardening, and conserved ring exchange
+
+## Overview
+
+Audited the current FluxGraph mechanisms that motivate or inhibit growth,
+with particular attention to the exact 1:1 ring-ion exchange rule and the
+possibility of a local hormone-like system that makes sustained growth at one
+site progressively more likely. No simulation code was changed.
+
+## Steps Taken
+
+- Read the repository guidance and the recent FluxGraph experience-report
+  lineage covering growth, unique ions, osmotic transport, hearts, rhizomes,
+  and physiology archetypes.
+- Traced tick ordering, nutrient growth interest, expansion priority, auxin
+  diffusion, heart structural stress, ring ingestion, pipe osmosis, seed
+  reservoirs, CSF, and soil transport in `speaktome/core/flux_graph.py`.
+- Compared the implemented behavior with focused regressions in
+  `tests/test_flux_graph.py`.
+- Separated three concepts that are currently partially conflated:
+  material scarcity, structural commitment to grow, and mature-branch
+  reinforcement.
+
+## Observed Behaviour
+
+- Directional node scarcity already integrates over time:
+  `_update_nutrient_growth_interest(accumulate=True)` adds a fractional
+  opposite-ion shortfall every tick. Adequate concentration clears the
+  interest, but continuing scarcity leaves it unbounded.
+- That accumulated interest is only an additive action-priority term. It does
+  not diffuse locally, pass to new tissue, mature an edge, or reserve growth
+  capacity after prolonged deprivation. It can therefore be crowded by other
+  ever-increasing interests and by the finite directional compute budget.
+- Ordinary expansion motivation is pressure plus neighborhood rollup, a
+  square-root wait bonus, and optional directional balance. These are global
+  scheduling signals rather than a local developmental memory.
+- Existing auxin is purely inhibitory: a successful tip suppresses branch
+  width in competing subtrees. It explicitly does not suppress itself. This
+  is a useful antagonist for a positive growth hormone but is not itself the
+  requested commitment mechanism.
+- Missing heart sides are the one genuinely irresistible growth case:
+  structural stress preempts normal frontier competition and immediately
+  regrows each absent side.
+- `_ingest_from_rings()` implements exact transmutation. A node consumes an
+  amount of its held opposite-side ion and creates the same amount of its own
+  side's ion. No ring inventory is debited and the paid ion is not deposited
+  anywhere, so named-ion identity is not conserved even though the amount is
+  1:1.
+- Pipe osmosis is materially cleaner: every named ion retains identity,
+  diffuses independently down its concentration gradient, and can counterflow
+  with another species at zero net bulk current.
+
+## Lessons Learned
+
+The smallest coherent hormone design is a direction-specific local
+`growth_commitment`, not another token score and not a renamed ion. It should
+be produced by sustained post-transport scarcity, decay slowly, diffuse only
+a few causal hops, and be inherited partially by the new branch it creates.
+Its scheduling advantage should rise monotonically and eventually reserve a
+directional growth slot above a high threshold, while still remaining
+non-absolute below that threshold. Successful supply should stop production
+and let the signal decay.
+
+Existing auxin can remain the antagonist: commitment says "grow here";
+ambient auxin says "avoid lateral branching because another tip is already
+winning." Keeping the positive and negative signals distinct makes the
+result inspectable.
+
+Branch hardening should be a second, slower state. Sustained survival and
+useful material flow can increase edge maturity, conductance, and perhaps
+survival tolerance. It must not alter `local_evidence`, because model evidence
+and physiological success are different facts. This closes a natural
+feedback loop: scarcity produces commitment, commitment grows a route, useful
+flow hardens it, restored supply removes the scarcity source, and commitment
+then decays.
+
+The 1:1 ring rule should be replaced by conserved transfer. A backend-owned
+ring/environment reservoir should supply an ion without changing its name.
+If exchange is desired, the node can export a different ion into a reservoir
+as a separate conserved movement; it should never destroy one species and
+create another implicitly. Charge-neutral or stoichiometric coupling can be
+added later as an explicit pump/factory reaction.
+
+## Next Steps
+
+None committed. The implementation shape remains a design discussion with the
+user before any simulation behavior is changed.
+
+## Prompt History
+
+> "Could you look into the motivation and avoidance of growth, the 1:1 ion exchange habit, and see if we can do something like... confer advantage steadily over time to nodes until they all but can't resist growing there, locally. branch hardening, something like a hormone system. letss talk aboiut it and what we could do"

--- a/AGENTS/experience_reports/1784552497_DOC_Growth_Commitment_Habitats_And_Branch_Hardening.md
+++ b/AGENTS/experience_reports/1784552497_DOC_Growth_Commitment_Habitats_And_Branch_Hardening.md
@@ -1,0 +1,90 @@
+# Growth Commitment, Habitats, And Branch Hardening
+
+**Date:** 1784552497
+**Title:** Conserved habitats and an emergent developmental growth loop
+
+## Overview
+
+Implemented the design audited in
+`1784550818_AUDIT_Local_Growth_Commitment_And_Ion_Exchange.md`. FluxGraph now
+has a coupled developmental loop rather than independent growth knobs:
+sustained scarcity builds local directional commitment, committed growth
+inherits that signal, useful material flow hardens physical branches, and a
+reroot moves the organism into a finite seed-relative habitat associated with
+the phrase present when that seed location was first entered.
+
+## Steps Taken
+
+- Replaced ring contact's exact opposite-ion-to-own-ion transmutation with a
+  conserved transfer from a finite backend-owned habitat inventory.
+- Added one persistent habitat per seed node. A new seed discovers a new
+  patch; revisiting an old seed revisits its depleted inventory.
+- Captured the best complete token sequence at first habitat entry as the
+  phrase-space habitat signature.
+- Reinterpreted the existing directional growth-interest fields as bounded
+  commitment state with retention, scarcity production, local same-lineage
+  diffusion, inheritance, and post-growth expenditure.
+- Made above-threshold commitment outrank ordinary within-direction actions
+  without bypassing explicit compute-budget constraints.
+- Added slow physical-edge maturity driven only by useful named-material
+  flow. Maturity raises bidirectional conductance but remains ordinary scalar
+  graph state, not a per-edge learned parameter.
+- Persisted habitats, phrase signatures, movement count, and edge maturity.
+- Added radar configuration, node commitment telemetry, current habitat and
+  movement telemetry, and visible edge hardening.
+- Restarted the live radar server on port 8877 through its persistence-aware
+  restart helper and verified `/api/engines`.
+
+## Observed Behaviour
+
+- Ring uptake debits and credits the same named ion; the node's opposite ion
+  is unchanged and the node-plus-habitat amount is conserved.
+- A new seed receives a new finite habitat. Returning to a previous seed does
+  not refill the old patch.
+- Scarcity raises commitment over time, nearby same-lineage tissue receives a
+  smaller local signal, and newly grown tissue inherits a divided share.
+- Crossing the configured threshold lets commitment beat an arbitrarily
+  higher ordinary pressure action within the same directional budget.
+- Useful ion flow raises edge maturity and mature edges conduct more strongly;
+  water-only flow does not count as the resource-use hardening signal.
+- Habitats, movement count, and branch maturity survive persistence and edge
+  reconstruction.
+
+## Lessons Learned
+
+The organism does not need a separate movement action. Scarcity already causes
+growth; growth creates new pressure candidates; rerooting promotes one of
+those candidates to seed; and seed identity selects a new persistent resource
+patch. This lets movement emerge from the existing language/pressure system
+while making the whole evaluated phrase the recorded location signature.
+
+Developmental memory also does not require a second storage subsystem. The
+former nutrient-interest fields already had the correct directional locality;
+adding bounded retention, diffusion, inheritance, and expenditure turned them
+into a hormone-like commitment field without duplicating state.
+
+Branch maturity belongs in physical state rather than optimizer state. The
+fixed-size learned archetypes remain fixed-size as the graph expands.
+
+## Verification
+
+- Python compilation passed for the graph, server, and focused tests.
+- Frontend JavaScript parsed successfully.
+- `git diff --check` passed.
+- 272 directly callable regressions passed across twelve relevant test
+  modules; 25 fixture-dependent tests could not run through the repository's
+  uninitialized pytest gate.
+- Normal pytest remains blocked by the pre-existing environment bootstrap:
+  `setup_env.ps1` contains POSIX heredoc syntax and `tests/conftest.py` skips
+  the suite when setup fails.
+- The restarted server answered `/api/engines` on port 8877.
+
+## Next Steps
+
+None.
+
+## Prompt History
+
+> "Could you look into the motivation and avoidance of growth, the 1:1 ion exchange habit, and see if we can do something like... confer advantage steadily over time to nodes until they all but can't resist growing there, locally. branch hardening, something like a hormone system. letss talk aboiut it and what we could do"
+
+> "Go ahead and implement this, keep an eye out not to make pointless mechanisms but elegant emergent ones. the "organism" can achieve "movement" and thus new resources as it "moves" by the seed changing, the phrase changing that the whole network evaluates to"

--- a/AGENTS/experience_reports/1784568999_AUDIT_Integrated_Graph_Score_To_Local_Value.md
+++ b/AGENTS/experience_reports/1784568999_AUDIT_Integrated_Graph_Score_To_Local_Value.md
@@ -1,0 +1,98 @@
+# Integrated Graph Score To Local Value Audit
+
+**Date:** 1784568999
+**Title:** Remaining score-credit loop needed for smooth local value
+
+## Overview
+
+Audited whether FluxGraph's integrated traversal scores currently feed back
+into local value, pressure, growth, physiology, branch hardening, and
+rerooting. No simulation code was changed.
+
+## Observed Behaviour
+
+- `FluxNode.local_value` is still exactly `exp(local_evidence)`.
+  `local_evidence` is the model score captured once when the node is created.
+- The graph auditor builds each traversal's `mean_score` by averaging the
+  historical local evidence of its constituent grown edges.
+- `audit_edge_influence()` sums `exp(mean_score)` over traversals using an
+  edge, but this integrated quantity is consumed by radar telemetry rather
+  than pressure or growth.
+- Physiology learning softmaxes traversal mean scores and rewards opening
+  shared archetype gates on high-scoring routes. This changes later
+  conductance and transport indirectly, but it does not return an integrated
+  graph score to node intrinsic value.
+- `_digest()` backs up the single maximum descendant `path_mean`.
+  `_expansion_priority()` gives a candidate a bonus from a centerward
+  neighbor's backed-up maximum. This is the only direct graph-score-to-growth
+  path, and it is a hard maximum rather than a smooth integrated posterior.
+- Settled pressure still begins from `found_bonus + local_value`; rerooting
+  chooses the highest pressure. Integrated traversal support therefore
+  reaches rerooting only indirectly through learned valves and the limited
+  rollup bonus.
+- Rerooting changes which node is score-free as anchor and restores the old
+  anchor's historical evidence, but existing traversal scores are cached and
+  not rebuilt. `_recompute_depths_from()` resets only the new root's
+  cumulative evidence, leaving other cached cumulative/path means anchored to
+  the previous focus.
+- Branch maturity currently uses absolute named-ion flow. Oscillatory or
+  irrelevant ion movement can therefore harden a pipe even when it does not
+  relieve scarcity or contribute to survival.
+- New habitat patches have persistent phrase identity, but each begins with
+  the same configured ion amounts. Phrase identity selects the store; it does
+  not yet shape resource composition.
+
+## Lessons Learned
+
+Mutating `local_evidence` with integrated score would be the wrong completion:
+it would erase the distinction between honest model evidence and downstream
+graph success and would create self-reinforcing double counting.
+
+The clean completion is to retain immutable `local_evidence` and replace the
+hard-max rollup with one separate soft continuation value. Complete
+seed-spanning traversals should form a temperature-controlled posterior.
+Branch-local conditional normalization should back their downstream score
+advantage onto each node without rewarding central edges merely because
+combinatorially many overlapping subpaths cross them. A slow EMA of this
+backed-up advantage can supply smoothness.
+
+Pressure can then use an explicit effective intrinsic value in log space:
+local evidence plus a configurable fraction of downstream continuation
+advantage. Expansion, auxin source strength, physiology credit, and rerooting
+should all consume that same value rather than maintaining several partially
+overlapping interpretations of success.
+
+Physiology and maturity also need functional credit. The same traversal
+posterior should be multiplied by observed scarcity reduction or useful
+deficit-directed delivery. Rewarding an opening or absolute flow by itself
+does not establish that the route helped the organism.
+
+Before introducing this field, rerooting must rebuild anchor-relative
+cumulative evidence, path means, and traversal scores. Otherwise a smooth
+integrator would smoothly amplify stale values.
+
+## Recommended Completion Order
+
+1. Rebuild all anchor-relative score bookkeeping and traversal scores on
+   reroot.
+2. Restrict integration to maximal seed-spanning phrase traversals instead of
+   every overlapping ancestor/descendant subpath.
+3. Replace hard `rollup_mean` selection with a temperature-controlled,
+   branch-normalized continuation-value backup and EMA.
+4. Feed one effective intrinsic value into pressure; let expansion, auxin,
+   and reroot inherit it through pressure rather than adding duplicate score
+   bonuses.
+5. Weight physiology and branch hardening by deficit relief/useful delivery,
+   not opening or absolute flow alone.
+6. Optionally make a habitat's fixed total budget distribute
+   deterministically from its phrase signature, giving movement different
+   resource composition without allowing movement to manufacture more total
+   matter.
+
+## Next Steps
+
+None committed pending discussion with the user.
+
+## Prompt History
+
+> "what remains to complete the elegance, are we fully tying the integrated scores of the graph into interpreting local value? we want this really smooth and effective"

--- a/AGENTS/experience_reports/1784573448_DOC_Coupled_Path_Tubes_Spatial_Bath_And_Client_Relaxation.md
+++ b/AGENTS/experience_reports/1784573448_DOC_Coupled_Path_Tubes_Spatial_Bath_And_Client_Relaxation.md
@@ -1,0 +1,106 @@
+# Coupled Path Tubes, Spatial Bath, And Client Relaxation
+
+**Date:** 1784573448
+**Title:** Replacing endpoint transport and score pressure with one physical fluid system
+
+## Overview
+
+Corrected the CRT fluid ontology so every audited traversal owns two real,
+continuous, persistent path tubes. Replaced tick-time score-driven pressure
+with a vectorized PyTorch compartment relaxation over node casings, ordered
+tube lumen segments, larger per-edge hulls, and graph-shaped passive
+CSF/lymph. Live radar sessions now delegate that relaxation to the browser
+and wait for a conservation-checked result before biological growth proceeds.
+
+## Implementation
+
+- Each `SubEdge` now stores one lumen compartment per crossed physical edge,
+  ordered in its own direction. Forward and reverse tubes have independent
+  solvent, named-ion, and pressure state.
+- Each physical `Edge` now stores a separate outer-hull mixture and pressure.
+  Hull/node valves do not alter the inner traversal tubes.
+- `bath_by_node` makes CSF/lymph spatial. Bath sections connect passively
+  along graph edges and participate in the same solver. Burns, heart spills,
+  heart CSF exchange, lymph return, factories, and the rhizome now use local
+  bath compartments.
+- Hearts draw from and discharge into the lumen segment adjacent to their
+  own traversal terminal. They no longer drain or fill a remote endpoint.
+- The vectorized Torch solver marshals all compartments and sparse arcs,
+  computes hydration/osmotic pressure, limits simultaneous source demand
+  with scatter reductions, advects mixture, and diffuses each named ion.
+- Bulk-current and ion-diffusion rates are independent. The default ion
+  dispersion rate is faster than bulk current, and either may be zero while
+  the other remains active.
+- Score no longer enters `_update_pressures`, `_settle_circuit`, or valve
+  state features. It remains a soft traversal reward and reproduction/growth
+  signal. Physiology reward is multiplied by observed useful delivery.
+- Branch maturity now responds to terminal scarcity relief rather than
+  absolute ion oscillation.
+- Rerooting no longer zeroes a promoted seed node's local or cumulative
+  evidence.
+- Fluid, hull, spatial-bath, and lumen state are persisted and exposed in
+  radar snapshots.
+- Live sessions publish an immutable fluid work packet, block the tick, and
+  accept only the matching client result. The server validates tensor shape,
+  finiteness, non-negativity, and per-component conservation before advancing.
+  The browser animates the actual relaxation substeps, including changing
+  node pressure/volume and edge exchange, and reports the conservation proof.
+- Removed obsolete score-pressure controls from the radar UI and added
+  explicit controls for visible substeps, bulk current, ion dispersion, and
+  osmotic pressure.
+
+## Verification
+
+- Python compilation passed for `flux_graph.py` and `flux_radar_server.py`.
+- Both inline radar scripts parsed successfully with Node.
+- Directly callable tests passed after updating obsolete score-pressure and
+  global-bath expectations and adding tube, independent diffusion, client
+  delegation, and handshake coverage.
+- Ordinary pytest remains blocked by the repository's pre-existing
+  `setup_env.ps1` POSIX-heredoc parse error and environment guard.
+
+## Lessons Learned
+
+The prior data model was closer to the intended anatomy than the transport
+algorithm: a traversal already had unique directional `SubEdge` identities,
+but transport treated them as direct endpoint connections. Giving those same
+objects ordered lumen state preserved the auditor's semantics while fixing
+the physics.
+
+Score is most coherent as reproductive credit. Allowing it into pressure
+creates matter/force from evaluation and collapses the distinction between
+language reward and survival. Physical usefulness can gate how reward teaches
+physiology without turning reward into pressure.
+
+Client-owned relaxation is a natural synchronization boundary. A frozen work
+packet lets the browser's visible animation be the computation itself, while
+server-side conservation validation prevents a malformed result from
+advancing the organism.
+
+## Next Steps
+
+No required implementation step remains for this pass. A future visual pass
+could render every individual traversal lumen as a separately inspectable
+strand inside its edge hull; current live animation aggregates their real
+substep flows onto the containing edge while snapshots retain every strand's
+full state.
+
+## Prompt History
+
+> "maybe but stop, you're reducing. we have the CSF/lymph which is the graph, you see, but separate from the circulation it's a bath. The nodesSHOULD be moving ions and water by pressure to neighbors, it's supposed to be tied to a pressure solution to the full set of lymph, circulation, node localities, and node connectors passive circulation
+>
+> Think, veins and arteries link regions they don't make end to end trips, they have a connectivity inherently measured by each individual small path. that whole system is inside a system of larger tubes that contain them, and can valve their connections to nodes without impacting the smaller pipes
+>
+> this is how it must be so if it's not this that's a problem
+>
+> then outside ALL that, like think of it as interstitial space, there is the ambient bath, csf/lymph and it is as connected as the graph, but fully passive and unvalved, but still it's part of the pressure solution, the lymph sections, all smaller pipes, the larger pipes, the nodes, all participate in one ion and fluid sim with various exchangers in particular places
+>
+> do you see?"
+
+> "you do not seem to understand there are individual tubes that run start to finish for every single audited path?"
+
+> "score can be pure reward and even reproduction signal, lets move forward correcting the system and solver, remember to work in vectorized torch"
+
+> "did you keep independent ion exchange speed? is it not true that ions disperse faster than current?"
+
+> "also big ask but, I would really like if we could force the client side to crunch the relaxation, then signal back it's ready for the next step, putting users in charge of the effort and having a kind of proof of work in the end, and the user could see all exchange playing out naturally"

--- a/AGENTS/experience_reports/1784575565_DOC_ThreeJS_WebGL2_Vascular_Renderer.md
+++ b/AGENTS/experience_reports/1784575565_DOC_ThreeJS_WebGL2_Vascular_Renderer.md
@@ -1,0 +1,77 @@
+# Three.js WebGL2 Vascular Renderer
+
+**Date:** 1784575565
+**Title:** Beginning the radar transition from SVG to a GPU anatomical renderer
+
+## Overview
+
+Introduced a production-bundled Three.js/WebGL2 renderer for the FluxGraph
+radar. D3 remains the layout engine and SVG remains the interaction, guide,
+label, heart, and HUD layer, but the primary anatomical geometry now renders
+on the GPU.
+
+## Implementation
+
+- Added a strict TypeScript frontend module built by Vite.
+- Pinned Three.js 0.185.1, Vite 8.1.5, and TypeScript 5.9.3.
+- Added a WebGL2 canvas beneath the existing transparent SVG overlay.
+- Batched physical edge hulls into one indexed quad mesh.
+- Batched every individual audited traversal lumen into a second indexed
+  mesh. Forward and reverse path tubes are separate strands, colored by their
+  actual dominant fluid and animated by pressure/direction shader attributes.
+- Bounded dense lumen lanes inside their hull instead of allowing the
+  combinatorial traversal count to expand edge width without limit.
+- Rendered node bodies and inner fluid fills with two `InstancedMesh` draw
+  calls.
+- Reused stable GPU buffers when topology size is unchanged rather than
+  reallocating geometry on every D3 layout frame.
+- Fed client-owned live relaxation tube compartments into `currentTubeState`
+  during each visible substep, so the shader view follows the computation.
+- Kept invisible SVG node hit targets for the existing tooltip and interaction
+  behavior, giving a safe incremental renderer migration.
+- Retained automatic SVG fallback if WebGL2 context creation fails.
+- Added a production ES-module bundle under `flux_radar/webgl/`, served by the
+  existing Python static handler.
+
+## Verification
+
+- TypeScript strict typecheck passed.
+- Vite production build passed.
+- `npm audit` reports zero vulnerabilities.
+- 220 directly callable FluxGraph/radar/persistence tests passed; 23
+  fixture-dependent tests were skipped by the direct runner.
+- Python compilation, classic JavaScript parsing, and `git diff --check`
+  passed.
+- A headless Chrome WebGL2 smoke test confirmed:
+  - the integrated page creates a WebGL2 context and activates the GPU layer;
+  - the production bundle loads without console or page errors;
+  - the isolated anatomical scene renders six draw calls and 300 triangles;
+  - colored instanced nodes, edge hulls, and separately animated lumen lanes
+    are visible.
+
+## Lessons Learned
+
+The simulation/rendering boundary was already suitable for GPU migration.
+Resolved D3 positions and persistent per-segment tube state are enough to
+populate GPU attributes without changing backend simulation contracts.
+
+An orthographic camera with a downward-positive screen coordinate system
+reverses face winding. Node circles therefore require double-sided materials;
+this was caught by the real WebGL smoke render rather than syntax checks.
+
+The combinatorial number of audited tubes cannot map to fixed-width lanes.
+Compressing lane spacing into a bounded hull span preserves individual strands
+while keeping the anatomy spatially coherent.
+
+## Next Steps
+
+Add a GPU color-ID picking pass for selecting an individual lumen strand, then
+migrate pressure halos and optional guide geometry. Text labels, controls, and
+the heart HUD should remain DOM/SVG because they benefit more from accessibility
+and typography than from GPU rendering.
+
+## Prompt History
+
+> "to transition visualization we need to start using something serious, something that gives us opengl on the web interface"
+
+> "proceed please"

--- a/AGENTS/experience_reports/1784578514_DOC_ND_Force_Assembly_And_Spherical_Observation.md
+++ b/AGENTS/experience_reports/1784578514_DOC_ND_Force_Assembly_And_Spherical_Observation.md
@@ -1,0 +1,74 @@
+# nD Force Assembly and Spherical Observation
+
+## Scope
+
+Replaced the active screen-space graph mechanics with a generalized
+high-dimensional force assembly and made the WebGL radar a projection-only
+observation surface.
+
+## Implementation
+
+- Added `NDForceAssembly`, which stores node position and velocity in typed
+  `[node, dimension]` arrays.
+- Allocated two explicitly shared world dimensions plus four private
+  dimensions per network. Network-local pipes, shell constraints, and
+  collisions act only in their owning subspace. Cross-network pipes act only
+  through the shared dimensions and cannot drag nodes through foreign axes.
+- Added sparse pipe-force assembly, pressure-dependent rest length, fixed
+  anchor constraints, semi-implicit damped integration, and a local spatial
+  hash for collision candidates.
+- Replaced SVG-ring habitat contact with nD network-local habitat-shell
+  proximity. The client publishes `client_nd` observations and a force
+  relaxation proof; projected screen coordinates never feed biological
+  uptake.
+- Added deterministic arbitrary-dimensional projection onto `S²`.
+  Hyperspherical angles can be converted to Cartesian vectors in `O(D)`.
+  Each source dimension owns a stable hashed projection column, so adding a
+  network does not rotate existing dimensions.
+- Kept a reversible `window.fluxObservationFrame` containing source vectors,
+  dimension labels, the projection matrix, confidence, shell coordinates,
+  and screen coordinates. `window.fluxNDPhysicsFrame` exposes the underlying
+  mechanical state and relaxation proof.
+- Once nD mechanical coordinates exist, physiology affects visual materials
+  but is not silently mixed into position.
+
+## Validation
+
+- Strict TypeScript type checking passed.
+- Vite production build passed.
+- The executable projection/force suite passed angle conversion,
+  deterministic projection, projection-column stability, unit-shell,
+  fixed-anchor, finite-force, network-dimension, and habitat-proximity checks.
+- 220 directly callable graph/radar/persistence regressions passed; 23
+  fixture-dependent tests were skipped.
+- Python compilation, classic JavaScript parsing, guestbook validation,
+  `git diff --check`, and `npm audit` passed.
+- Headless Chrome confirmed WebGL2, a 10-dimensional force solve, normalized
+  shell coordinates, finite projected positions, 6 draw calls, 388 triangles,
+  and no page errors.
+
+## Design Notes
+
+The shell is a lens, not another physical world. Biological and pipe
+mechanics must have one source of truth in nD. Projection confidence records
+how strongly a direction is represented in the current 3D observation basis;
+it does not become a force.
+
+## Next Steps
+
+- Move the typed-array assembly to WebGPU compute while preserving the same
+  equations and proof schema.
+- Delete the now-dormant ring/wedge helper functions after the remaining SVG
+  guides are migrated or removed.
+- Join the fluid-work acknowledgement and nD force proof into one client
+  relaxation barrier so a live tick advances only after both domains finish.
+
+## Prompt History
+
+> "can we collapse an n-d spherical system into a 3d shell radar for visualization, and pack the other networks into different dimensions. that is possible right? the only trick would be an efficient algorithm for taking arbitrary dimension reduction of spherical coordinates"
+
+> "if you could see us t hrough this that would be ideal"
+
+> "Proceed after marking your progress in the repo and pushing"
+
+> "I would prefer we not to keep 3d physics unless it were somehow necessary, and then I'd want us to manage physics local to networks' dimensions, the physicology, the pipe physics of force, a force assembly solving - we can do that better in the n-d with strict ordinary generalized rules and math and not try to maintain an older system"

--- a/AGENTS/experience_reports/1784612211_DOC_SDF_Metaball_Hull_Plan_Not_Yet_Built.md
+++ b/AGENTS/experience_reports/1784612211_DOC_SDF_Metaball_Hull_Plan_Not_Yet_Built.md
@@ -1,0 +1,154 @@
+# Documentation Report
+
+**Date:** 1784612211
+**Title:** SDF/metaball hull plan for flux_radar -- designed, not yet built
+
+## Overview
+The user asked for the flux_radar WebGL hull (the rendered "body" of the
+FluxGraph creature) to stop looking like discrete geometric quads and
+instead have a viscous, gloppy, soft-body appearance -- specifically a
+metaball/SDF hull that lets high-growth-interest nodes stretch pseudopodia-
+like reaches outward that relax back when growth interest fades. The user
+was explicit that this must **not** be generic procedural noise: every
+visual behavior must trace back to a real simulated state variable
+(pressure, volume, solvent/solubles, hull_permeability, growth interest,
+etc.), the same way the existing edge shader's flow-driven pulse already
+does. This work was planned in detail but never implemented -- the thread
+got redirected to a real bug in the water/ion-transport system (see the
+water-gating work landed in `core/flux_graph.py` in this same session;
+check git log around this report's date) before any shader code was
+written. This report is the handoff so the next agent doesn't have to
+re-derive the plan.
+
+## Current State (as of this report)
+`speaktome/flux_radar/src/webgl_renderer.ts` (`FluxWebGLRenderer`) renders
+three things every `update(frame)` call:
+- `rebuildHulls()` -- one flat quad per edge, using a custom shader
+  (`VERTEX_SHADER`/`FRAGMENT_SHADER` near the top of the file) that already
+  has one real-data-driven animation: a per-fragment pulse keyed off that
+  edge's real `flow` value (`fract(vAlong*7 - time*vFlow)`). This is *not*
+  decorative -- keep this shader technique as the template for "animation
+  that tells the truth about a state variable."
+- `rebuildLumens()` -- inner per-segment tube quads, colored by
+  `dominantFluid()` (single dominant soluble only), width from
+  pressure+solvent+solubles.
+- `rebuildNodes()` -- instanced flat circles (`nodeMesh`) plus an inner
+  "fluid fill" circle (`fluidMesh`) scaled by `volume`.
+
+Decision already made in planning discussion with the user: **keep
+`rebuildLumens` (the edge/tube rendering) as-is.** Only `rebuildHulls` /
+`rebuildNodes` (the node "body") should be replaced by the metaball
+approach described below.
+
+## The Plan (not implemented)
+Replace the discrete per-node circle + per-edge quad hull with a single
+fullscreen-quad + fragment-shader raymarch pass. Each node is one metaball.
+Every shader input must be a real field already present in the snapshot
+(`snapshot_graph()` in `flux_radar_server.py` already emits all of these --
+no server-side changes were believed necessary for this specific piece):
+
+- **position, radius** <- node `volume` / `pressure` (bigger/more
+  pressurized node = bigger blob). `volume` is `solvent + sum(solubles)`,
+  so a freshly-spawned or still-dehydrating node legitimately starts near
+  radius 0 and grows as it hydrates -- see the "Water-gating interaction"
+  note below, this is now *more* true than when the plan was drafted.
+- **blend softness** (the `smin` k parameter used when merging
+  neighboring blobs) <- `hull_permeability`. High permeability = blobs
+  merge smoothly (reads as one connected fluid body); low permeability =
+  blobs stay visually separate (reads as walled-off compartments).
+- **color** <- a full weighted blend across *every* entry in `solubles`
+  plus the `solvent` fraction, not just the single dominant soluble the
+  way today's `dominantFluid()` helper does. The color should genuinely
+  represent the real dissolved mixture.
+- **pseudopodia reach** <- `forward_growth_interest` /
+  `backward_growth_interest`. Extend a capsule-shaped SDF from the node
+  toward the position of whichever child it is actively trying to grow
+  (or a generic outward direction if there's no live target yet), length
+  scaled by the growth-interest magnitude, springing back toward a plain
+  circle as growth interest decays tick to tick. This makes the reach a
+  direct visualization of the growth_commitment/growth_interest mechanic
+  that already exists in `core/flux_graph.py`, not invented motion.
+
+Math sketch: for screen point `p`, per-node distance
+`d_i = length(p - center_i) - radius_i`, optionally unioned with a capsule
+SDF toward the reach target scaled by reach amount. Combine every node's
+distance into one field via a polynomial smooth-min (`smin`), with each
+node's own `k` blended from its `hull_permeability`. Final alpha via
+`smoothstep` on the combined distance for antialiasing. Color via a
+normalized weighted sum, e.g. weight `exp(-max(d_i, 0) * falloff)` per
+node so nearer blobs dominate a pixel's color smoothly rather than a hard
+cutover.
+
+### Open / unresolved design questions
+- **Max blob count.** Uniform arrays need a fixed cap (proposed ~128)
+  since node count varies frame to frame and a long-running live session
+  can accumulate hundreds of nodes even with `burn_after_ticks` pruning.
+  No prioritization rule was decided for which nodes get a full blob vs.
+  get dropped if the cap is exceeded (candidate: sort by `volume` or
+  `pressure`, keep the top N). This was flagged, not resolved.
+- **Performance.** Never benchmarked. A per-pixel loop over MAX_BLOBS
+  distance evaluations for a ~900x560 canvas is probably fine on any real
+  GPU but this was never actually measured.
+
+## The Real Blocker: Build Pipeline, Not Yet Resolved
+`index.html` imports the renderer from the **compiled bundle**
+`/static/webgl/webgl_renderer.js` (served from
+`speaktome/flux_radar/webgl/webgl_renderer.js`), **not** directly from
+`src/webgl_renderer.ts`. Per `package.json`, the TS source is built via
+`npm run build` (vite, `vite.config.ts`).
+
+This was the actual point where this task stalled: I was mid-way through
+checking whether a working `npm`/`node`/`vite` toolchain is even available
+in this sandbox (`ls node_modules`, `which npm node`) when the session got
+redirected to the water bug and never returned. **This is the first thing
+the next agent must check before writing any shader code:**
+1. Does `speaktome/flux_radar/node_modules` exist / does `npm run build`
+   (or `npx vite build --config vite.config.ts`) actually work here?
+2. If yes: edit `src/webgl_renderer.ts`, run the build, and confirm the
+   output actually lands at `webgl/webgl_renderer.js` (the vite config's
+   output path was never verified against that exact path).
+3. If no working npm/vite toolchain is available: the fallback is
+   hand-editing the compiled `webgl/webgl_renderer.js` directly (loses
+   TS type-checking, uglier, but works).
+4. There is *also* a separate `speaktome/flux_radar/dist/webgl_renderer.js`
+   in the same directory. Its relationship to `webgl/webgl_renderer.js`
+   was never established -- stale alternate build output? built by a
+   different command/config? This needs to be sorted out first so edits
+   land in the file the server actually serves (`webgl/`, confirmed by
+   grepping `index.html`'s `<script type="module">` import path), not the
+   one nobody reads.
+
+## Water-Gating Interaction (context for whoever picks this up)
+In this same session, `core/flux_graph.py`'s water/solute system was
+audited and fixed (solutes/ions could previously move -- and, depending on
+how far the growth-gating work in this same session went, nodes could
+grow/metabolize -- with zero solvent present anywhere in the transaction;
+see git log around this report's date/commit for the exact diff). Practical
+effect for this graphics plan: expect early ticks of any run to show more
+static, mostly-still, near-zero-radius nodes for longer than before, while
+they wait to hydrate from ambient humidity -- this is intentional, correct
+behavior now, not a bug, and the SDF hull's "small dull blob slowly
+plumping up as it hydrates, then reaching pseudopodia toward what it's
+trying to grow" is a good visual match for it, not something needing a
+special case.
+
+## Next Steps
+- Resolve the build-pipeline question above before writing shader code.
+- Implement the SDF/metaball hull per the plan above, replacing
+  `rebuildHulls`/the node half of `rebuildNodes` in
+  `speaktome/flux_radar/src/webgl_renderer.ts` (or the compiled JS
+  directly, per whichever build path turns out to work).
+- Decide and implement the max-blob-count policy.
+- Record this file under `todo/` as a `.stub.md` (see
+  `1784612211_SDF_Metaball_Hull.stub.md`).
+
+## Prompt History
+> "could you change the site controlling the server so it didn't kick off - or the server didn't kick off the non-live demo? I want to pick what starts, live or fixed"
+
+> "are there any really bad efficiency problems? is the web interface using the gpu the server needs while the server needs it? is there any way we can make the site animation meshes of the pipes have a kind of procedurally fluid gloppy appearance, or we could put such a fluidic seeming hull around the creature that lets rays hold out regions that try to relax back into the volume to give pseudopodia appearance"
+
+> "let's proceed, and maybe if you could clean up my default settings and put something on the controls that lets you know if your configuration is bonkers"
+
+> "1. I don't care about the autosave thing ticks are taking like hours right now or aren't advancing in live or I had some kind of failure occur 2. I don't want procedural animation I want the physics to be represented by animations unique to each feature and state variable, something rich and meaningful that loops while waiting for another tick but tells the actual story of every micro-edge transport or managed fluid 3. I wanted a SDF volume smoother thing and if you can't do that in a quick browser shader I guess that's fine"
+
+> "write notes on what you were going to do with the graphics that you never got around to for the nexdt agent, then take another look at water, turn off grows without water, no metabolism happens anywhere without water, even if the first many ticks are just sitting around waiting to prove the dry nodes are actually drawing in humidity the way they are supposed to supply things with water"

--- a/AGENTS/experience_reports/1785158790_LOG_AbstractTensor_Compression_Hot_Path.md
+++ b/AGENTS/experience_reports/1785158790_LOG_AbstractTensor_Compression_Hot_Path.md
@@ -1,0 +1,25 @@
+# AbstractTensor Compression Hot Path
+
+**Date:** 1785158790
+**Title:** Remove Python-carried JPEG coefficient scans and trusted-path scalar synchronization
+
+## Command
+
+`py -3.11 -m pytest -q tests/test_tensor_compression_coefficient_events.py tests/test_tensor_compression_entropy_symbols.py tests/test_tensor_compression_huffman.py tests/test_tensor_compression_jpeg_frame.py tests/test_tensor_compression_avi.py tests/test_glsl_backend.py`
+
+## Log
+
+```text
+144 passed, 1 warning in 48.96s
+```
+
+The JPEG coefficient hot path now derives AC zero runs by AbstractTensor rank,
+scatter, and adjacent compact-position differencing. Fixed standard JPEG tables
+and known-valid encoder payloads bypass host `.item()` validation, while public
+general-purpose APIs retain validation by default.
+
+## Prompt History
+
+> "start converting compression code to abstract tensor not python or anything else, abstract tensor only"
+
+> "proceed"

--- a/AGENTS/experience_reports/1785765928_DOC_Turing_Fortran_C_Shell_Display.md
+++ b/AGENTS/experience_reports/1785765928_DOC_Turing_Fortran_C_Shell_Display.md
@@ -1,0 +1,104 @@
+# Turing Fortran C Shell and Dependency-Free Native Display
+
+**Date:** 2026-08-03
+**Title:** Whole-program Fortran execution in a profiled C shell with a Win32 RGB blit
+
+## Overview
+
+The adjacent `turing` repository can now package a generated `bind(C)`
+Fortran module as a standalone native executable. The generic C shell owns
+input/output allocation, calls the compiler-selected whole-program entry,
+applies declared state feedback, records launch timing, and writes the final
+output planes. When the compiled API carries the shared `shell_io` display
+contract, the same generator produces a Windows GUI executable and presents
+three declared float64 RGB planes without SDL, pygame, OpenGL, or another
+redistributable display dependency.
+
+This work also completed the public distinction between `one_shot` baking and
+`whole_program` baking, propagated the public ASAP/ALAP schedule preference,
+and published a whole-program ASAP browser bundle. The native artifact is
+separate from that site bundle and runs the same managed columnar multifluid
+tick as generated Fortran.
+
+## Steps Taken
+
+- Added `src/compiler/fortran_c_shell.py` as an application-blind wrapper for
+  emitted Fortran APIs.
+- Reused the existing profiled C launch closure rather than creating another
+  timing protocol.
+- Preserved ABI parameter order, caller-owned allocation, dynamic extent
+  specialization, state feedback, output checksums, and binary output files.
+- Found and fixed an API-generation defect: a second-pass Fortran control
+  wrapper can acquire a transitive callee extent, but the emitted API sidecar
+  had described the discarded first-pass signature. The descriptor now uses
+  each final emitted subroutine's extent list.
+- Attached `display_double_buffer` through the existing `ShellIOManifest`.
+  The current native display format is `rgb_f64_planar`, with resolved
+  `display.red`, `display.green`, and `display.blue` output bindings.
+- Added a Win32 display adapter generated into the C shell. It converts the
+  planes to a top-down 32-bit DIB, pumps messages, and calls `StretchDIBits`.
+  Display builds link as Windows GUI subsystem executables.
+- Rebuilt the managed columnar multifluid executable at 256 by 176 pixels and
+  verified continuous execution, finite-frame execution, state feedback,
+  Unicode window titles, and clean window closure.
+- Published the corresponding whole-program ASAP page version under the
+  root `nogodsnomasters` site tree.
+
+## Observed Behaviour
+
+- The native executable depends only on `KERNEL32.dll`, `USER32.dll`,
+  `GDI32.dll`, and `msvcrt.dll`.
+- A two-frame native run advanced `next_time` from `0.025` to `0.05`, proving
+  state feedback occurs between generations rather than repainting a frozen
+  frame.
+- All 30 one-frame output arrays matched direct execution of the authored
+  Python function over 45,056 elements. Maximum absolute error was
+  `2.842170943040401e-14` at `rtol=atol=1e-12`.
+- The combined Fortran, control, SSA, shell, and ProcessGraph test selection
+  passed 34 tests.
+- A raw physical framebuffer is not a stable facility for an ordinary Windows
+  process. Win32 GDI is the smallest dependable presentation boundary on the
+  current target; conversion and pixel ownership remain in the generated C
+  shell.
+
+## Lessons Learned
+
+- Calling convention sidecars must be derived from the final emitted
+  procedure, not an exploratory signature pass. A missing value extent does
+  not necessarily crash; it can shift every pointer argument and produce
+  plausible-looking zero output.
+- The existing `ShellIOManifest` is the correct common boundary. Display code
+  should consume resolved resource bindings and must not know the application
+  or infer channels from output names.
+- The native display can remain dependency-free while preserving the same
+  separation used by Wasm: compiled code publishes buffers, and the host shell
+  owns presentation and asynchronous operating-system interaction.
+- The current C implementation realizes display only. Merely having keyboard,
+  pointer, and file schemas does not mean those native mailboxes are live.
+
+## Next Steps
+
+- Implement the native input-event ring for keyboard and pointer messages.
+- Implement the asynchronous native file request/completion broker.
+- Add packed `rgb8`, `rgba8`, and scalar/indexed display adapters beside the
+  current planar float64 format.
+- Move native artifact construction behind a stable command or bundle role so
+  reproducing the executable does not require a one-off build driver.
+- Consider a presentation thread only after the shared double-buffer ownership
+  and generation counters are carried directly into the native adapter.
+
+These items are recorded in
+`todo/1785765928_turing_native_c_shell_io_handoff.stub.md`.
+
+## Prompt History
+
+> "let's put a flag in the compiler for one shot bake, which will render all logic and execute as a numeric block, like it used to before we started thinking about user control, or else with a different flag it does what we're trying to do lately and bakes the whole program with logic, and then could you bake a page the usual way for a version that uses asap (if that's been configured yet, the asap/alap flag, don't put it in if not someone is working on it) and for full program not numeric reduction"
+
+> "can you make this in fortran in a c shell for my own pleasure apart from the site"
+
+> "the program output stext, is this because we have no display adapter for the c shell"
+
+> "take a look at how the web assembly pipeline works, how there's a lot of io built in, we need to get there in the c, using at worst the most basic library we can possibly imagine that's really sure to be there, if we can't do what I'd prefer, which would be blit rgb ourselves, no window manager"
+
+> "prepare experience report and handoff document in the speaktome ecosystem and commit and push all your work in every repo you touched"
+

--- a/AGENTS/experience_reports/todo/1784575565_GPU_Lumen_Picking_And_SVG_Retirement.stub.md
+++ b/AGENTS/experience_reports/todo/1784575565_GPU_Lumen_Picking_And_SVG_Retirement.stub.md
@@ -1,0 +1,8 @@
+# GPU Lumen Picking And SVG Retirement
+
+Add a color-ID framebuffer pass for selecting individual traversal lumen
+segments, then migrate pressure halos and optional guide geometry. Preserve
+DOM/SVG for accessible labels, controls, tooltips, and the heart HUD.
+
+Source report:
+`AGENTS/experience_reports/1784575565_DOC_ThreeJS_WebGL2_Vascular_Renderer.md`

--- a/AGENTS/experience_reports/todo/1784578514_GPU_ND_Force_Assembly.stub.md
+++ b/AGENTS/experience_reports/todo/1784578514_GPU_ND_Force_Assembly.stub.md
@@ -1,0 +1,6 @@
+# GPU nD Force Assembly
+
+Move the browser's typed-array `NDForceAssembly` to WebGPU compute without
+changing its generalized force equations or proof schema. Combine its proof
+with the conserved-fluid work result behind one client acknowledgement
+barrier, then remove the dormant ring/wedge mechanics helpers.

--- a/AGENTS/experience_reports/todo/1784612211_SDF_Metaball_Hull.stub.md
+++ b/AGENTS/experience_reports/todo/1784612211_SDF_Metaball_Hull.stub.md
@@ -1,0 +1,23 @@
+# TODO Stub
+
+**Date:** 1784612211
+**Title:** Build the SDF/metaball hull for flux_radar
+
+See `AGENTS/experience_reports/1784612211_DOC_SDF_Metaball_Hull_Plan_Not_Yet_Built.md`
+for the full plan. Short version:
+
+- [ ] Check whether `npm run build` (vite) actually works in
+      `speaktome/flux_radar/` -- resolve the `dist/` vs `webgl/` build
+      output confusion first (server serves from `webgl/webgl_renderer.js`).
+- [ ] Replace `rebuildHulls`/the node half of `rebuildNodes` in
+      `src/webgl_renderer.ts` with a raymarched SDF/metaball fullscreen
+      pass. Keep `rebuildLumens` (edge tubes) as-is.
+- [ ] Every visual parameter must come from a real snapshot field: radius
+      from volume/pressure, blend softness from hull_permeability, color
+      from the full solubles blend (not just dominant), pseudopodia reach
+      from forward/backward_growth_interest toward the growing child. No
+      procedural noise.
+- [ ] Decide a max-blob-count cap and a prioritization rule for which
+      nodes render as full blobs if the live graph exceeds it.
+- [ ] Benchmark: never measured whether a per-pixel loop over the blob
+      cap is cheap enough at the demo's canvas size.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,29 @@
-# SpeakToMe Multi‑Project Repository
+# SpeakToMe multi-project repository
 
-This repository hosts several independent codebases that share a common virtual environment. Each codebase has its own documentation and optional dependency groups defined in its `pyproject.toml`.
+SpeakToMe is a Python research workspace whose codebases share environment and agent tooling but remain conceptually distinct. The central application explores beam-search controllers and “wide truth” region estimation; sibling packages cover tensor abstraction, DEC/Laplace utilities, printing, and time synchronization.
 
-## Available Codebases
+This directory is itself one project within the larger `C:\dev\Powershell` workspace. Instructions here do not make the parent directory a monorepo.
 
-- **speaktome** — main beam search controllers and utilities.
+## Codebases
+
+- **speaktome** — main beam-search controllers and utilities.
 - **laplace** — Laplace builder and DEC utilities.
 - **tensorprinting** — experimental Grand Printing Press package.
-- **timesync** — system clock offset helpers.
-- **AGENTS/tools** — shared helper scripts for repository management.
+- **timesync** — system-clock offset helpers.
+- **AGENTS/tools** — shared repository-management helpers.
 
-See `AGENTS/CODEBASE_REGISTRY.md` for the canonical list.
+See [`AGENTS/CODEBASE_REGISTRY.md`](AGENTS/CODEBASE_REGISTRY.md) for the canonical registry and [`AGENTS_FILESYSTEM_MAP.md`](AGENTS_FILESYSTEM_MAP.md) for orientation.
 
-## Environment Setup
+## Environment and tests
 
-All environment configuration is handled by the workflow described in
-`ENV_SETUP_OPTIONS.md`.
+Do not install packages manually into an arbitrary interpreter. Follow [`ENV_SETUP_OPTIONS.md`](ENV_SETUP_OPTIONS.md) and [`AGENTS_DO_NOT_PIP_MANUALLY.md`](AGENTS_DO_NOT_PIP_MANUALLY.md).
 
-## Legacy Modules
+Testing conventions, including the distinction between `tests/` and `testing/`, are in [`AGENTS_TESTING_ADVICE.md`](AGENTS_TESTING_ADVICE.md).
 
-The helper ``AGENTS.tools.headers.header_utils`` remains in the tree for historical
-reference only. **Do not import it**. Scripts should read ``ENV_SETUP_BOX``
-directly from the environment instead of relying on this module.
+## Design context
 
-Run ``python -m AGENTS.tools.headers.run_header_checks`` to automatically repair,
-validate and test file headers across the repository.
+For the C++ simulation ethos, read [`CRT_Vector_Manifesto.md`](CRT_Vector_Manifesto.md). For the beam-search direction—parallel forward/backward beams, independent batched/threaded workers, and “wide truth” region estimation—read [`VISION_FORWARD_BACKWARD_DIFFUSION.md`](VISION_FORWARD_BACKWARD_DIFFUSION.md).
 
-For the design ethos underpinning our C++ simulations, consult `CRT_Vector_Manifesto.md`.
+## Legacy tooling
 
-For where the beam search stack is headed (parallel forward/backward beams,
-independent batched/threaded workers, "wide truth" region estimation), consult
-`VISION_FORWARD_BACKWARD_DIFFUSION.md`.
+`AGENTS.tools.headers.header_utils` remains for historical reference only; do not import it. Scripts should read `ENV_SETUP_BOX` from the environment. Run `python -m AGENTS.tools.headers.run_header_checks` to repair, validate, and test repository headers.

--- a/speaktome/core/flux_graph.py
+++ b/speaktome/core/flux_graph.py
@@ -445,10 +445,16 @@ class IonReservoir:
         low, target, high = self.concentration_band()
         gate = max(0.0, min(1.0, self.opening_coverage * self.exchange_probability))
 
+        # The ion gate sits in the chamber's own water -- an ion cannot cross
+        # it, in either direction, unless the chamber actually has solvent to
+        # be dissolved in right now. No water at the membrane means no ion
+        # transport math at all, regardless of concentration pressure.
+        chamber_has_water = chamber.get("solvent", 0.0) > 0.0
+
         # The same gate skims excess ions or supplies deficient chambers.
         # An empty new reservoir begins with a zero band, so the first
         # matching chamber supply is excess and establishes its history.
-        if volume > 0.0 and target > 0.0:
+        if chamber_has_water and volume > 0.0 and target > 0.0:
             chamber_concentration = chamber_ions / volume
             if chamber_concentration > high:
                 correction = (
@@ -466,7 +472,7 @@ class IonReservoir:
                 moved = min(self.ion_amount, correction * gate)
                 chamber[self.ion_name] = chamber_ions + moved
                 self.ion_amount -= moved
-        elif volume > 0.0 and chamber_ions > 0.0:
+        elif chamber_has_water and volume > 0.0 and chamber_ions > 0.0:
             moved = chamber_ions * gate
             chamber[self.ion_name] = chamber_ions - moved
             self.ion_amount += moved
@@ -877,6 +883,22 @@ class FluxGraphConfig:
     # the next anchor from whatever's actually in the graph right now,
     # rather than waiting for a challenger to out-score it fairly.
     anchor_can_decay: bool = False
+    # A bare pressure inequality with zero cooldown means the causal
+    # center random-walks to whichever node has the highest *instantaneous*
+    # pressure every single tick -- a freshly grown leaf and a settling
+    # anchor (actively losing pressure to humidity/factory/bulk-transfer
+    # outflow every tick) cross constantly, never a rare event. That
+    # thrashes _reroot's own heart teardown/rebuild every tick (see
+    # _reroot's _spill_heart_to_csf) instead of letting one lineage
+    # actually get explored -- "crowds with hearts, doesn't beam search."
+    # reroot_margin requires a real, decisive win, not a coin flip;
+    # reroot_cooldown_ticks guarantees a newly-rooted lineage gets that
+    # many ticks to actually develop before it can be displaced again.
+    # Neither throttles the anchor_can_decay forced-replacement path --
+    # that one is survival (the anchor is already dead), not exploration
+    # stability, and must never be blocked by a cooldown.
+    reroot_margin: float = 0.05
+    reroot_cooldown_ticks: int = 3
     compute_budget_per_tick: int = 4
     branch_factor: int = 3
     max_context_tokens: int = 64
@@ -1293,6 +1315,11 @@ class FluxGraph:
         self.habitats: Dict[int, Dict[str, float]] = {}
         self.habitat_signatures: Dict[int, List[int]] = {}
         self.movement_count: int = 0
+        # Ticks elapsed since the last reroot -- see FluxGraphConfig.
+        # reroot_cooldown_ticks. Large (not 0) so a reroot is allowed
+        # immediately if the very first challenger check already clears
+        # the cooldown at tick 1.
+        self._ticks_since_reroot: int = 10**9
         # Stable named logits for every continuous valve and pore. Keeping
         # ownership here rather than on mutable dataclasses makes parameters
         # easy to optimize, persist, and enumerate even as topology grows.
@@ -2383,6 +2410,20 @@ class FluxGraph:
             pressure=1.0 + self.config.found_bonus,
             created_tick=0,
             expanded=True,  # the anchor doesn't get "expanded" itself
+            # The anchor sits at the center and belongs to no slice (see
+            # _node_slice), so it never receives the ordinary per-slice
+            # ambient humidity exchange every other node gets -- without
+            # its own starting reserve it would stay permanently dry and
+            # (now that growth requires water) could never sprout its
+            # first children at all. 1.0 matches uniform_field's default
+            # ambient level, i.e. "the seed starts as hydrated as the
+            # steady state everything else is drawn toward" -- not an
+            # arbitrary number. Only while the fluid layer is actually on:
+            # with it off there is no water concept in play (growth stays
+            # ungated too, see _expandable_nodes), and plain score-driven
+            # pressure derivation expects a freshly seeded graph at exactly
+            # zero physical inventory.
+            solvent=1.0 if self.config.graph_auditor_enabled else 0.0,
         )
         self.anchor_id = node_id
         self.rhizome_owner_id = node_id
@@ -2934,6 +2975,11 @@ class FluxGraph:
             self._apply_reservoir_learning()
             self._emit_status("humidity", "exchanging solvent and dissolved ions")
             self._exchange_humidity()
+            # A still-dry anchor's first children are withheld by
+            # spawn_first_children() itself; retrying here (idempotent
+            # once they exist) means they appear the same tick the anchor
+            # finally hydrates, rather than needing a separate mechanism.
+            self.spawn_first_children()
             self._emit_status("rings", "ingesting boundary supplies")
             self._ingest_from_habitat_shells()
             self._emit_status("pumping", "beating regional hearts")
@@ -3000,9 +3046,24 @@ class FluxGraph:
         support, it can't just sit there forever the way an unsupported
         leaf can't: this force-picks the current highest-pressure live node
         as the next anchor from whatever's actually in the graph right now,
-        rather than waiting for a challenger to fairly out-score it.
+        rather than waiting for a challenger to fairly out-score it. This
+        forced path is survival, not exploration stability, so it ignores
+        reroot_cooldown_ticks entirely -- a dead anchor cannot be left in
+        place just because the clock hasn't run out.
+
+        The ordinary challenger path below is gated by both
+        reroot_cooldown_ticks (a newly-rooted lineage gets that many ticks
+        before it can be displaced again) and reroot_margin (the challenger
+        must clear the anchor by more than that, not just any epsilon) --
+        without them the causal focus random-walks to whichever node has
+        the highest *instantaneous* pressure every single tick (a fresh
+        leaf and a settling anchor, which loses pressure to humidity/
+        factory/bulk-transfer outflow every tick, cross constantly), tearing
+        down and rebuilding every heart on every tick instead of letting one
+        lineage actually get explored.
         """
         anchor = self.nodes[self.anchor_id]
+        self._ticks_since_reroot += 1
 
         if self.config.anchor_can_decay:
             if anchor.pressure < self.config.starvation_floor:
@@ -3015,12 +3076,16 @@ class FluxGraph:
                     self._reroot(replacement_id)
                 return
 
+        if self._ticks_since_reroot < max(0, int(self.config.reroot_cooldown_ticks)):
+            return
+
+        margin = max(0.0, float(self.config.reroot_margin))
         challenger_id = None
         challenger_pressure = anchor.pressure
         for node_id, node in self.nodes.items():
             if node.burned or node_id == self.anchor_id:
                 continue
-            if node.pressure > challenger_pressure:
+            if node.pressure > challenger_pressure + margin:
                 challenger_pressure = node.pressure
                 challenger_id = node_id
         if challenger_id is None:
@@ -3055,13 +3120,30 @@ class FluxGraph:
         old_anchor_id = self.anchor_id
         if new_root_id == old_anchor_id:
             return
+        self._ticks_since_reroot = 0
         old_anchor_tokens = self.anchor_tokens
         old_anchor_local_evidence = self.anchor_local_evidence
         # The old seed heart does not travel with the focus. Re-rooting
         # dumps every chamber and reservoir into the shared CSF bath.
         self._spill_heart_to_csf("main")
-        self.nodes[old_anchor_id].tokens = old_anchor_tokens
-        self.nodes[old_anchor_id].local_evidence = old_anchor_local_evidence
+        old_anchor = self.nodes[old_anchor_id]
+        # A demotion is not a destruction -- old_anchor stays alive -- but
+        # material leaving a role goes through CSF/lymph in every case, no
+        # exception for "the node itself survives." Its own solvent/
+        # solubles land in its own bath_by_node entry (a live compartment,
+        # since this node isn't burned) instead of continuing to sit
+        # privately on the node the instant it stops being anchor.
+        if old_anchor.solvent or old_anchor.solubles:
+            local_bath = self.bath_by_node.setdefault(old_anchor_id, {})
+            if old_anchor.solvent:
+                local_bath["solvent"] = local_bath.get("solvent", 0.0) + old_anchor.solvent
+                old_anchor.solvent = 0.0
+            for name, amount in old_anchor.solubles.items():
+                if amount:
+                    local_bath[name] = local_bath.get(name, 0.0) + amount
+            old_anchor.solubles = {}
+        old_anchor.tokens = old_anchor_tokens
+        old_anchor.local_evidence = old_anchor_local_evidence
         new_root = self.nodes[new_root_id]
         self.anchor_tokens, self.anchor_local_evidence = self._reset_to_anchor_invariants(new_root)
         self.anchor_id = new_root_id
@@ -3980,10 +4062,21 @@ class FluxGraph:
         # Forward tips have no live children farther forward. Backward tips
         # have no live parents farther backward. Ownership follows the one
         # global backward->forward axis, not radial distance from a center.
+        #
+        # Growth is metabolic work: a node with no solvent has nothing to
+        # spend and cannot put out new tissue, no matter how much pressure
+        # it's carrying -- it simply waits at the frontier until ambient
+        # humidity exchange (see _exchange_humidity, which runs earlier
+        # this same tick) gives it some. Only enforced while the fluid
+        # layer is actually simulating water at all (graph_auditor_enabled)
+        # -- with it off there is no water concept in play, so growth stays
+        # ungated, exactly as it always has.
+        fluid_on = self.config.graph_auditor_enabled
         return [
             n for n in self.nodes.values()
             if not n.burned
             and n.direction is not None
+            and (not fluid_on or n.solvent > 0.0)
             and (
                 (n.direction is Direction.FORWARD and not self._live_children(n.id))
                 or (n.direction is Direction.BACKWARD and not self._live_parents(n.id))
@@ -4166,6 +4259,7 @@ class FluxGraph:
         healthy enough to keep winning the normal compute competition while
         the other side is absent.
         """
+        fluid_on = self.config.graph_auditor_enabled
         heart_stresses = self._heart_growth_stresses()
         if any(
             stress["missing_forward"] or stress["missing_backward"]
@@ -4173,6 +4267,11 @@ class FluxGraph:
         ):
             for stress in heart_stresses.values():
                 pump_id = stress["pump_id"]
+                pump = self.nodes[pump_id]
+                if fluid_on and pump.solvent <= 0.0:
+                    # No water at the pump means no growth from it this
+                    # tick either, same as any other node -- it just waits.
+                    continue
                 if stress["missing_forward"]:
                     # For a heart this is ordinary shoot/sprout growth, not
                     # cross-growth from an already directional cell.
@@ -4205,12 +4304,14 @@ class FluxGraph:
             if not n.burned
             and n.direction is Direction.BACKWARD
             and n.forward_growth_interest > 0.0
+            and (not fluid_on or n.solvent > 0.0)
         )
         backward_pool.extend(
             (n, True) for n in self.nodes.values()
             if not n.burned
             and n.direction is Direction.FORWARD
             and n.backward_growth_interest > 0.0
+            and (not fluid_on or n.solvent > 0.0)
         )
 
         def action_priority(action) -> float:
@@ -4446,13 +4547,36 @@ class FluxGraph:
         def mark_burned(cur_id: int) -> None:
             cur = self.nodes[cur_id]
             cur.burned = True
-            local_bath = self.bath_by_node.setdefault(cur_id, {})
-            if cur.solvent:
-                local_bath["solvent"] = local_bath.get("solvent", 0.0) + cur.solvent
-                cur.solvent = 0.0
-            for name, amount in cur.solubles.items():
-                if amount:
-                    local_bath[name] = local_bath.get(name, 0.0) + amount
+            # bath_by_node[cur_id] is permanently excluded from every future
+            # coupled fluid solve once cur_id is burned (see
+            # _solve_coupled_fluid_system's live_nodes filter) -- depositing
+            # this node's water in its own entry would conserve it on paper
+            # while actually orphaning it somewhere the pressure/flow solver
+            # can never reach again. Hand it instead to a still-living
+            # neighbor it was actually connected to, or the anchor as the
+            # guaranteed-alive fallback -- the same destination
+            # Heart._spill_heart_to_csf uses when a whole heart dies.
+            destination_id = next(
+                (
+                    neighbor_id for neighbor_id in cur.parent_ids + cur.children_ids
+                    if neighbor_id in self.nodes and not self.nodes[neighbor_id].burned
+                ),
+                None,
+            )
+            if (
+                destination_id is None
+                and self.anchor_id in self.nodes
+                and not self.nodes[self.anchor_id].burned
+            ):
+                destination_id = self.anchor_id
+            if destination_id is not None:
+                local_bath = self.bath_by_node.setdefault(destination_id, {})
+                if cur.solvent:
+                    local_bath["solvent"] = local_bath.get("solvent", 0.0) + cur.solvent
+                for name, amount in cur.solubles.items():
+                    if amount:
+                        local_bath[name] = local_bath.get(name, 0.0) + amount
+            cur.solvent = 0.0
             cur.solubles = {}
             if self.config.verbose:
                 print(f"  [burn] node {cur_id} (tokens={cur.tokens}, dir={cur.direction}) starved out")
@@ -5307,7 +5431,21 @@ class FluxGraph:
             raise ValueError(f"node {node_id} has no direction")
 
     def spawn_first_children(self) -> None:
-        """Seed one forward and one backward child directly off the anchor."""
+        """Seed one forward and one backward child directly off the anchor.
+
+        The anchor is created with zero solvent (see seed()) -- while the
+        fluid layer is on, a dry anchor has nothing to grow with yet, so
+        this is a safe no-op instead of forcing growth out of nothing.
+        Idempotent and meant to be retried every tick (see tick()) until
+        ambient humidity exchange gives the anchor some water: the
+        "already has a child on either side" check is what makes repeated
+        calls safe rather than re-growing first children over and over.
+        """
+        anchor = self.nodes[self.anchor_id]
+        if self._live_children(self.anchor_id) or self._live_parents(self.anchor_id):
+            return
+        if self.config.graph_auditor_enabled and anchor.solvent <= 0.0:
+            return
         self._expand_forward(self.anchor_id)
         self._expand_backward(self.anchor_id)
         self.nodes[self.anchor_id].expanded = True
@@ -5843,16 +5981,20 @@ class FluxGraph:
                 flow = min(0.0, flow)
             node.solvent = max(0.0, node.solvent + flow)
 
-            for name, ambient_amount in ambient_solutes.items():
-                permeability = self._learned_node_permeability(node, name)
-                delta = (
-                    node.humidity_exchange
-                    * permeability
-                    * (ambient_amount - node.solubles.get(name, 0.0))
-                )
-                node.solubles[name] = max(
-                    0.0, node.solubles.get(name, 0.0) + delta
-                )
+            # A dissolved solute cannot move ambient-ward without a solvent
+            # to be dissolved in -- a dry node holds its solutes exactly as
+            # they are, no matter how large the ambient concentration gap.
+            if node.solvent > 0.0:
+                for name, ambient_amount in ambient_solutes.items():
+                    permeability = self._learned_node_permeability(node, name)
+                    delta = (
+                        node.humidity_exchange
+                        * permeability
+                        * (ambient_amount - node.solubles.get(name, 0.0))
+                    )
+                    node.solubles[name] = max(
+                        0.0, node.solubles.get(name, 0.0) + delta
+                    )
 
     def _exchange_humidity(self) -> None:
         """Batch passive solvent and ambient-solute exchange by node/material."""
@@ -6063,10 +6205,14 @@ class FluxGraph:
             solvent_flow = solvent_flow.clamp_max(0.0)
         solvent = (solvent + solvent_flow).clamp_min(0.0)
         if materials:
+            # Same rule as the scalar path: no solvent, no solute movement --
+            # a dry node is not a medium anything can dissolve into or out of.
+            has_water = (solvent > 0.0).to(dtype)[:, None]
             material_delta = (
                 exchange_rate[:, None]
                 * permeability[:, 1:]
                 * (ambient - held[:, 1:])
+                * has_water
             )
             new_materials = (held[:, 1:] + material_delta).clamp_min(0.0)
         else:
@@ -6114,6 +6260,10 @@ class FluxGraph:
         network_roots = self.orthogonal_network_roots()
         for nid, node in self.nodes.items():
             if node.burned:
+                continue
+            # A habitat shell hands off a dissolved soluble -- there is
+            # nothing to dissolve it into at a node holding no solvent.
+            if node.solvent <= 0.0:
                 continue
             near = proximity.get(nid)
             if not near:
@@ -6460,12 +6610,21 @@ class FluxGraph:
             if values.shape[1] > 1:
                 volume = values.sum(dim=1).clamp_min(1e-12)
                 concentration = values[:, 1:] / volume[:, None]
+                # Diffusion needs a continuous water medium on both ends --
+                # a compartment holding zero solvent has nothing to dissolve
+                # a solute out of, or into, no matter the concentration gap.
+                has_water = values[:, 0] > 0.0
+                water_gate = (
+                    has_water.index_select(0, src_idx)
+                    & has_water.index_select(0, dst_idx)
+                ).to(dtype)[:, None]
                 raw_diff = (
                     torch.relu(
                         concentration.index_select(0, src_idx)
                         - concentration.index_select(0, dst_idx)
                     )
                     * (conductance * cfg.fluid_diffusion_conductance * dt)[:, None]
+                    * water_gate
                 )
                 source_matrix = src_idx[:, None].expand_as(raw_diff)
                 demand = torch.zeros_like(values[:, 1:])
@@ -7153,7 +7312,16 @@ class FluxGraph:
         return batches
 
     def _run_node_factories(self) -> None:
-        """Execute configured node roles against circulation and/or CSF."""
+        """Execute configured node roles against circulation and/or CSF.
+
+        A factory's own recipe only declares the specific inputs it
+        consumes -- most don't name "solvent" as one of them, so nothing
+        here would otherwise stop a reaction from running in a mixture
+        that happens to hold zero water. Metabolism needs a medium to
+        happen in: no water in the relevant compartment means that
+        compartment's reactions simply don't run this tick, regardless of
+        whether its other named inputs are present.
+        """
         for node in self.nodes.values():
             node.factory_auxin = 0.0
             if node.burned:
@@ -7161,19 +7329,21 @@ class FluxGraph:
             circulation = dict(node.solubles)
             circulation["solvent"] = node.solvent
             local_bath = self.bath_by_node.setdefault(node.id, {})
+            circulation_has_water = circulation.get("solvent", 0.0) > 0.0
+            bath_has_water = local_bath.get("solvent", 0.0) > 0.0
             changed_circulation = False
             for factory in node.factories:
                 if not factory.enabled or factory.throughput <= 0.0:
                     continue
                 medium = factory.medium.lower()
                 remaining = factory.throughput
-                if medium in ("circulatory", "both"):
+                if medium in ("circulatory", "both") and circulation_has_water:
                     used = self._run_factory_reaction(
                         node, factory, circulation, remaining, local_bath
                     )
                     remaining -= used
                     changed_circulation = changed_circulation or used > 0.0
-                if medium in ("csf", "both") and remaining > 0.0:
+                if medium in ("csf", "both") and remaining > 0.0 and bath_has_water:
                     self._run_factory_reaction(
                         node, factory, local_bath, remaining, local_bath
                     )
@@ -7413,26 +7583,32 @@ class FluxGraph:
 
         pump = self.nodes[pump_id]
         heart = self._configure_seed_heart(region, pump_id, initially_full=False)
-
-        intake_plans = {
-            slice_name: self._chamber_intake_plan(routes, pump)
-            for slice_name, routes in inflow_routes.items()
-        }
-        for slice_name, plan in intake_plans.items():
-            pooled = self._drain_plan(plan)
-            chamber = heart.chamber(slice_name, "in")
-            for name, amount in pooled.items():
-                chamber[name] = chamber.get(name, 0.0) + amount
         for slice_name in outflow_routes:
             heart.chamber(slice_name, "out")  # chamber exists even before anything reaches it
+        for slice_name in inflow_routes:
+            heart.chamber(slice_name, "in")  # ditto, so a brand-new slice can still pull this same beat
 
+        # Intake is the pump's inhale, not a passive equalization: the same
+        # beat-driven contraction fraction that governs how hard an
+        # out-chamber pushes into the network now governs how hard an
+        # in-chamber pulls from it (see _squeeze_out_chambers -- "when it
+        # pushes, it pushes"; this is the same mechanic in reverse). No
+        # phase this tick means no beat at all, so nothing pulls or pushes.
         phase = heart.script[heart.phase_index % len(heart.script)] if heart.script else None
+        contractions = heart._resolve_contractions(phase) if phase is not None else {}
+        for slice_name, routes in inflow_routes.items():
+            chamber = heart.chamber(slice_name, "in")
+            fraction = contractions.get(f"{slice_name}|in", 0.0)
+            plan = self._chamber_intake_plan(routes, fraction)
+            pooled = self._drain_plan(plan)
+            for name, amount in pooled.items():
+                chamber[name] = chamber.get(name, 0.0) + amount
+
         heart._run_hooks("pre")
         heart.exchange_seed_reservoirs()
         self._permeate_heart_forward_to_background(heart)
         if phase is not None:
             valves = heart._resolve_valves(phase)
-            contractions = heart._resolve_contractions(phase)
             heart._osmotic_rebalance(valves)
             heart._squeeze_in_chambers(valves, contractions)
             self._squeeze_out_chambers(phase, contractions, outflow_routes, heart)
@@ -7511,24 +7687,39 @@ class FluxGraph:
                 )
 
     def _chamber_intake_plan(
-        self, inflow: List[Tuple["SubEdge", int]], anchor: FluxNode
+        self, inflow: List[Tuple["SubEdge", int]], fraction: float
     ) -> List[Tuple[SubEdge, int, float]]:
-        """What one chamber's inflow subedges would draw this beat --
-        computed exactly like ordinary transport (anchor standing in as
-        the destination), purely read-only, so every chamber can be
-        measured from the same snapshot before anything is drained.
+        """What one chamber's inflow subedges deliver this beat: an active
+        pull, not a passive pressure/volume comparison.
+
+        ``fraction`` is this beat's in-chamber contraction (see
+        _resolve_contractions) -- the exact same number that governs how
+        hard the matching out-chamber pushes into the network this same
+        beat (_squeeze_out_chambers), applied here in reverse: the pump
+        draws that fraction of whatever is actually sitting in each open
+        segment, unconditionally. A real pump doesn't check whether its
+        supply line has "enough pressure relative to me" before it
+        inhales -- it inhales, and whatever's there comes. (An earlier
+        version compared the segment against the chamber's, then the pump
+        node's, own volume -- both were passive equalizations disguised
+        as intake, and the node comparison in particular was a bar the
+        segment could structurally never clear, since the pump node's own
+        solvent/solubles are never touched by heart transport at all.)
+        Purely read-only so every chamber can be measured from the same
+        pre-beat snapshot before anything is drained.
         """
         plan = []
+        if fraction <= 0.0:
+            return plan
+        pull = min(1.0, fraction)
         for sub, segment_index in inflow:
             segment_volume = (
                 sub.segment_solvent[segment_index]
                 + sum(sub.segment_solubles[segment_index].values())
             )
-            drive = (
-                sub.segment_pressures[segment_index] - anchor.pressure
-                + segment_volume - anchor.volume
-            )
-            amount = self._learned_subedge_opening(sub) * max(0.0, drive)
+            if segment_volume <= 0.0:
+                continue
+            amount = self._learned_subedge_opening(sub) * segment_volume * pull
             if amount > 0.0:
                 plan.append((sub, segment_index, amount))
         return plan

--- a/speaktome/core/flux_graph.py
+++ b/speaktome/core/flux_graph.py
@@ -1325,7 +1325,7 @@ class FluxGraph:
         # door). Written wholesale by absorb_external_physics (one atomic
         # reference swap, same GIL reasoning as published_snapshot -- no
         # lock needed), read by whichever backend passes consume that
-        # domain's observations (see _ingest_from_rings). Latest payload
+        # domain's observations (see _ingest_from_habitat_shells). Latest payload
         # per domain wins; stale observations are simply reused until the
         # next one arrives.
         self.external_physics: Dict[str, Dict[str, Any]] = {}
@@ -2935,7 +2935,7 @@ class FluxGraph:
             self._emit_status("humidity", "exchanging solvent and dissolved ions")
             self._exchange_humidity()
             self._emit_status("rings", "ingesting boundary supplies")
-            self._ingest_from_rings()
+            self._ingest_from_habitat_shells()
             self._emit_status("pumping", "beating regional hearts")
             self._pump_hearts()
             self._emit_status("soil", "permeating the level-zero interface")
@@ -6081,16 +6081,15 @@ class FluxGraph:
             for name, amount in zip(materials, row):
                 node.solubles[name] = amount
 
-    def _ingest_from_rings(self) -> None:
-        """Conserved ring dispensing from the active seed's finite habitat.
+    def _ingest_from_habitat_shells(self) -> None:
+        """Conserved shell dispensing from the active seed's finite habitat.
 
-        Each pie slice's ring hands its own unique soluble to nearby nodes,
-        at a rate set by how close each node
-        currently sits to its ring *in the client's own interface sim*.
-        That nearness doesn't exist back here at all -- the backend has
-        no node positions -- so it arrives through the external-physics
-        exchange (absorb_external_physics, domain "client", key
-        "ring_proximity": node_id -> 0..1 with 1 = right on the ring).
+        Each network-local nD habitat shell hands its own unique soluble to
+        nearby nodes, at a rate set by distance in that network's dimensions.
+        The backend has no mechanical coordinates, so the client publishes
+        the result through the external-physics exchange (domain "client_nd",
+        key "habitat_proximity": node_id -> 0..1). The projected S² radar
+        position never participates in uptake.
         No client watching means no payload means no dispensing: ring
         ingestion is genuinely part of the gamified simulation, not a
         backend-only process wearing its name.
@@ -6100,8 +6099,8 @@ class FluxGraph:
         the node's opposite ion is untouched. This replaces the previous
         implicit transmutation of one ion identity into another.
         """
-        client = self.external_physics.get("client", {})
-        proximity: Dict[int, float] = client.get("ring_proximity") or {}
+        client = self.external_physics.get("client_nd", {})
+        proximity: Dict[int, float] = client.get("habitat_proximity") or {}
         if not proximity:
             return
         patch = self._ensure_current_habitat()

--- a/speaktome/core/flux_graph.py
+++ b/speaktome/core/flux_graph.py
@@ -7,18 +7,13 @@ committed sentence and no finalization step -- at any point you can ask
 for the current best path, but the graph keeps growing and re-scoring for
 as long as you keep ticking it.
 
-Every node gets pressure -- a live, continuously recomputed value, not an
-accumulated score. Each discrete tick recomputes every node's pressure
-from its own local evidence (how likely its token was when it was
-created) plus flux received from its neighbors, the way current flows
-through a resistor network: edges with good scores conduct flux easily,
-edges with bad scores resist it. A node's pressure is what it currently
-supports and is supported by -- not a running total. There is no blanket
-decay; a node only loses standing if it stops having good lines running
-through it (no supportive flux from neighbors, and weak local evidence of
-its own), at which point it starves and, if that persists, burns off the
-extremity. A node with a strong descendant never starves, because that
-descendant's pressure flows back to it every tick.
+Every node gets pressure -- a live physical value, never an accumulated
+language score. Each tick couples node casings, the ordered lumen segments
+of every audited path tube, larger per-edge hulls, and a spatial passive
+CSF/lymph bath. Hearts and exchangers move conserved water and named ions;
+local hydration, osmotic loading, and compliance then determine pressure.
+Model score remains a reward and reproduction signal: it can teach useful
+physiology and favor future growth, but it cannot manufacture pressure.
 
 Compute is the resource that actually grows the network: each tick, a
 bounded number of the highest-pressure not-yet-expanded nodes get spent
@@ -51,6 +46,7 @@ pure display question, not a reason to remove it from the graph.
 from __future__ import annotations
 
 import math
+import random
 import time
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Tuple
@@ -158,6 +154,15 @@ class SubEdge:
     traversal_key: Tuple[int, ...]  # endpoint pair, or full path when endpoints have >1 causal route
     direction: str  # "forward" | "reverse"
     constriction: float = 1.0
+    # One persistent lumen compartment per physical edge crossed.  The list
+    # is ordered in this tube's direction of travel.  A traversal therefore
+    # has two independent continuous tubes, not an endpoint-to-endpoint
+    # teleport whose result is merely painted onto the intervening edges.
+    segment_edge_keys: List[Tuple[int, int]] = field(default_factory=list)
+    segment_solvent: List[float] = field(default_factory=list)
+    segment_solubles: List[Dict[str, float]] = field(default_factory=list)
+    segment_pressures: List[float] = field(default_factory=list)
+    delivered_utility: float = 0.0
 
     def is_open_at(self, node_id: int) -> bool:
         """Whether this subedge currently allows volume transfer at node_id.
@@ -221,6 +226,16 @@ class Edge:
     pressure_drop: float = 0.0
     # Signed material flow: ``solvent`` is water; every other key is one ion.
     component_flows: Dict[str, float] = field(default_factory=dict)
+    # Slow, non-trainable developmental memory. Useful named-material flow
+    # hardens a pipe; disuse softens it. Shared physiology archetypes remain
+    # the only learned parameters, so topology growth does not grow the
+    # optimizer state.
+    maturity: float = 0.0
+    # Fluid in the larger per-edge casing around all traversal lumens.
+    # Its node valves are independent of every inner SubEdge valve.
+    hull_solvent: float = 0.0
+    hull_solubles: Dict[str, float] = field(default_factory=dict)
+    hull_pressure: float = 0.0
 
 
 @dataclass
@@ -736,10 +751,10 @@ class FluxNode:
     # Parent ownership always points from the lower level to the higher
     # level. depth remains abs(level) for existing radial consumers.
     level: Optional[int] = None
-    # Nutrient stress accumulates rather than becoming an instant topology
-    # override. A forward-side cell lacking backward ions raises backward
-    # (parent-growing) interest; a backward-side cell lacking forward ions
-    # raises forward (child-growing) interest.
+    # Direction-specific local growth commitment. Sustained opposite-ion
+    # scarcity produces it, nearby same-lineage tissue shares a little, and
+    # new growth inherits part of it. These historical names remain for save
+    # compatibility and UI continuity.
     backward_growth_interest: float = 0.0
     forward_growth_interest: float = 0.0
     # Which seed-layer causal focus this node currently belongs to. A node
@@ -904,7 +919,8 @@ class FluxGraphConfig:
     sprout_branch_factor: int = 1
     sprout_hot_loop_depth: int = 1
     air_root_branch_factor: int = 1
-    air_root_hot_loop_depth: int = 1    # Per-direction candidate selection. "topk" (default): exactly
+    air_root_hot_loop_depth: int = 1
+    # Per-direction candidate selection. "topk" (default): exactly
     # branch_factor (or its per-direction override) highest-probability
     # candidates, a fixed count regardless of how the distribution is
     # actually shaped. "topp": nucleus sampling -- keep however many of
@@ -914,7 +930,9 @@ class FluxGraphConfig:
     # an arbitrary fixed count. branch_factor is ignored in "topp" mode --
     # there's no fixed-K concept once selection is coverage-based --
     # except as an upper cap when auxin_suppression is also on, so apical
-    # dominance still means something in topp mode too.
+    # dominance still means something in topp mode too. "stddev" keeps
+    # branch_factor children but samples them across standardized score
+    # bands, preserving a representative cross-section of the distribution.
     forward_selection_mode: str = "topk"
     backward_selection_mode: str = "topk"
     forward_top_p: float = 0.9
@@ -1044,6 +1062,17 @@ class FluxGraphConfig:
     # attenuation (a distant tip suppresses as hard as an adjacent one);
     # near 0 = only immediate neighbors feel any suppression at all.
     auxin_decay: float = 0.6
+    # Positive developmental counterpart to inhibitory auxin. Remaining
+    # post-physiology scarcity produces a bounded, slowly-decaying local
+    # commitment. Above the threshold it outranks ordinary actions within
+    # that direction's existing compute budget.
+    growth_commitment_gain: float = 1.0
+    growth_commitment_retention: float = 0.85
+    growth_commitment_diffusion: float = 0.15
+    growth_commitment_inheritance: float = 0.5
+    growth_commitment_after_growth: float = 0.25
+    growth_commitment_threshold: float = 3.0
+    growth_commitment_max: float = 6.0
     # Head pressure: sustaining flow to a point further from the anchor
     # costs more than to a nearby one, modeled on real xylem transport
     # (lifting water against a taller column of it costs more head
@@ -1152,6 +1181,16 @@ class FluxGraphConfig:
     # Material scarcity is continuous rather than binary. A node's need is
     # the fractional shortfall below this required opposite-ion concentration.
     growth_target_ion_concentration: float = 0.1
+    # Finite seed-relative habitat patches. A new active seed discovers one
+    # patch containing this much of each currently-existing network-side ion;
+    # returning to an old seed returns to the same depleted patch.
+    habitat_ring_ion_amount: float = 4.0
+    ring_uptake_rate: float = 1.0
+    # Useful solute flow slowly hardens physical branches. Maturity is scalar
+    # graph state, not a per-edge learned parameter.
+    branch_maturity_gain: float = 0.1
+    branch_maturity_retention: float = 0.995
+    branch_maturity_conductance_bonus: float = 1.0
     # Every cousin heart shares this one graph-global CSF bath. These active
     # defaults make that link real without instant mixing; lymph returns a
     # smaller fraction to the active seed's heart each tick.
@@ -1174,6 +1213,22 @@ class FluxGraphConfig:
     physiology_initial_opening: float = 0.8
     physiology_traversal_temperature: float = 0.5
     physiology_track_model_gradients: bool = False
+    # Coupled fluid solver. Pressure is generated only from local hydration
+    # and ion loading (plus heart/pump transfers performed immediately before
+    # the solve); language-model score never enters this equation.
+    fluid_solver_substeps: int = 8
+    fluid_time_step: float = 0.08
+    fluid_bulk_conductance: float = 0.35
+    fluid_diffusion_conductance: float = 0.6
+    fluid_osmotic_pressure: float = 0.25
+    node_compliance: float = 1.0
+    tube_compliance: float = 0.5
+    hull_compliance: float = 2.0
+    bath_compliance: float = 4.0
+    hull_node_valve: float = 0.35
+    hull_bath_permeability: float = 0.08
+    node_bath_permeability: float = 0.04
+    bath_graph_conductance: float = 0.2
 
 
 class FluxGraph:
@@ -1212,6 +1267,18 @@ class FluxGraph:
         # it drains slowly home to the seed heart (lymph return). Dormant
         # until its throttles are dialed above 0 (see FluxGraphConfig).
         self.bath: Dict[str, float] = {}
+        # Spatial CSF/lymph/interstitial compartments. ``bath`` remains the
+        # compatibility inlet/outlet reservoir; material entering it is
+        # deposited at the active seed before each coupled solve.
+        self.bath_by_node: Dict[int, Dict[str, float]] = {}
+        self._pending_traversal_tubes: Dict[str, Any] = {}
+        # Live UI sessions may install a synchronous delegate. The solver
+        # publishes an immutable work packet and blocks here until that client
+        # returns a conservation-checked relaxation result.
+        self.fluid_work_delegate: Optional[
+            Callable[[Dict[str, Any]], Dict[str, Any]]
+        ] = None
+        self.last_fluid_proof: Optional[Dict[str, Any]] = None
         # Environmental mixtures outside circulation. Forward material
         # crosses level-zero into background; root-needed forward ions
         # cross again, more slowly, into soil.
@@ -1219,6 +1286,13 @@ class FluxGraph:
         self.soil: Dict[str, float] = {}
         self.rhizome: Dict[str, float] = {}
         self.rhizome_owner_id: Optional[int] = None
+        # Finite environmental stores indexed by seed identity. The active
+        # anchor selects the current patch; changing anchor is the organism's
+        # movement through phrase space. Patch inventories survive departure,
+        # so returning does not manufacture fresh material.
+        self.habitats: Dict[int, Dict[str, float]] = {}
+        self.habitat_signatures: Dict[int, List[int]] = {}
+        self.movement_count: int = 0
         # Stable named logits for every continuous valve and pore. Keeping
         # ownership here rather than on mutable dataclasses makes parameters
         # easy to optimize, persist, and enumerate even as topology grows.
@@ -1398,10 +1472,126 @@ class FluxGraph:
         "destination_osmotic_fraction",
         "path_quality",
     )
+    _EDGE_ARCHETYPE_FEATURES = _SUBEDGE_ARCHETYPE_FEATURES
+    _NODE_ARCHETYPE_FEATURES = (
+        "bias",
+        "pressure",
+        "water_fraction",
+        "osmotic_fraction",
+        "material_fraction",
+        "scarcity",
+    )
+    _HEART_ARCHETYPE_FEATURES = (
+        "bias",
+        "declared_throttle",
+        "circulating_fraction",
+        "csf_fraction",
+    )
+    _RESERVOIR_ARCHETYPE_FEATURES = (
+        "bias",
+        "fullness",
+        "ion_fraction",
+        "solvent_fraction",
+    )
 
     @classmethod
     def _subedge_archetype_key(cls, direction: str, feature: str) -> str:
         return f"archetype:subedge:{direction}:{feature}"
+
+    @staticmethod
+    def _archetype_key(kind: str, feature: str) -> str:
+        return f"archetype:{kind}:{feature}"
+
+    def _ensure_linear_archetype(
+        self,
+        kind: str,
+        features: Tuple[str, ...],
+        initial: Optional[float] = None,
+    ) -> None:
+        opening = (
+            self.config.physiology_initial_opening
+            if initial is None else initial
+        )
+        for feature in features:
+            key = self._archetype_key(kind, feature)
+            if key in self.physiology_parameters:
+                continue
+            if feature == "bias":
+                self._physiology_parameter(key, opening)
+            else:
+                self.physiology_parameters[key] = torch.nn.Parameter(
+                    torch.zeros((), dtype=torch.float32, device=self.device)
+                )
+
+    def _linear_archetype_openings(
+        self, kind: str, features: Tuple[str, ...], feature_tensor
+    ):
+        weights = torch.stack(
+            [
+                self.physiology_parameters[self._archetype_key(kind, name)]
+                for name in features
+            ]
+        )
+        return torch.sigmoid(feature_tensor @ weights)
+
+    def _ensure_state_archetypes(self) -> None:
+        """Collapse old instance logits into fixed-size state archetypes."""
+        if torch is None or not self.config.physiology_learning_enabled:
+            return
+        legacy = {
+            key: parameter
+            for key, parameter in self.physiology_parameters.items()
+            if not key.startswith("archetype:")
+        }
+
+        def mean_opening(predicate) -> float:
+            values = [
+                float(torch.sigmoid(parameter).detach().item())
+                for key, parameter in legacy.items()
+                if predicate(key)
+            ]
+            return (
+                sum(values) / len(values)
+                if values else self.config.physiology_initial_opening
+            )
+
+        for direction in ("forward", "reverse"):
+            self._ensure_linear_archetype(
+                f"edge:{direction}",
+                self._EDGE_ARCHETYPE_FEATURES,
+                mean_opening(
+                    lambda key, direction=direction:
+                    key.startswith("edge:") and key.endswith(f":{direction}")
+                ),
+            )
+        self._ensure_linear_archetype(
+            "node:hull",
+            self._NODE_ARCHETYPE_FEATURES,
+            mean_opening(lambda key: key.startswith("node:") and key.endswith(":hull")),
+        )
+        self._ensure_linear_archetype(
+            "node:pore",
+            self._NODE_ARCHETYPE_FEATURES,
+            mean_opening(lambda key: key.startswith("node:") and ":pore:" in key),
+        )
+        self._ensure_linear_archetype(
+            "heart:valve",
+            self._HEART_ARCHETYPE_FEATURES,
+            mean_opening(lambda key: key.startswith("heart:") and ":valve:" in key),
+        )
+        for gate_name in ("coverage", "exchange", "membrane"):
+            self._ensure_linear_archetype(
+                f"reservoir:{gate_name}",
+                self._RESERVOIR_ARCHETYPE_FEATURES,
+                mean_opening(
+                    lambda key, gate_name=gate_name:
+                    key.startswith("heart:")
+                    and ":reservoir:" in key
+                    and key.endswith(f":{gate_name}")
+                ),
+            )
+        for key in legacy:
+            del self.physiology_parameters[key]
 
     def _ensure_subedge_archetype(self) -> None:
         """Create one shared state-response model for each flow direction.
@@ -1442,6 +1632,7 @@ class FluxGraph:
                     )
         for key in legacy:
             del self.physiology_parameters[key]
+        self._ensure_state_archetypes()
 
     def _subedge_archetype_openings(
         self,
@@ -1466,7 +1657,10 @@ class FluxGraph:
         end_osmotic = (end_volume - end_solvent).clamp_min(0.0) / (
             end_volume.clamp_min(eps)
         )
-        quality = torch.exp(path_score).clamp(0.0, 1.0)
+        # Kept as a zero-valued migration column so older saved archetype
+        # tensors remain shape-compatible. Score is a teaching/reproduction
+        # reward, never an input that opens a physical valve by itself.
+        quality = torch.zeros_like(path_score)
         ones = torch.ones_like(start_volume)
         forward_features = torch.stack(
             (
@@ -1559,18 +1753,238 @@ class FluxGraph:
             0.0,
             min(1.0, float(node.pore_permeabilities.get(material, 1.0))),
         )
-        return (
-            hull
-            * pore
-            * self._gate_value(self._node_hull_gate_key(node.id))
-            * self._gate_value(self._node_pore_gate_key(node.id, material))
+        if not self.config.physiology_learning_enabled or torch is None:
+            return hull * pore
+        self._ensure_subedge_archetype()
+        volume = max(node.volume, 1e-12)
+        water_fraction = max(0.0, node.solvent) / volume
+        osmotic_fraction = max(0.0, volume - node.solvent) / volume
+        material_fraction = max(0.0, node.solubles.get(material, 0.0)) / volume
+        features = torch.tensor(
+            [[
+                1.0,
+                math.tanh(float(node.pressure)),
+                water_fraction,
+                osmotic_fraction,
+                material_fraction,
+                1.0 - min(1.0, material_fraction),
+            ]],
+            dtype=torch.float32,
+            device=self.device,
         )
+        hull_opening = self._linear_archetype_openings(
+            "node:hull", self._NODE_ARCHETYPE_FEATURES, features
+        )[0]
+        pore_opening = self._linear_archetype_openings(
+            "node:pore", self._NODE_ARCHETYPE_FEATURES, features
+        )[0]
+        learned = float((hull_opening * pore_opening).detach().item())
+        return hull * pore * learned
+
+    def node_archetype_opening_state(
+        self, nodes: Optional[List[FluxNode]] = None
+    ) -> Dict[int, Dict[str, Any]]:
+        """Evaluate all displayed node hulls and pores in two tensor batches."""
+        selected = nodes or [
+            node for node in self.nodes.values() if not node.burned
+        ]
+        if not selected:
+            return {}
+        materials = sorted(
+            {
+                "solvent",
+                *(
+                    name
+                    for node in selected
+                    for name in (
+                        set(node.solubles) | set(node.pore_permeabilities)
+                    )
+                ),
+            }
+        )
+        if not self.config.physiology_learning_enabled or torch is None:
+            return {
+                node.id: {
+                    "hull": 1.0,
+                    "pores": {name: 1.0 for name in materials},
+                }
+                for node in selected
+            }
+        self._ensure_subedge_archetype()
+        rows = []
+        material_rows = []
+        for node in selected:
+            volume = max(node.volume, 1e-12)
+            water = max(0.0, node.solvent) / volume
+            osmotic = max(0.0, volume - node.solvent) / volume
+            pressure = math.tanh(node.pressure)
+            rows.append([
+                1.0, pressure, water, osmotic, osmotic,
+                1.0 - min(1.0, osmotic),
+            ])
+            material_rows.extend(
+                [
+                    1.0,
+                    pressure,
+                    water,
+                    osmotic,
+                    (
+                        max(0.0, node.solvent)
+                        if name == "solvent"
+                        else max(0.0, node.solubles.get(name, 0.0))
+                    ) / volume,
+                    1.0 - min(
+                        1.0,
+                        (
+                            max(0.0, node.solvent)
+                            if name == "solvent"
+                            else max(0.0, node.solubles.get(name, 0.0))
+                        ) / volume,
+                    ),
+                ]
+                for name in materials
+            )
+        hull = self._linear_archetype_openings(
+            "node:hull",
+            self._NODE_ARCHETYPE_FEATURES,
+            torch.tensor(rows, dtype=torch.float32, device=self.device),
+        ).detach().cpu().tolist()
+        pore = self._linear_archetype_openings(
+            "node:pore",
+            self._NODE_ARCHETYPE_FEATURES,
+            torch.tensor(
+                material_rows, dtype=torch.float32, device=self.device
+            ),
+        ).reshape(len(selected), len(materials)).detach().cpu().tolist()
+        return {
+            node.id: {
+                "hull": hull_value,
+                "pores": dict(zip(materials, pore_values)),
+            }
+            for node, hull_value, pore_values in zip(selected, hull, pore)
+        }
+
+    def _learned_edge_opening(
+        self, parent_id: int, child_id: int, direction: str
+    ) -> float:
+        if not self.config.physiology_learning_enabled or torch is None:
+            return 1.0
+        self._ensure_subedge_archetype()
+        start = self.nodes[parent_id]
+        end = self.nodes[child_id]
+        if direction == "reverse":
+            start, end = end, start
+        start_volume = max(start.volume, 1e-12)
+        end_volume = max(end.volume, 1e-12)
+        features = torch.tensor(
+            [[
+                1.0,
+                math.tanh(start.pressure - end.pressure),
+                max(0.0, start.solvent) / start_volume,
+                max(0.0, end.solvent) / end_volume,
+                math.tanh(start_volume - end_volume),
+                max(0.0, start_volume - start.solvent) / start_volume,
+                max(0.0, end_volume - end.solvent) / end_volume,
+                math.exp(min(0.0, end.local_evidence)),
+            ]],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        return float(
+            self._linear_archetype_openings(
+                f"edge:{direction}", self._EDGE_ARCHETYPE_FEATURES, features
+            )[0].detach().item()
+        )
+
+    def edge_archetype_opening_state(
+        self, edge_keys: Optional[List[Tuple[int, int]]] = None
+    ) -> Dict[Tuple[int, int], Tuple[float, float]]:
+        """Evaluate every requested physical edge valve in two batches."""
+        keys = edge_keys or list(self.edges)
+        keys = [
+            (parent_id, child_id)
+            for parent_id, child_id in keys
+            if parent_id in self.nodes and child_id in self.nodes
+        ]
+        if not keys:
+            return {}
+        if not self.config.physiology_learning_enabled or torch is None:
+            return {key: (1.0, 1.0) for key in keys}
+        self._ensure_subedge_archetype()
+        rows = {"forward": [], "reverse": []}
+        for parent_id, child_id in keys:
+            parent = self.nodes[parent_id]
+            child = self.nodes[child_id]
+            quality = math.exp(min(0.0, child.local_evidence))
+            for direction, source, destination in (
+                ("forward", parent, child),
+                ("reverse", child, parent),
+            ):
+                source_volume = max(source.volume, 1e-12)
+                destination_volume = max(destination.volume, 1e-12)
+                rows[direction].append([
+                    1.0,
+                    math.tanh(source.pressure - destination.pressure),
+                    max(0.0, source.solvent) / source_volume,
+                    max(0.0, destination.solvent) / destination_volume,
+                    math.tanh(source_volume - destination_volume),
+                    max(0.0, source_volume - source.solvent)
+                    / source_volume,
+                    max(0.0, destination_volume - destination.solvent)
+                    / destination_volume,
+                    quality,
+                ])
+        openings = {
+            direction: self._linear_archetype_openings(
+                f"edge:{direction}",
+                self._EDGE_ARCHETYPE_FEATURES,
+                torch.tensor(
+                    direction_rows,
+                    dtype=torch.float32,
+                    device=self.device,
+                ),
+            ).detach().cpu().tolist()
+            for direction, direction_rows in rows.items()
+        }
+        return {
+            key: (
+                openings["forward"][index],
+                openings["reverse"][index],
+            )
+            for index, key in enumerate(keys)
+        }
 
     def _heart_valve_modulator(
         self, region: str, in_slice: str, out_slice: str, throttle: float
     ) -> float:
-        key = f"heart:{region}:valve:{in_slice}->{out_slice}"
-        return max(0.0, min(1.0, float(throttle) * self._gate_value(key)))
+        if not self.config.physiology_learning_enabled or torch is None:
+            return max(0.0, min(1.0, float(throttle)))
+        self._ensure_subedge_archetype()
+        heart = self.hearts.get(region)
+        circulating = (
+            sum(sum(max(0.0, value) for value in mix.values())
+                for mix in heart.chambers.values())
+            if heart is not None else 0.0
+        )
+        csf = sum(max(0.0, value) for value in self.bath.values())
+        total = circulating + csf
+        features = torch.tensor(
+            [[
+                1.0,
+                max(0.0, min(1.0, float(throttle))),
+                circulating / max(total, 1e-12),
+                csf / max(total, 1e-12),
+            ]],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        opening = self._linear_archetype_openings(
+            "heart:valve", self._HEART_ARCHETYPE_FEATURES, features
+        )[0]
+        return max(
+            0.0,
+            min(1.0, float(throttle) * float(opening.detach().item())),
+        )
 
     def _bind_heart_learning(self, region: str, heart: Heart) -> None:
         heart.valve_modulator = (
@@ -1583,57 +1997,48 @@ class FluxGraph:
     def _apply_reservoir_learning(self) -> None:
         if not self.config.physiology_learning_enabled:
             return
+        self._ensure_physiology_parameters()
         for region, heart in self.hearts.items():
             for name, reservoir in heart.reservoirs.items():
-                reservoir.opening_coverage = self._gate_value(
-                    f"heart:{region}:reservoir:{name}:coverage"
+                total = max(reservoir.storage_volume, 1e-12)
+                features = torch.tensor(
+                    [[
+                        1.0,
+                        reservoir.fullness,
+                        max(0.0, reservoir.ion_amount) / total,
+                        max(0.0, reservoir.solvent) / total,
+                    ]],
+                    dtype=torch.float32,
+                    device=self.device,
                 )
-                reservoir.exchange_probability = self._gate_value(
-                    f"heart:{region}:reservoir:{name}:exchange"
+                reservoir.opening_coverage = float(
+                    self._linear_archetype_openings(
+                        "reservoir:coverage",
+                        self._RESERVOIR_ARCHETYPE_FEATURES,
+                        features,
+                    )[0].detach().item()
                 )
-                reservoir.membrane_permeability = self._gate_value(
-                    f"heart:{region}:reservoir:{name}:membrane"
+                reservoir.exchange_probability = float(
+                    self._linear_archetype_openings(
+                        "reservoir:exchange",
+                        self._RESERVOIR_ARCHETYPE_FEATURES,
+                        features,
+                    )[0].detach().item()
+                )
+                reservoir.membrane_permeability = float(
+                    self._linear_archetype_openings(
+                        "reservoir:membrane",
+                        self._RESERVOIR_ARCHETYPE_FEATURES,
+                        features,
+                    )[0].detach().item()
                 )
 
     def _ensure_physiology_parameters(self) -> None:
         if not self.config.physiology_learning_enabled or torch is None:
             return
         self._ensure_subedge_archetype()
-        network_roots = self.orthogonal_network_roots()
-        for (parent_id, child_id), edge in self.edges.items():
-            if self.nodes[parent_id].burned or self.nodes[child_id].burned:
-                continue
-            self._physiology_parameter(
-                self._edge_gate_key(parent_id, child_id, "forward")
-            )
-            self._physiology_parameter(
-                self._edge_gate_key(parent_id, child_id, "reverse")
-            )
-        for node_id, node in self.nodes.items():
-            if node.burned:
-                continue
-            self._physiology_parameter(self._node_hull_gate_key(node_id))
-            materials = {"solvent", *node.solubles.keys()}
-            slices = self._node_slice(node_id, node, network_roots)
-            if slices is not None:
-                materials.update(slices)
-            for material in materials:
-                self._physiology_parameter(
-                    self._node_pore_gate_key(node_id, material)
-                )
         for region, heart in self.hearts.items():
             self._bind_heart_learning(region, heart)
-            if heart.script:
-                phase = heart.script[heart.phase_index % len(heart.script)]
-                for in_slice, out_slice in heart._resolve_valves(phase):
-                    self._physiology_parameter(
-                        f"heart:{region}:valve:{in_slice}->{out_slice}"
-                    )
-            for name in heart.reservoirs:
-                for gate_name in ("coverage", "exchange", "membrane"):
-                    self._physiology_parameter(
-                        f"heart:{region}:reservoir:{name}:{gate_name}"
-                    )
 
     def _learn_physiology(self) -> None:
         """Diffuse score-weighted reward over every audited traversal."""
@@ -1659,33 +2064,8 @@ class FluxGraph:
         best_key, best = max(
             live_traversals, key=lambda item: item[1].mean_score
         )
-        heart_support = {
-            key for key in self.physiology_parameters
-            if key.startswith("heart:main:")
-        }
-        pore_keys_by_node: Dict[int, List[str]] = {}
-        for key in self.physiology_parameters:
-            if not key.startswith("node:") or ":pore:" not in key:
-                continue
-            try:
-                node_id = int(key.split(":", 2)[1])
-            except (ValueError, IndexError):
-                continue
-            pore_keys_by_node.setdefault(node_id, []).append(key)
-
         for parameter in self.physiology_parameters.values():
             parameter.grad = None
-        structural_keys = [
-            key
-            for key in self.physiology_parameters
-            if not key.startswith("archetype:")
-        ]
-        structural_openings = torch.stack(
-            [
-                torch.sigmoid(self.physiology_parameters[key])
-                for key in structural_keys
-            ]
-        ) if structural_keys else None
         score_tensor = torch.tensor(
             [
                 float(traversal.mean_score)
@@ -1735,58 +2115,167 @@ class FluxGraph:
             ),
             score_tensor,
         )
+        physical_utility = torch.tensor(
+            [
+                sum(sub.delivered_utility for sub in traversal.subedges)
+                for _, traversal in live_traversals
+            ],
+            dtype=torch.float32,
+            device=self.device,
+        )
+        if bool((physical_utility > 0.0).any()):
+            physical_utility = physical_utility / physical_utility.max().clamp_min(1e-12)
         expected_route_opening = (
-            traversal_weights * archetype_openings.mean(dim=1)
+            traversal_weights
+            * physical_utility
+            * archetype_openings.mean(dim=1)
         ).sum()
+        reward_terms = [expected_route_opening]
+        resource_terms = [archetype_openings.mean()]
 
-        detached_weights = traversal_weights.detach().cpu().tolist()
-        gate_coefficients: Dict[str, float] = {}
-        for weight, (traversal_key, traversal) in zip(
-            detached_weights, live_traversals
-        ):
-            supporting = set(heart_support)
-            for parent_id, child_id in zip(
-                traversal.node_ids, traversal.node_ids[1:]
+        live_edges = [
+            (parent_id, child_id)
+            for parent_id, child_id in self.edges
+            if parent_id in self.nodes
+            and child_id in self.nodes
+            and not self.nodes[parent_id].burned
+            and not self.nodes[child_id].burned
+        ]
+        if live_edges:
+            edge_quality = []
+            forward_rows = []
+            reverse_rows = []
+            for parent_id, child_id in live_edges:
+                parent = self.nodes[parent_id]
+                child = self.nodes[child_id]
+                parent_volume = max(parent.volume, 1e-12)
+                child_volume = max(child.volume, 1e-12)
+                quality = math.exp(min(0.0, child.local_evidence))
+                edge_quality.append(quality)
+                forward_rows.append([
+                    1.0,
+                    math.tanh(parent.pressure - child.pressure),
+                    max(0.0, parent.solvent) / parent_volume,
+                    max(0.0, child.solvent) / child_volume,
+                    math.tanh(parent_volume - child_volume),
+                    max(0.0, parent_volume - parent.solvent) / parent_volume,
+                    max(0.0, child_volume - child.solvent) / child_volume,
+                    quality,
+                ])
+                reverse_rows.append([
+                    1.0,
+                    math.tanh(child.pressure - parent.pressure),
+                    max(0.0, child.solvent) / child_volume,
+                    max(0.0, parent.solvent) / parent_volume,
+                    math.tanh(child_volume - parent_volume),
+                    max(0.0, child_volume - child.solvent) / child_volume,
+                    max(0.0, parent_volume - parent.solvent) / parent_volume,
+                    quality,
+                ])
+            edge_quality_tensor = torch.tensor(
+                edge_quality, dtype=torch.float32, device=self.device
+            )
+            edge_weights = torch.softmax(
+                edge_quality_tensor / temperature, dim=0
+            )
+            for direction, rows in (
+                ("forward", forward_rows),
+                ("reverse", reverse_rows),
             ):
-                supporting.add(
-                    self._edge_gate_key(parent_id, child_id, "forward")
+                opening = self._linear_archetype_openings(
+                    f"edge:{direction}",
+                    self._EDGE_ARCHETYPE_FEATURES,
+                    torch.tensor(
+                        rows, dtype=torch.float32, device=self.device
+                    ),
                 )
-                supporting.add(
-                    self._edge_gate_key(parent_id, child_id, "reverse")
+                reward_terms.append((edge_weights * opening).sum())
+                resource_terms.append(opening.mean())
+
+        live_nodes = [node for node in self.nodes.values() if not node.burned]
+        if live_nodes:
+            node_rows = []
+            node_quality = []
+            for node in live_nodes:
+                volume = max(node.volume, 1e-12)
+                water = max(0.0, node.solvent) / volume
+                osmotic = max(0.0, volume - node.solvent) / volume
+                material = osmotic
+                node_rows.append([
+                    1.0,
+                    math.tanh(node.pressure),
+                    water,
+                    osmotic,
+                    material,
+                    1.0 - min(1.0, material),
+                ])
+                node_quality.append(math.exp(min(0.0, node.local_evidence)))
+            node_features = torch.tensor(
+                node_rows, dtype=torch.float32, device=self.device
+            )
+            node_weights = torch.softmax(
+                torch.tensor(
+                    node_quality, dtype=torch.float32, device=self.device
+                ) / temperature,
+                dim=0,
+            )
+            for kind in ("node:hull", "node:pore"):
+                opening = self._linear_archetype_openings(
+                    kind, self._NODE_ARCHETYPE_FEATURES, node_features
                 )
-            for node_id in traversal.node_ids:
-                supporting.add(self._node_hull_gate_key(node_id))
-                supporting.update(pore_keys_by_node.get(node_id, ()))
-            supporting = {
-                key for key in supporting
-                if key in self.physiology_parameters
-            }
-            if supporting:
-                share = float(weight) / len(supporting)
-                for key in supporting:
-                    gate_coefficients[key] = (
-                        gate_coefficients.get(key, 0.0) + share
-                    )
-        expected_structural_opening = (
-            torch.stack(
-                [
-                    torch.sigmoid(self.physiology_parameters[key])
-                    * coefficient
-                    for key, coefficient in gate_coefficients.items()
-                ]
-            ).sum()
-            if gate_coefficients
-            else expected_route_opening.new_zeros(())
-        )
-        expected_survival = (
-            0.5 * expected_route_opening
-            + 0.5 * expected_structural_opening
-        )
-        resource_opening = archetype_openings.mean()
-        if structural_openings is not None:
-            resource_opening = (
-                resource_opening + structural_openings.mean()
-            ) * 0.5
+                reward_terms.append((node_weights * opening).sum())
+                resource_terms.append(opening.mean())
+
+        heart_rows = []
+        for heart in self.hearts.values():
+            circulating = sum(
+                sum(max(0.0, value) for value in mix.values())
+                for mix in heart.chambers.values()
+            )
+            csf = sum(max(0.0, value) for value in self.bath.values())
+            total = circulating + csf
+            heart_rows.append([
+                1.0,
+                1.0,
+                circulating / max(total, 1e-12),
+                csf / max(total, 1e-12),
+            ])
+        if heart_rows:
+            heart_opening = self._linear_archetype_openings(
+                "heart:valve",
+                self._HEART_ARCHETYPE_FEATURES,
+                torch.tensor(
+                    heart_rows, dtype=torch.float32, device=self.device
+                ),
+            )
+            reward_terms.append(heart_opening.mean())
+            resource_terms.append(heart_opening.mean())
+
+        reservoir_rows = []
+        for heart in self.hearts.values():
+            for reservoir in heart.reservoirs.values():
+                total = max(reservoir.storage_volume, 1e-12)
+                reservoir_rows.append([
+                    1.0,
+                    reservoir.fullness,
+                    max(0.0, reservoir.ion_amount) / total,
+                    max(0.0, reservoir.solvent) / total,
+                ])
+        if reservoir_rows:
+            reservoir_features = torch.tensor(
+                reservoir_rows, dtype=torch.float32, device=self.device
+            )
+            for gate_name in ("coverage", "exchange", "membrane"):
+                opening = self._linear_archetype_openings(
+                    f"reservoir:{gate_name}",
+                    self._RESERVOIR_ARCHETYPE_FEATURES,
+                    reservoir_features,
+                )
+                reward_terms.append(opening.mean())
+                resource_terms.append(opening.mean())
+
+        expected_survival = torch.stack(reward_terms).mean()
+        resource_opening = torch.stack(resource_terms).mean()
         loss = (
             -expected_survival
             + max(0.0, float(self.config.physiology_resource_cost))
@@ -1813,7 +2302,7 @@ class FluxGraph:
         openings = {
             key: float(torch.sigmoid(parameter).detach().item())
             for key, parameter in self.physiology_parameters.items()
-            if not key.startswith("archetype:")
+            if key.startswith("archetype:") and key.endswith(":bias")
         } if torch is not None else {}
         archetype_coefficients = {
             key: float(parameter.detach().item())
@@ -1822,21 +2311,24 @@ class FluxGraph:
         } if torch is not None else {}
         by_kind: Dict[str, List[float]] = {}
         for key, opening in openings.items():
-            by_kind.setdefault(key.split(":", 1)[0], []).append(opening)
+            parts = key.split(":")
+            kind = ":".join(parts[1:-1])
+            by_kind.setdefault(kind, []).append(opening)
         values = list(openings.values())
+        archetype_groups: Dict[str, int] = {}
+        for key in archetype_coefficients:
+            parts = key.split(":")
+            kind = ":".join(parts[1:-1])
+            archetype_groups[kind] = archetype_groups.get(kind, 0) + 1
         return {
             "enabled": self.config.physiology_learning_enabled,
             "parameter_count": len(self.physiology_parameters),
             "archetype_parameter_count": len(archetype_coefficients),
             "archetypes": {
-                "subedge": {
-                    "parameter_count": len(archetype_coefficients),
-                    "coefficient_l1_mean": (
-                        sum(abs(value) for value in archetype_coefficients.values())
-                        / len(archetype_coefficients)
-                        if archetype_coefficients else None
-                    ),
+                kind: {
+                    "parameter_count": count,
                 }
+                for kind, count in archetype_groups.items()
             },
             "opening_mean": sum(values) / len(values) if values else None,
             "opening_min": min(values) if values else None,
@@ -1895,6 +2387,7 @@ class FluxGraph:
         self.anchor_id = node_id
         self.rhizome_owner_id = node_id
         self._configure_seed_heart("main", node_id, initially_full=True)
+        self._ensure_current_habitat()
         self._publish_snapshot()
         return node_id
 
@@ -2008,6 +2501,30 @@ class FluxGraph:
         """
         self.external_physics[domain] = payload
 
+    def _ensure_current_habitat(self) -> Dict[str, float]:
+        """Return the active seed's persistent finite environmental patch.
+
+        A habitat is created exactly once per seed node. Its initial named
+        ions reflect the regional hearts present when that phrase-space
+        location is first entered. Later topology can use those materials but
+        cannot make the patch refill; revisiting the seed returns to the same
+        inventory.
+        """
+        if self.anchor_id is None:
+            return {}
+        patch = self.habitats.get(self.anchor_id)
+        if patch is not None:
+            return patch
+        amount = max(0.0, float(self.config.habitat_ring_ion_amount))
+        patch = {}
+        for region in self._region_pump_nodes():
+            patch[f"{region}:forward"] = amount
+            patch[f"{region}:backward"] = amount
+        self.habitats[self.anchor_id] = patch
+        tokens, _ = self.best_path()
+        self.habitat_signatures[self.anchor_id] = list(tokens or self.anchor_tokens)
+        return patch
+
     def export_fluid_state(self) -> Dict[str, Any]:
         """The graph-level fluid state that lives outside individual nodes
         -- the CSF bath and every region heart's chambers, reservoirs,
@@ -2016,10 +2533,50 @@ class FluxGraph:
         not here."""
         return {
             "bath": dict(self.bath),
+            "bath_by_node": {
+                str(node_id): dict(mixture)
+                for node_id, mixture in self.bath_by_node.items()
+            },
             "background": dict(self.background),
             "soil": dict(self.soil),
             "rhizome": dict(self.rhizome),
             "rhizome_owner_id": self.rhizome_owner_id,
+            "habitats": {
+                str(seed_id): dict(mixture)
+                for seed_id, mixture in self.habitats.items()
+            },
+            "habitat_signatures": {
+                str(seed_id): list(tokens)
+                for seed_id, tokens in self.habitat_signatures.items()
+            },
+            "movement_count": self.movement_count,
+            "edge_maturity": {
+                f"{parent_id}:{child_id}": edge.maturity
+                for (parent_id, child_id), edge in self.edges.items()
+                if edge.maturity
+            },
+            "edge_hulls": {
+                f"{parent_id}:{child_id}": {
+                    "solvent": edge.hull_solvent,
+                    "solubles": dict(edge.hull_solubles),
+                    "pressure": edge.hull_pressure,
+                }
+                for (parent_id, child_id), edge in self.edges.items()
+                if edge.hull_solvent or edge.hull_solubles
+            },
+            "traversal_tubes": {
+                ",".join(str(part) for part in key): [
+                    {
+                        "direction": sub.direction,
+                        "edge_keys": [list(edge_key) for edge_key in sub.segment_edge_keys],
+                        "solvent": list(sub.segment_solvent),
+                        "solubles": [dict(mixture) for mixture in sub.segment_solubles],
+                        "pressures": list(sub.segment_pressures),
+                    }
+                    for sub in traversal.subedges
+                ]
+                for key, traversal in self.traversals.items()
+            },
             "physiology": {
                 "logits": {
                     key: float(parameter.detach().item())
@@ -2062,10 +2619,49 @@ class FluxGraph:
         (custom phase lists aren't round-tripped -- they fall back to the
         configured script, since a phase list can hold arbitrary code)."""
         self.bath = dict(state.get("bath", {}))
+        self.bath_by_node = {
+            int(node_id): dict(mixture)
+            for node_id, mixture in state.get("bath_by_node", {}).items()
+        }
         self.background = dict(state.get("background", {}))
         self.soil = dict(state.get("soil", {}))
         self.rhizome = dict(state.get("rhizome", {}))
         self.rhizome_owner_id = self.anchor_id
+        self.habitats = {
+            int(seed_id): dict(mixture)
+            for seed_id, mixture in state.get("habitats", {}).items()
+        }
+        self.habitat_signatures = {
+            int(seed_id): list(tokens)
+            for seed_id, tokens in state.get("habitat_signatures", {}).items()
+        }
+        self.movement_count = int(state.get("movement_count", 0))
+        self._ensure_current_habitat()
+        for key, value in state.get("edge_maturity", {}).items():
+            try:
+                parent_text, child_text = str(key).split(":", 1)
+                edge = self.edges.get((int(parent_text), int(child_text)))
+                if edge is not None:
+                    edge.maturity = max(0.0, min(1.0, float(value)))
+            except (TypeError, ValueError):
+                continue
+        for key, hstate in state.get("edge_hulls", {}).items():
+            try:
+                parent_text, child_text = str(key).split(":", 1)
+                edge = self.edges.get((int(parent_text), int(child_text)))
+                if edge is not None:
+                    edge.hull_solvent = max(0.0, float(hstate.get("solvent", 0.0)))
+                    edge.hull_solubles = {
+                        str(name): max(0.0, float(amount))
+                        for name, amount in hstate.get("solubles", {}).items()
+                    }
+                    edge.hull_pressure = max(0.0, float(hstate.get("pressure", 0.0)))
+            except (TypeError, ValueError):
+                continue
+        # Traversals are reconstructed lazily by the auditor. Restore tube
+        # inventories only for paths already present (newer loaders may audit
+        # before importing); otherwise keep the payload for that first audit.
+        self._pending_traversal_tubes = dict(state.get("traversal_tubes", {}))
         for region, hstate in state.get("hearts", {}).items():
             heart = self._heart_for(region)
             heart.chambers = {k: dict(v) for k, v in hstate.get("chambers", {}).items()}
@@ -2332,7 +2928,25 @@ class FluxGraph:
         """Advance one discrete step."""
         self.tick_count += 1
         self._tick_started_at = time.monotonic()
-        self._emit_status("settling", "relaxing circuit", 0, self.config.max_relaxation_iterations)
+        if self.config.graph_auditor_enabled:
+            self._emit_status("auditing", "materializing every causal path tube")
+            self._run_graph_auditor()
+            self._apply_reservoir_learning()
+            self._emit_status("humidity", "exchanging solvent and dissolved ions")
+            self._exchange_humidity()
+            self._emit_status("rings", "ingesting boundary supplies")
+            self._ingest_from_rings()
+            self._emit_status("pumping", "beating regional hearts")
+            self._pump_hearts()
+            self._emit_status("soil", "permeating the level-zero interface")
+            self._permeate_background_into_soil()
+            self._absorb_soil_by_roots()
+            self._emit_status("factories", "running node synthesis")
+            self._run_node_factories()
+        self._emit_status(
+            "settling", "relaxing coupled fluid compartments",
+            0, self.config.fluid_solver_substeps,
+        )
         self._settle_circuit()
         self._emit_status("rerooting", "checking causal focus")
         self._maybe_reroot()
@@ -2341,36 +2955,25 @@ class FluxGraph:
         self._emit_status("auxin", "diffusing growth signals")
         self._diffuse_auxin()
         if self.config.graph_auditor_enabled:
-            # Local missing-ion stress requests an opposite-direction root sprout.
-            self._emit_status("nutrients", "reading local sprout demand")
+            # Except for the boot tick, this reads the fully reconciled
+            # post-physiology state left by the preceding tick.
+            self._emit_status("nutrients", "building local growth commitment")
             self._update_nutrient_growth_interest()
         self._emit_status("expanding", "selecting growth fronts")
         self._expand_top_pressure_nodes()
         self._emit_status("starvation", "reaping disconnected or starved tissue")
         self._starve_and_burn()
         if self.config.graph_auditor_enabled:
-            self._emit_status("auditing", "enumerating causal paths")
+            # Growth can create fresh paths. Materialize their empty lumens
+            # now so the next beat sees the exact current vascular topology.
+            self._emit_status("auditing", "materializing newly grown path tubes")
             self._run_graph_auditor()
             self._emit_status(
-                "learning", "diffusing traversal reward through valves and pores"
+                "learning", "using path score as reward and reproduction signal"
             )
             self._learn_physiology()
-            self._apply_reservoir_learning()
-            self._emit_status("humidity", "exchanging solvent and dissolved ions")
-            self._exchange_humidity()
-            self._emit_status("rings", "ingesting boundary supplies")
-            self._ingest_from_rings()
-            self._emit_status("transport", "moving fluid through traversals")
-            self._transport_subedges()
-            self._emit_status("pumping", "beating regional hearts")
-            self._pump_hearts()
-            self._emit_status("soil", "permeating the level-zero interface")
-            self._permeate_background_into_soil()
-            self._absorb_soil_by_roots()
-            self._emit_status("factories", "running node synthesis")
-            self._run_node_factories()
-            self._emit_status("nutrients", "reconciling local sprout demand")
-            self._update_nutrient_growth_interest(accumulate=False)
+            self._emit_status("hardening", "maturing useful physical routes")
+            self._update_branch_maturity()
         self._publish_snapshot()
         self._emit_status("complete", "tick snapshot published", 1, 1)
 
@@ -2469,6 +3072,8 @@ class FluxGraph:
         # whose owner is no longer on the new level-zero seed tier.
         self._reap_dead_hearts(set(self._region_pump_nodes()))
         self._configure_seed_heart("main", new_root_id, initially_full=False)
+        self.movement_count += 1
+        self._ensure_current_habitat()
 
     def _reset_to_anchor_invariants(self, node: FluxNode) -> Tuple[List[int], float]:
         """Match seed()'s anchor construction, in place, for a node that's becoming the anchor.
@@ -2496,8 +3101,9 @@ class FluxGraph:
         node.direction = None
         node.depth = 0
         node.level = 0
-        node.local_evidence = 0.0
-        node.cumulative_evidence = 0.0
+        # Score is a permanent reward observation. Becoming the active seed
+        # changes neither this token's reward nor the accumulated reward of
+        # its causal lineage; seed status has no hydraulic privilege.
         node.low_pressure_ticks = 0
         node.expanded = True
         return captured_tokens, captured_local_evidence
@@ -2708,15 +3314,25 @@ class FluxGraph:
             if neighbor_id in self.nodes[node_id].parent_ids
             else (node_id, neighbor_id)
         )
+        edge = self.edges.get((parent_id, child_id))
+        maturity = edge.maturity if edge is not None else 0.0
+        hardening = 1.0 + max(
+            0.0, float(self.config.branch_maturity_conductance_bonus)
+        ) * max(0.0, min(1.0, maturity))
         if neighbor_id in self.nodes[node_id].parent_ids:
-            valve = self._gate_value(
-                self._edge_gate_key(parent_id, child_id, "forward")
+            valve = self._learned_edge_opening(
+                parent_id, child_id, "forward"
             )
-            return base * valve
-        valve = self._gate_value(
-            self._edge_gate_key(parent_id, child_id, "reverse")
+            return base * valve * hardening
+        valve = self._learned_edge_opening(
+            parent_id, child_id, "reverse"
         )
-        return base * self.config.return_conductance_scale * valve
+        return (
+            base
+            * self.config.return_conductance_scale
+            * valve
+            * hardening
+        )
 
     def _shared_token_intrinsic(self) -> Dict[int, float]:
         """Nodes sharing the exact same token span divide their intrinsic claim
@@ -2763,7 +3379,7 @@ class FluxGraph:
         forward_reach: float = 0.0,
         backward_reach: float = 0.0,
     ) -> float:
-        """One relaxation sweep. Returns the largest pressure change seen.
+        """Refresh node pressure from local physical inventory only.
 
         inflow is a conductance-weighted average of neighbor pressure,
         normalized by *total conductance* -- sum(conductance_i * pressure_i)
@@ -2872,21 +3488,51 @@ class FluxGraph:
         return max_delta
 
     def _settle_circuit(self) -> int:
-        """Iterate relaxation until pressure stops moving (or the iteration cap).
+        """Settle the coupled physical fluid system.
 
-        A single sweep is a half-propagated transient, not a solved
-        circuit -- multi-hop support hasn't had a chance to arrive yet.
-        This is pure local arithmetic (no model calls), so iterating it
-        many times per tick is cheap; only the *decisions* made off of it
-        (expansion, starvation) are expensive, and those should see a
-        settled state, not a snapshot mid-flight.
-
-        Shared-token trading (_shared_token_intrinsic) and the forward/
-        backward reach gap (for balance_weight) both happen once here,
-        before the very first sweep -- structural facts about the tree
-        that the whole exterior relaxation then treats as fixed input for
-        this tick, not something recomputed sweep to sweep.
+        Pressure is an observation of hydration and named-ion loading in
+        nodes, tube lumens, edge hulls, and spatial bath compartments. Score,
+        found bonus, population heuristics, and seed identity do not create
+        pressure. They remain reward/reproduction signals used by growth.
         """
+        if self.config.graph_auditor_enabled:
+            self._run_graph_auditor()
+            self._solve_coupled_fluid_system()
+            return max(1, int(self.config.fluid_solver_substeps))
+
+        # Without the fluid topology enabled, retain current inventories but
+        # still derive node pressure from physical local state only.
+        compliance = max(1e-6, float(self.config.node_compliance))
+        for node in self.nodes.values():
+            if node.burned:
+                continue
+            node.pressure = (
+                max(0.0, node.solvent)
+                + self.config.fluid_osmotic_pressure
+                * sum(max(0.0, amount) for amount in node.solubles.values())
+                / max(1e-6, node.solvent)
+            ) / compliance
+        return 1
+
+        # Legacy score-driven resistor relaxation is intentionally unreachable
+        # below. It remains temporarily as migration context for saved knobs.
+        compliance = max(1e-6, float(self.config.node_compliance))
+        max_delta = 0.0
+        for node in self.nodes.values():
+            if node.burned:
+                continue
+            new_pressure = (
+                max(0.0, node.solvent)
+                + self.config.fluid_osmotic_pressure
+                * sum(max(0.0, amount) for amount in node.solubles.values())
+                / max(1e-6, node.solvent)
+            ) / compliance
+            max_delta = max(max_delta, abs(new_pressure - node.pressure))
+            node.pressure = new_pressure
+        return max_delta
+
+        # Legacy score-driven pressure code remains below only as migration
+        # context for old configuration names; it is intentionally unreachable.
         cfg = self.config
         shared_intrinsic = self._shared_token_intrinsic()
         forward_reach = self._direction_reach(Direction.FORWARD)
@@ -3192,6 +3838,96 @@ class FluxGraph:
             keep = min(keep, self._effective_branch_factor(node))
         return max(1, keep)
 
+    def _stddev_sample_candidates(
+        self,
+        node: FluxNode,
+        candidates: List[Tuple[List[int], float]],
+        keep: int,
+    ) -> List[Tuple[List[int], float]]:
+        """Sample score-standardized bands while preserving probability mass.
+
+        Every occupied one-standard-deviation band receives a representative
+        before remaining seats are assigned in proportion to each band's
+        model-probability mass. Sampling within a band is probability weighted
+        and without replacement. Returned scores remain the true model scores.
+        """
+        keep = min(max(0, int(keep)), len(candidates))
+        if keep == 0:
+            return []
+        scores = [float(score) for _, score in candidates]
+        mean = sum(scores) / len(scores)
+        variance = sum((score - mean) ** 2 for score in scores) / len(scores)
+        deviation = math.sqrt(variance)
+        if deviation <= 1e-12:
+            return candidates[:keep]
+
+        bands: Dict[int, List[int]] = {}
+        for index, score in enumerate(scores):
+            z_score = (score - mean) / deviation
+            # Do not let the enormous aggregate mass of individually
+            # implausible tail items dominate the representative sample.
+            if z_score < -2.0:
+                continue
+            bands.setdefault(math.floor(z_score), []).append(index)
+        if not bands:
+            bands[0] = [max(range(len(scores)), key=scores.__getitem__)]
+
+        rng = random.Random(
+            ((self.tick_count + 1) * 0x9E3779B1)
+            ^ (node.id * 0x85EBCA77)
+            ^ (1 if node.direction is Direction.FORWARD else 2)
+        )
+        remaining = {band: list(indices) for band, indices in bands.items()}
+        selected: List[int] = []
+        maximum = max(scores)
+
+        def weight(index: int) -> float:
+            return math.exp(scores[index] - maximum)
+
+        def draw_from_band(band: int) -> None:
+            indices = remaining[band]
+            weights = [weight(index) for index in indices]
+            target = rng.random() * sum(weights)
+            running = 0.0
+            chosen_at = len(indices) - 1
+            for position, item_weight in enumerate(weights):
+                running += item_weight
+                if running >= target:
+                    chosen_at = position
+                    break
+            selected.append(indices.pop(chosen_at))
+
+        band_mass = {
+            band: sum(weight(index) for index in indices)
+            for band, indices in remaining.items()
+        }
+        for band in sorted(bands, key=band_mass.get, reverse=True)[:keep]:
+            draw_from_band(band)
+
+        while len(selected) < keep:
+            live_bands = [band for band, indices in remaining.items() if indices]
+            if not live_bands:
+                break
+            masses = [
+                sum(weight(index) for index in remaining[band])
+                for band in live_bands
+            ]
+            target = rng.random() * sum(masses)
+            running = 0.0
+            chosen_band = live_bands[-1]
+            for band, mass in zip(live_bands, masses):
+                running += mass
+                if running >= target:
+                    chosen_band = band
+                    break
+            draw_from_band(chosen_band)
+
+        return sorted(
+            (candidates[index] for index in selected),
+            key=lambda pair: pair[1],
+            reverse=True,
+        )
+
     def _direction_reach(self, direction: Direction) -> float:
         """How far a direction's frontier currently extends from the anchor.
 
@@ -3254,16 +3990,75 @@ class FluxGraph:
             )
         ]
 
-    def _update_nutrient_growth_interest(self, accumulate: bool = True) -> None:
-        """Accumulate cross-growth interest from continuous ion scarcity.
+    def _heart_growth_stresses(self) -> Dict[str, Dict[str, Any]]:
+        """Return structural side scarcity for every seed-tier heart.
 
-        Each node measures the concentration of its required opposite-side
-        ion against ``growth_target_ion_concentration``. Its fractional
-        shortfall (0..1), not a binary present/absent flag, is the demand
-        added to sprout or air-root priority. Adequate supply clears demand.
+        A heart is connected on one side only when a direct live neighbor on
+        that side belongs to the pump's metabolic lineage. A causal edge into
+        an unrelated cousin network does not satisfy the requirement. Missing
+        forward tissue is sprout stress; missing backward tissue is root
+        stress. Seed-tier pumps have no direction of their own, so this check
+        is deliberately separate from node-local ion scarcity.
+        """
+        stresses: Dict[str, Dict[str, Any]] = {}
+        for region, pump_id in self._region_pump_nodes().items():
+            pump = self.nodes[pump_id]
+            lineage_id = (
+                pump.center_id
+                if pump.center_id is not None else pump_id
+            )
+
+            def same_lineage(node_id: int) -> bool:
+                node = self.nodes[node_id]
+                node_lineage = (
+                    node.center_id
+                    if node.center_id is not None else node.id
+                )
+                return node_lineage == lineage_id
+
+            forward_connections = [
+                child_id
+                for child_id in self._live_children(pump_id)
+                if same_lineage(child_id)
+            ]
+            backward_connections = [
+                parent_id
+                for parent_id in self._live_parents(pump_id)
+                if same_lineage(parent_id)
+            ]
+            missing_forward = not forward_connections
+            missing_backward = not backward_connections
+            pump.forward_growth_interest = (
+                1.0 if missing_forward else 0.0
+            )
+            pump.backward_growth_interest = (
+                1.0 if missing_backward else 0.0
+            )
+            stresses[region] = {
+                "pump_id": pump_id,
+                "lineage_id": lineage_id,
+                "missing_forward": missing_forward,
+                "missing_backward": missing_backward,
+                "forward_connections": forward_connections,
+                "backward_connections": backward_connections,
+            }
+        return stresses
+
+    def _update_nutrient_growth_interest(self, accumulate: bool = True) -> None:
+        """Update the local, direction-specific growth commitment field.
+
+        Each directional node produces commitment from its remaining
+        opposite-ion shortfall. Existing signal decays, while the strongest
+        signal on adjacent same-lineage, same-side tissue diffuses locally.
+        The update is simultaneous so dict iteration order cannot steer the
+        hormone field. ``accumulate=False`` remains a compatibility-only
+        reconciliation mode that clears a fully supplied site without
+        advancing developmental time.
         """
         target = max(1e-12, float(self.config.growth_target_ion_concentration))
         network_roots = self.orthogonal_network_roots()
+        scarcity_by_node: Dict[int, float] = {}
+        field_by_node: Dict[int, str] = {}
         for nid, node in self.nodes.items():
             if node.burned or node.direction is None:
                 continue
@@ -3281,10 +4076,57 @@ class FluxGraph:
                 if node.direction is Direction.FORWARD
                 else "forward_growth_interest"
             )
-            if scarcity <= 0.0:
-                setattr(node, interest_name, 0.0)
-            elif accumulate:
-                setattr(node, interest_name, getattr(node, interest_name) + scarcity)
+            scarcity_by_node[nid] = scarcity
+            field_by_node[nid] = interest_name
+
+        if not accumulate:
+            for nid, scarcity in scarcity_by_node.items():
+                if scarcity <= 0.0:
+                    setattr(self.nodes[nid], field_by_node[nid], 0.0)
+            return
+
+        retention = max(
+            0.0, min(1.0, float(self.config.growth_commitment_retention))
+        )
+        diffusion = max(
+            0.0, min(1.0, float(self.config.growth_commitment_diffusion))
+        )
+        gain = max(0.0, float(self.config.growth_commitment_gain))
+        maximum = max(
+            0.0,
+            float(
+                max(
+                    self.config.growth_commitment_max,
+                    self.config.growth_commitment_threshold,
+                )
+            ),
+        )
+        previous = {
+            nid: max(0.0, float(getattr(self.nodes[nid], field_name)))
+            for nid, field_name in field_by_node.items()
+        }
+        updated: Dict[int, float] = {}
+        for nid, scarcity in scarcity_by_node.items():
+            node = self.nodes[nid]
+            field_name = field_by_node[nid]
+            ambient = max(
+                (
+                    previous[neighbor_id]
+                    for neighbor_id in self._neighbors(nid)
+                    if neighbor_id in previous
+                    and field_by_node[neighbor_id] == field_name
+                    and self.nodes[neighbor_id].center_id == node.center_id
+                ),
+                default=0.0,
+            )
+            retained = retention * previous[nid]
+            local_spread = diffusion * max(0.0, ambient - retained)
+            updated[nid] = min(
+                maximum,
+                retained + gain * scarcity + local_spread,
+            )
+        for nid, value in updated.items():
+            setattr(self.nodes[nid], field_by_node[nid], value)
     def _expand_top_pressure_nodes(self) -> None:
         """Pick this tick's compute-budget candidates, split fairly by direction.
 
@@ -3324,13 +4166,20 @@ class FluxGraph:
         healthy enough to keep winning the normal compute competition while
         the other side is absent.
         """
-        missing_forward_side = not self._live_children(self.anchor_id)
-        missing_backward_side = not self._live_parents(self.anchor_id)
-        if missing_forward_side or missing_backward_side:
-            if missing_forward_side:
-                self._expand_forward(self.anchor_id)
-            if missing_backward_side:
-                self._expand_backward(self.anchor_id)
+        heart_stresses = self._heart_growth_stresses()
+        if any(
+            stress["missing_forward"] or stress["missing_backward"]
+            for stress in heart_stresses.values()
+        ):
+            for stress in heart_stresses.values():
+                pump_id = stress["pump_id"]
+                if stress["missing_forward"]:
+                    # For a heart this is ordinary shoot/sprout growth, not
+                    # cross-growth from an already directional cell.
+                    self._expand_forward(pump_id)
+                if stress["missing_backward"]:
+                    # An air root launched by a heart is simply its root side.
+                    self._expand_backward(pump_id)
             return
 
         forward_reach = self._direction_reach(Direction.FORWARD)
@@ -3375,8 +4224,25 @@ class FluxGraph:
                 )
             return priority(node) + stress
 
-        forward_pool.sort(key=action_priority, reverse=True)
-        backward_pool.sort(key=action_priority, reverse=True)
+        threshold = max(
+            0.0, float(self.config.growth_commitment_threshold)
+        )
+
+        def action_rank(action) -> Tuple[bool, float]:
+            node, nutrient_driven = action
+            stress = (
+                node.forward_growth_interest
+                if nutrient_driven and node.direction is Direction.BACKWARD
+                else (
+                    node.backward_growth_interest
+                    if nutrient_driven
+                    else 0.0
+                )
+            )
+            return nutrient_driven and stress >= threshold, action_priority(action)
+
+        forward_pool.sort(key=action_rank, reverse=True)
+        backward_pool.sort(key=action_rank, reverse=True)
 
         cfg = self.config
         explicit_budgets = cfg.forward_budget_per_tick is not None or cfg.backward_budget_per_tick is not None
@@ -3395,7 +4261,7 @@ class FluxGraph:
             if leftover_budget > 0:
                 remaining = sorted(
                     forward_pool[forward_floor:] + backward_pool[backward_floor:],
-                    key=action_priority, reverse=True,
+                    key=action_rank, reverse=True,
                 )
                 for action in remaining[:leftover_budget]:
                     node, nutrient_driven = action
@@ -3533,6 +4399,13 @@ class FluxGraph:
         for node_id, node in self.nodes.items():
             if node.burned or node_id == self.anchor_id:
                 continue
+            # Expansion precedes starvation in tick(). A node born during
+            # this expansion has not yet reached the auditor, humidity,
+            # transport, heart, soil, or factory phases below starvation.
+            # Do not spend one of its survival strikes before it has had
+            # that first complete physiology pass.
+            if self.tick_count > 0 and node.created_tick == self.tick_count:
+                continue
             if node.pressure < cfg.starvation_floor:
                 node.low_pressure_ticks += 1
             else:
@@ -3573,12 +4446,13 @@ class FluxGraph:
         def mark_burned(cur_id: int) -> None:
             cur = self.nodes[cur_id]
             cur.burned = True
+            local_bath = self.bath_by_node.setdefault(cur_id, {})
             if cur.solvent:
-                self.bath["solvent"] = self.bath.get("solvent", 0.0) + cur.solvent
+                local_bath["solvent"] = local_bath.get("solvent", 0.0) + cur.solvent
                 cur.solvent = 0.0
             for name, amount in cur.solubles.items():
                 if amount:
-                    self.bath[name] = self.bath.get(name, 0.0) + amount
+                    local_bath[name] = local_bath.get(name, 0.0) + amount
             cur.solubles = {}
             if self.config.verbose:
                 print(f"  [burn] node {cur_id} (tokens={cur.tokens}, dir={cur.direction}) starved out")
@@ -4015,9 +4889,10 @@ class FluxGraph:
         # rather than being capped by a narrow topk-sized fetch.
         needs_wide_shortlist = poetic is not None or word_trie is not None
         for node in nodes:
+            selection_mode = self._direction_selection_mode(node.direction)
             base_shortlist_k = (
                 self.config.top_p_shortlist_ceiling
-                if self._direction_selection_mode(node.direction) == "topp"
+                if selection_mode in {"topp", "stddev"}
                 else self._direction_branch_factor(node.direction)
             )
             if node.direction is Direction.FORWARD:
@@ -4047,7 +4922,15 @@ class FluxGraph:
                 shortlist_k = base_shortlist_k
                 if needs_wide_shortlist:
                     shortlist_k = max(shortlist_k, self.config.poetic_shortlist_k)
-                round0 = scored[:shortlist_k]
+                if selection_mode == "stddev":
+                    pre_sample = [([tid], score) for tid, score in scored]
+                    if word_trie is not None:
+                        pre_sample = self._stddev_sample_candidates(
+                            node, pre_sample, shortlist_k
+                        )
+                    round0 = [(tokens[0], score) for tokens, score in pre_sample]
+                else:
+                    round0 = scored[:shortlist_k]
                 if word_trie is not None:
                     spans = self._grow_backward_word(node, round0)
                 else:
@@ -4395,6 +5278,11 @@ class FluxGraph:
         built once from a real dictionary, not a per-candidate rerank here.
         """
         poetic = self.config.poetic_attractor
+        if (
+            self._direction_selection_mode(node.direction) == "stddev"
+            and candidates
+        ):
+            return self._stddev_sample_candidates(node, candidates, keep)
         if poetic is None or not candidates:
             return candidates[:keep]
 
@@ -4538,6 +5426,7 @@ class FluxGraph:
         score: float,
         tokens: List[int],
         live_token_spans,
+        commitment_share: float = 1.0,
     ) -> FluxNode:
         node_id = self._alloc_id()
         token_key = tuple(int(t) for t in tokens)
@@ -4560,6 +5449,18 @@ class FluxGraph:
             cumulative_evidence=cumulative,
             rollup_mean=cumulative / max(depth, 1),
         )
+        inheritance = max(
+            0.0, min(1.0, float(self.config.growth_commitment_inheritance))
+        )
+        inherited = inheritance * max(0.0, commitment_share)
+        if level > int(source.level or 0):
+            node.forward_growth_interest = (
+                max(0.0, source.forward_growth_interest) * inherited
+            )
+        elif level < int(source.level or 0):
+            node.backward_growth_interest = (
+                max(0.0, source.backward_growth_interest) * inherited
+            )
         self.nodes[node_id] = node
         if level == 0 and node_id != self.anchor_id:
             self._configure_seed_heart(f"net:{node_id}", node_id, initially_full=False)
@@ -4587,22 +5488,44 @@ class FluxGraph:
     ) -> None:
         source = self.nodes[source_id]
         live_token_spans = self._live_token_spans()
+        count = max(1, min(len(scores), len(token_spans)))
         for score, tokens in zip(scores, token_spans):
             child = self._new_growth_node(
-                source, int(source.level or 0) + 1, score, tokens, live_token_spans
+                source,
+                int(source.level or 0) + 1,
+                score,
+                tokens,
+                live_token_spans,
+                commitment_share=1.0 / count,
             )
             self._record_growth_edge(source_id, child.id, child, "postfix_beam")
+        if count and scores and token_spans:
+            source.forward_growth_interest *= max(
+                0.0,
+                min(1.0, float(self.config.growth_commitment_after_growth)),
+            )
 
     def _attach_backward_parents(
         self, source_id: int, scores: List[float], token_spans: List[List[int]]
     ) -> None:
         source = self.nodes[source_id]
         live_token_spans = self._live_token_spans()
+        count = max(1, min(len(scores), len(token_spans)))
         for score, tokens in zip(scores, token_spans):
             parent = self._new_growth_node(
-                source, int(source.level or 0) - 1, score, tokens, live_token_spans
+                source,
+                int(source.level or 0) - 1,
+                score,
+                tokens,
+                live_token_spans,
+                commitment_share=1.0 / count,
             )
             self._record_growth_edge(parent.id, source_id, parent, "prefix_beam")
+        if count and scores and token_spans:
+            source.backward_growth_interest *= max(
+                0.0,
+                min(1.0, float(self.config.growth_commitment_after_growth)),
+            )
 
     def _run_graph_auditor(self) -> None:
         """Enumerate every causal path among currently-live nodes -- every
@@ -4690,9 +5613,24 @@ class FluxGraph:
 
         # Every Traversal adds two SubEdges -- one going one way, one
         # going the other -- held by every real Edge its path crosses.
-        forward_sub = SubEdge(traversal_key=key, direction="forward")
-        reverse_sub = SubEdge(traversal_key=key, direction="reverse")
-        for a, b in zip(node_ids, node_ids[1:]):
+        edge_keys = list(zip(node_ids, node_ids[1:]))
+        forward_sub = SubEdge(
+            traversal_key=key,
+            direction="forward",
+            segment_edge_keys=list(edge_keys),
+            segment_solvent=[0.0] * len(edge_keys),
+            segment_solubles=[{} for _ in edge_keys],
+            segment_pressures=[0.0] * len(edge_keys),
+        )
+        reverse_sub = SubEdge(
+            traversal_key=key,
+            direction="reverse",
+            segment_edge_keys=list(reversed(edge_keys)),
+            segment_solvent=[0.0] * len(edge_keys),
+            segment_solubles=[{} for _ in edge_keys],
+            segment_pressures=[0.0] * len(edge_keys),
+        )
+        for a, b in edge_keys:
             edge = self.edges.get((a, b))
             if edge is not None:
                 edge.subedges.append(forward_sub)
@@ -4706,8 +5644,37 @@ class FluxGraph:
             closed_tick=self.tick_count,
             subedges=[forward_sub, reverse_sub],
         )
+        saved_tubes = self._pending_traversal_tubes.pop(
+            ",".join(str(part) for part in key), None
+        )
+        if saved_tubes:
+            by_direction = {
+                str(item.get("direction")): item for item in saved_tubes
+            }
+            for sub in (forward_sub, reverse_sub):
+                item = by_direction.get(sub.direction)
+                if not item or len(item.get("solvent", [])) != len(sub.segment_edge_keys):
+                    continue
+                sub.segment_solvent = [
+                    max(0.0, float(value)) for value in item.get("solvent", [])
+                ]
+                sub.segment_solubles = [
+                    {
+                        str(name): max(0.0, float(amount))
+                        for name, amount in mixture.items()
+                    }
+                    for mixture in item.get("solubles", [])
+                ]
+                sub.segment_pressures = [
+                    max(0.0, float(value))
+                    for value in item.get(
+                        "pressures", [0.0] * len(sub.segment_edge_keys)
+                    )
+                ]
 
-    def audit_edge_influence(self) -> Dict[Tuple[int, int], Dict[str, float]]:
+    def audit_edge_influence(
+        self, ensure_current: bool = True
+    ) -> Dict[Tuple[int, int], Dict[str, float]]:
         """Run the auditor, then integrate every traversal's own path
         quality onto each real edge (an adjacent pair in some traversal's
         node_ids) it passes through.
@@ -4724,7 +5691,8 @@ class FluxGraph:
         (total / count) separately from the *total* volume of influence
         running through it.
         """
-        self._run_graph_auditor()
+        if ensure_current:
+            self._run_graph_auditor()
         influence: Dict[Tuple[int, int], Dict[str, float]] = {}
         for traversal in self.traversals.values():
             quality = math.exp(traversal.mean_score)
@@ -4815,7 +5783,7 @@ class FluxGraph:
         fn = per_slice.get(field_name, self.config.scalar_fields.get(field_name))
         return float(fn(radius)) if fn is not None else 0.0
 
-    def _exchange_humidity(self) -> None:
+    def _exchange_humidity_scalar(self) -> None:
         """Exchange solvent and dissolved ambient materials through pores.
 
         ``humidity`` remains the ambient water amount. Every other scalar
@@ -4886,9 +5854,238 @@ class FluxGraph:
                     0.0, node.solubles.get(name, 0.0) + delta
                 )
 
+    def _exchange_humidity(self) -> None:
+        """Batch passive solvent and ambient-solute exchange by node/material."""
+        if torch is None:
+            self._exchange_humidity_scalar()
+            return
+        anchor_pressure = self.nodes[self.anchor_id].pressure
+        heart_low = anchor_pressure < self.config.starvation_floor
+        ceiling = self.config.overpressure_ceiling
+        heart_high = ceiling > 0.0 and anchor_pressure > ceiling
+        network_roots = self.orthogonal_network_roots()
+        exchange_nodes: List[FluxNode] = []
+        node_slices: List[str] = []
+        radii: List[float] = []
+        material_names = set(self.config.scalar_fields)
+        for fields in self.config.slice_scalar_fields.values():
+            material_names.update(fields)
+        material_names.discard("humidity")
+        materials = sorted(material_names)
+
+        for nid, node in self.nodes.items():
+            if node.burned or node.humidity_exchange <= 0.0:
+                continue
+            slices = self._node_slice(nid, node, network_roots)
+            if slices is None:
+                continue
+            own_slice, _ = slices
+            center_id = (
+                node.center_id
+                if node.center_id in self.nodes
+                else self.anchor_id
+            )
+            center_level = self.nodes[center_id].level or 0
+            exchange_nodes.append(node)
+            node_slices.append(own_slice)
+            radii.append(float(abs((node.level or 0) - center_level)))
+        if not exchange_nodes:
+            return
+
+        self._emit_status(
+            "humidity", "sampling ambient fields", 1, 3
+        )
+        ambient_humidity = []
+        ambient_materials = []
+        for slice_name, radius in zip(node_slices, radii):
+            ambient_humidity.append(
+                max(
+                    0.0,
+                    self._field_value(slice_name, "humidity", radius),
+                )
+            )
+            ambient_materials.append(
+                [
+                    max(
+                        0.0,
+                        self._field_value(slice_name, name, radius),
+                    )
+                    for name in materials
+                ]
+            )
+
+        dtype = torch.float32
+        device = self.device
+        solvent = torch.tensor(
+            [max(0.0, node.solvent) for node in exchange_nodes],
+            dtype=dtype,
+            device=device,
+        )
+        solute_total = torch.tensor(
+            [
+                sum(max(0.0, value) for value in node.solubles.values())
+                for node in exchange_nodes
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        volume = (solvent + solute_total).clamp_min(1e-12)
+        water_fraction = solvent / volume
+        osmotic_fraction = solute_total / volume
+        humidity = torch.tensor(
+            ambient_humidity, dtype=dtype, device=device
+        )
+        ambient = (
+            torch.tensor(ambient_materials, dtype=dtype, device=device)
+            if materials
+            else torch.empty(
+                (len(exchange_nodes), 0), dtype=dtype, device=device
+            )
+        )
+        ambient_osmoles = ambient.sum(dim=1)
+        ambient_activity = humidity / (
+            humidity + ambient_osmoles
+        ).clamp_min(1e-12)
+        exchange_rate = torch.tensor(
+            [node.humidity_exchange for node in exchange_nodes],
+            dtype=dtype,
+            device=device,
+        )
+        pressure_feature = torch.tanh(
+            torch.tensor(
+                [node.pressure for node in exchange_nodes],
+                dtype=dtype,
+                device=device,
+            )
+        )
+        hull_features = torch.stack(
+            (
+                torch.ones_like(volume),
+                pressure_feature,
+                water_fraction,
+                osmotic_fraction,
+                osmotic_fraction,
+                1.0 - osmotic_fraction.clamp_max(1.0),
+            ),
+            dim=1,
+        )
+        if self.config.physiology_learning_enabled:
+            self._ensure_subedge_archetype()
+            learned_hull = self._linear_archetype_openings(
+                "node:hull", self._NODE_ARCHETYPE_FEATURES, hull_features
+            )
+        else:
+            learned_hull = torch.ones_like(volume)
+        declared_hull = torch.tensor(
+            [
+                max(0.0, min(1.0, node.hull_permeability))
+                for node in exchange_nodes
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        hull_opening = declared_hull * learned_hull
+
+        self._emit_status(
+            "humidity", "evaluating pore archetype batch", 2, 3
+        )
+        all_materials = ["solvent", *materials]
+        held = torch.zeros(
+            (len(exchange_nodes), len(all_materials)),
+            dtype=dtype,
+            device=device,
+        )
+        held[:, 0] = solvent
+        for column, name in enumerate(materials, start=1):
+            held[:, column] = torch.tensor(
+                [
+                    max(0.0, node.solubles.get(name, 0.0))
+                    for node in exchange_nodes
+                ],
+                dtype=dtype,
+                device=device,
+            )
+        material_fraction = held / volume[:, None]
+        pore_features = torch.stack(
+            (
+                torch.ones_like(material_fraction),
+                pressure_feature[:, None].expand_as(material_fraction),
+                water_fraction[:, None].expand_as(material_fraction),
+                osmotic_fraction[:, None].expand_as(material_fraction),
+                material_fraction,
+                1.0 - material_fraction.clamp_max(1.0),
+            ),
+            dim=2,
+        )
+        if self.config.physiology_learning_enabled:
+            learned_pore = self._linear_archetype_openings(
+                "node:pore",
+                self._NODE_ARCHETYPE_FEATURES,
+                pore_features.reshape(
+                    -1, len(self._NODE_ARCHETYPE_FEATURES)
+                ),
+            ).reshape_as(material_fraction)
+        else:
+            learned_pore = torch.ones_like(material_fraction)
+        declared_pore = torch.tensor(
+            [
+                [
+                    max(
+                        0.0,
+                        min(
+                            1.0,
+                            node.pore_permeabilities.get(name, 1.0),
+                        ),
+                    )
+                    for name in all_materials
+                ]
+                for node in exchange_nodes
+            ],
+            dtype=dtype,
+            device=device,
+        )
+        permeability = (
+            hull_opening[:, None] * declared_pore * learned_pore
+        )
+
+        self._emit_status(
+            "humidity", "applying exchange batch", 3, 3
+        )
+        target_solvent = humidity + solute_total * ambient_activity
+        solvent_flow = (
+            exchange_rate
+            * permeability[:, 0]
+            * (target_solvent - solvent)
+        )
+        if heart_low:
+            solvent_flow = solvent_flow.clamp_min(0.0)
+        elif heart_high:
+            solvent_flow = solvent_flow.clamp_max(0.0)
+        solvent = (solvent + solvent_flow).clamp_min(0.0)
+        if materials:
+            material_delta = (
+                exchange_rate[:, None]
+                * permeability[:, 1:]
+                * (ambient - held[:, 1:])
+            )
+            new_materials = (held[:, 1:] + material_delta).clamp_min(0.0)
+        else:
+            new_materials = held[:, 1:]
+
+        solvent_rows = solvent.detach().cpu().tolist()
+        material_rows = new_materials.detach().cpu().tolist()
+        for node, new_solvent, row in zip(
+            exchange_nodes, solvent_rows, material_rows
+        ):
+            node.solvent = new_solvent
+            for name, amount in zip(materials, row):
+                node.solubles[name] = amount
+
     def _ingest_from_rings(self) -> None:
-        """Ring dispensing: each pie slice's ring hands its own unique
-        soluble to nearby nodes, at a rate set by how close each node
+        """Conserved ring dispensing from the active seed's finite habitat.
+
+        Each pie slice's ring hands its own unique soluble to nearby nodes,
+        at a rate set by how close each node
         currently sits to its ring *in the client's own interface sim*.
         That nearness doesn't exist back here at all -- the backend has
         no node positions -- so it arrives through the external-physics
@@ -4899,15 +6096,21 @@ class FluxGraph:
         backend-only process wearing its name.
 
         One unique substance per pie slice (see _node_slice for naming).
-        Ingesting your own slice's soluble consumes an equal amount of
-        the *opposite* slice's soluble (same group, other direction)
-        already held in the node: amount = proximity * opposite_held, so
-        nearness and available payment are the only throttles -- no
-        arbitrary rate constant.
+        Uptake debits the same named ion from the backend-owned habitat;
+        the node's opposite ion is untouched. This replaces the previous
+        implicit transmutation of one ion identity into another.
         """
         client = self.external_physics.get("client", {})
         proximity: Dict[int, float] = client.get("ring_proximity") or {}
         if not proximity:
+            return
+        patch = self._ensure_current_habitat()
+        target = max(
+            0.0,
+            min(1.0, float(self.config.growth_target_ion_concentration)),
+        )
+        uptake_rate = max(0.0, min(1.0, float(self.config.ring_uptake_rate)))
+        if target <= 0.0 or uptake_rate <= 0.0:
             return
         network_roots = self.orthogonal_network_roots()
         for nid, node in self.nodes.items():
@@ -4919,13 +6122,440 @@ class FluxGraph:
             slices = self._node_slice(nid, node, network_roots)
             if slices is None:
                 continue
-            own_name, opposite_name = slices
-            opposite_held = node.solubles.get(opposite_name, 0.0)
-            if opposite_held <= 0.0:
+            own_name, _ = slices
+            available = max(0.0, patch.get(own_name, 0.0))
+            if available <= 0.0:
                 continue
-            amount = min(1.0, max(0.0, float(near))) * opposite_held
-            node.solubles[opposite_name] = opposite_held - amount
-            node.solubles[own_name] = node.solubles.get(own_name, 0.0) + amount
+            held = max(0.0, node.solubles.get(own_name, 0.0))
+            volume = max(node.volume, 1.0)
+            concentration = held / volume
+            if concentration >= target:
+                continue
+            # Adding x solute also adds x total volume. This is the exact
+            # correction needed to reach target before contact throttling.
+            correction = (
+                (target * volume - held) / max(1e-12, 1.0 - target)
+            )
+            amount = min(
+                available,
+                correction
+                * min(1.0, max(0.0, float(near)))
+                * uptake_rate,
+            )
+            if amount <= 0.0:
+                continue
+            patch[own_name] = available - amount
+            node.solubles[own_name] = held + amount
+
+    def _solve_coupled_fluid_system(self) -> None:
+        """Relax nodes, path lumens, edge hulls, and spatial bath together.
+
+        Every row is a real fluid compartment and every sparse connection is
+        marshalled once, then all pressure, advection, diffusion, source
+        limiting, and accumulation happens with Torch scatter operations.
+        Audited tubes connect to nodes only at their terminals. Their ordered
+        lumen segments remain stateful between ticks; intermediate graph
+        nodes are deliberately absent from those connection lists.
+        """
+        if torch is None:
+            # The corrected model intentionally has one implementation: a
+            # vectorized coupled solve. Silently reverting to endpoint
+            # teleportation would change the physical ontology.
+            self.physiology_error = "PyTorch is required for coupled fluid transport"
+            return
+
+        cfg = self.config
+        live_nodes = [node for node in self.nodes.values() if not node.burned]
+        if not live_nodes:
+            return
+        self._reset_edge_flow()
+
+        # Compatibility/global inputs enter the spatial bath at their actual
+        # locality: the active seed. They cease being a globally mixed bath.
+        anchor_bath = self.bath_by_node.setdefault(self.anchor_id, {})
+        for name, amount in list(self.bath.items()):
+            if amount:
+                anchor_bath[name] = anchor_bath.get(name, 0.0) + max(0.0, float(amount))
+        self.bath.clear()
+        for node in live_nodes:
+            self.bath_by_node.setdefault(node.id, {})
+
+        compartments: List[Tuple[str, Any, Optional[int]]] = []
+        compliance: List[float] = []
+        node_comp: Dict[int, int] = {}
+        bath_comp: Dict[int, int] = {}
+        hull_comp: Dict[Tuple[int, int], int] = {}
+        tube_comp: Dict[Tuple[int, int], int] = {}
+
+        for node in live_nodes:
+            node_comp[node.id] = len(compartments)
+            compartments.append(("node", node, None))
+            compliance.append(max(1e-6, float(cfg.node_compliance)))
+        for node in live_nodes:
+            bath_comp[node.id] = len(compartments)
+            compartments.append(("bath", self.bath_by_node[node.id], None))
+            compliance.append(max(1e-6, float(cfg.bath_compliance)))
+        for edge_key, edge in self.edges.items():
+            if edge_key[0] not in node_comp or edge_key[1] not in node_comp:
+                continue
+            hull_comp[edge_key] = len(compartments)
+            compartments.append(("hull", edge, None))
+            compliance.append(max(1e-6, float(cfg.hull_compliance)))
+        live_traversals = [
+            traversal for traversal in self.traversals.values()
+            if traversal.start_id in node_comp and traversal.end_id in node_comp
+        ]
+        for traversal in live_traversals:
+            for sub_index, sub in enumerate(traversal.subedges):
+                sub.delivered_utility = 0.0
+                for segment_index in range(len(sub.segment_edge_keys)):
+                    tube_comp[(id(sub), segment_index)] = len(compartments)
+                    compartments.append(("tube", sub, segment_index))
+                    compliance.append(max(1e-6, float(cfg.tube_compliance)))
+
+        names = {"solvent"}
+        for kind, owner, segment_index in compartments:
+            if kind == "node":
+                names.update(owner.solubles)
+            elif kind == "bath":
+                names.update(owner)
+            elif kind == "hull":
+                names.update(owner.hull_solubles)
+            else:
+                names.update(owner.segment_solubles[segment_index])
+        component_names = ["solvent"] + sorted(names - {"solvent"})
+        component_index = {name: index for index, name in enumerate(component_names)}
+        rows: List[List[float]] = []
+        for kind, owner, segment_index in compartments:
+            row = [0.0] * len(component_names)
+            if kind == "node":
+                row[0], solubles = owner.solvent, owner.solubles
+            elif kind == "bath":
+                row[0], solubles = owner.get("solvent", 0.0), owner
+            elif kind == "hull":
+                row[0], solubles = owner.hull_solvent, owner.hull_solubles
+            else:
+                row[0] = owner.segment_solvent[segment_index]
+                solubles = owner.segment_solubles[segment_index]
+            for name, amount in solubles.items():
+                if name != "solvent" and name in component_index:
+                    row[component_index[name]] = max(0.0, float(amount))
+            rows.append(row)
+
+        # Sparse arcs. Passive connections get both directions; tube arcs
+        # are genuinely one-way and ordered from terminal to terminal.
+        arc_src: List[int] = []
+        arc_dst: List[int] = []
+        arc_g: List[float] = []
+        arc_edge: List[int] = []
+        arc_sign: List[float] = []
+        edge_items = list(self.edges.items())
+        edge_index = {key: index for index, (key, _) in enumerate(edge_items)}
+
+        def arc(src: int, dst: int, conductance: float,
+                edge_key: Optional[Tuple[int, int]] = None, sign: float = 0.0) -> None:
+            if conductance <= 0.0:
+                return
+            arc_src.append(src)
+            arc_dst.append(dst)
+            arc_g.append(conductance)
+            arc_edge.append(edge_index.get(edge_key, -1) if edge_key else -1)
+            arc_sign.append(sign)
+
+        def passive(a: int, b: int, conductance: float,
+                    edge_key: Optional[Tuple[int, int]] = None) -> None:
+            sign = 1.0
+            if edge_key and compartments[a][0] == "node":
+                sign = 1.0 if compartments[a][1].id == edge_key[0] else -1.0
+            arc(a, b, conductance, edge_key, sign)
+            arc(b, a, conductance, edge_key, -sign)
+
+        for edge_key, edge in edge_items:
+            a, b = edge_key
+            if edge_key not in hull_comp or a not in node_comp or b not in node_comp:
+                continue
+            hardening = 1.0 + cfg.branch_maturity_conductance_bonus * edge.maturity
+            valve = max(0.0, float(cfg.hull_node_valve)) * hardening
+            passive(node_comp[a], hull_comp[edge_key], valve, edge_key)
+            passive(hull_comp[edge_key], node_comp[b], valve, edge_key)
+            passive(bath_comp[a], bath_comp[b], cfg.bath_graph_conductance, edge_key)
+            passive(hull_comp[edge_key], bath_comp[a], cfg.hull_bath_permeability)
+            passive(hull_comp[edge_key], bath_comp[b], cfg.hull_bath_permeability)
+        for node in live_nodes:
+            passive(node_comp[node.id], bath_comp[node.id], cfg.node_bath_permeability)
+
+        terminal_arcs: List[Tuple[int, SubEdge, int]] = []
+        for traversal in live_traversals:
+            for sub in traversal.subedges:
+                count = len(sub.segment_edge_keys)
+                if not count:
+                    continue
+                start_id = traversal.start_id if sub.direction == "forward" else traversal.end_id
+                end_id = traversal.end_id if sub.direction == "forward" else traversal.start_id
+                chain = [node_comp[start_id]] + [
+                    tube_comp[(id(sub), i)] for i in range(count)
+                ] + [node_comp[end_id]]
+                gate = self._learned_subedge_opening(sub)
+                for link_index, (src, dst) in enumerate(zip(chain, chain[1:])):
+                    edge_key = sub.segment_edge_keys[min(link_index, count - 1)]
+                    causal_sign = 1.0 if sub.direction == "forward" else -1.0
+                    conductance = 1.0
+                    if link_index in (0, count):
+                        conductance *= gate
+                    edge = self.edges.get(edge_key)
+                    if edge is not None:
+                        conductance *= (
+                            1.0
+                            + cfg.branch_maturity_conductance_bonus * edge.maturity
+                        )
+                    arc(src, dst, conductance, edge_key, causal_sign)
+                    if link_index == count:
+                        terminal_arcs.append((len(arc_src) - 1, sub, end_id))
+
+        device, dtype = self.device, torch.float64
+        initial_values = torch.tensor(rows, dtype=dtype, device=device)
+        values = initial_values.clone()
+        compliance_t = torch.tensor(compliance, dtype=dtype, device=device)
+        if not arc_src:
+            return
+        src_idx = torch.tensor(arc_src, dtype=torch.long, device=device)
+        dst_idx = torch.tensor(arc_dst, dtype=torch.long, device=device)
+        conductance = torch.tensor(arc_g, dtype=dtype, device=device)
+        dt = max(0.0, float(cfg.fluid_time_step))
+        edge_flow = torch.zeros(len(edge_items), dtype=dtype, device=device)
+        edge_components = torch.zeros(
+            (len(edge_items), len(component_names)), dtype=dtype, device=device
+        )
+        delivered = torch.zeros(len(arc_src), dtype=dtype, device=device)
+
+        def limited_transfer(raw: Any, source: Any, available: Any) -> Any:
+            demand = torch.zeros_like(available)
+            demand.index_add_(0, source, raw)
+            scale = torch.where(
+                demand > 0.0,
+                torch.minimum(
+                    torch.ones_like(demand),
+                    available / demand.clamp_min(1e-12),
+                ),
+                torch.ones_like(demand),
+            )
+            return raw * scale.index_select(0, source)
+
+        client_result = None
+        if self.fluid_work_delegate is not None:
+            packet = {
+                "tick": self.tick_count,
+                "components": component_names,
+                "values": rows,
+                "compliance": compliance,
+                "compartments": [
+                    (
+                        {"kind": "node", "node_id": owner.id}
+                        if kind == "node"
+                        else {"kind": "bath", "node_id": next(
+                            node_id for node_id, mixture in self.bath_by_node.items()
+                            if mixture is owner
+                        )}
+                        if kind == "bath"
+                        else {"kind": "hull", "edge": [owner.from_id, owner.to_id]}
+                        if kind == "hull"
+                        else {
+                            "kind": "tube",
+                            "traversal": list(owner.traversal_key),
+                            "direction": owner.direction,
+                            "segment": segment_index,
+                            "edge": list(owner.segment_edge_keys[segment_index]),
+                        }
+                    )
+                    for kind, owner, segment_index in compartments
+                ],
+                "arcs": {
+                    "source": arc_src,
+                    "destination": arc_dst,
+                    "conductance": arc_g,
+                    "edge": [
+                        list(edge_items[index][0]) if index >= 0 else None
+                        for index in arc_edge
+                    ],
+                    "sign": arc_sign,
+                },
+                "parameters": {
+                    "substeps": max(1, int(cfg.fluid_solver_substeps)),
+                    "time_step": dt,
+                    "bulk_conductance": float(cfg.fluid_bulk_conductance),
+                    "ion_diffusion": float(cfg.fluid_diffusion_conductance),
+                    "osmotic_pressure": float(cfg.fluid_osmotic_pressure),
+                },
+            }
+            client_result = self.fluid_work_delegate(packet)
+
+        if client_result is not None:
+            result_rows = client_result.get("values", [])
+            arc_bulk = client_result.get("arc_bulk", [])
+            arc_components = client_result.get("arc_components", [])
+            expected_shape = (len(compartments), len(component_names))
+            if (
+                len(result_rows) != expected_shape[0]
+                or any(len(row) != expected_shape[1] for row in result_rows)
+                or len(arc_bulk) != len(arc_src)
+                or len(arc_components) != len(arc_src)
+                or any(len(row) != expected_shape[1] for row in arc_components)
+            ):
+                raise ValueError("client fluid result has the wrong tensor shape")
+            values = torch.tensor(result_rows, dtype=dtype, device=device)
+            if not bool(torch.isfinite(values).all()) or bool((values < -1e-9).any()):
+                raise ValueError("client fluid result contains invalid material amounts")
+            initial_total = initial_values.sum(dim=0)
+            final_total = values.sum(dim=0)
+            residual = float(torch.max(torch.abs(initial_total - final_total)).item())
+            if residual > 1e-7:
+                raise ValueError(
+                    f"client fluid result violates conservation (residual {residual:.3g})"
+                )
+            delivered = torch.tensor(arc_bulk, dtype=dtype, device=device)
+            arc_component_tensor = torch.tensor(
+                arc_components, dtype=dtype, device=device
+            )
+            edge_ids = torch.tensor(arc_edge, dtype=torch.long, device=device)
+            valid = edge_ids >= 0
+            if bool(valid.any()):
+                selected_edges = edge_ids[valid]
+                signs = torch.tensor(arc_sign, dtype=dtype, device=device)[valid]
+                edge_flow.index_add_(0, selected_edges, delivered[valid] * signs)
+                edge_components.index_add_(
+                    0,
+                    selected_edges,
+                    arc_component_tensor[valid] * signs[:, None],
+                )
+            self.last_fluid_proof = {
+                "tick": self.tick_count,
+                "worker": "client",
+                "conservation_residual": residual,
+                "substeps": max(1, int(cfg.fluid_solver_substeps)),
+                "work_id": client_result.get("work_id"),
+            }
+        else:
+          for _ in range(max(1, int(cfg.fluid_solver_substeps))):
+            volume = values.sum(dim=1)
+            solute = values[:, 1:].sum(dim=1) if values.shape[1] > 1 else torch.zeros_like(volume)
+            solvent = values[:, 0]
+            pressure = (
+                solvent
+                + cfg.fluid_osmotic_pressure
+                * solute / solvent.clamp_min(1e-6)
+            ) / compliance_t
+            raw_bulk = (
+                torch.relu(pressure.index_select(0, src_idx) - pressure.index_select(0, dst_idx))
+                * conductance * cfg.fluid_bulk_conductance * dt
+            )
+            moved_bulk = limited_transfer(raw_bulk, src_idx, volume)
+            source_values = values.index_select(0, src_idx)
+            mixture = (
+                source_values / source_values.sum(dim=1, keepdim=True).clamp_min(1e-12)
+                * moved_bulk[:, None]
+            )
+            values.index_add_(0, src_idx, -mixture)
+            values.index_add_(0, dst_idx, mixture)
+            delivered += moved_bulk
+
+            if values.shape[1] > 1:
+                volume = values.sum(dim=1).clamp_min(1e-12)
+                concentration = values[:, 1:] / volume[:, None]
+                raw_diff = (
+                    torch.relu(
+                        concentration.index_select(0, src_idx)
+                        - concentration.index_select(0, dst_idx)
+                    )
+                    * (conductance * cfg.fluid_diffusion_conductance * dt)[:, None]
+                )
+                source_matrix = src_idx[:, None].expand_as(raw_diff)
+                demand = torch.zeros_like(values[:, 1:])
+                demand.scatter_add_(0, source_matrix, raw_diff)
+                scale = torch.where(
+                    demand > 0.0,
+                    torch.minimum(
+                        torch.ones_like(demand),
+                        values[:, 1:] / demand.clamp_min(1e-12),
+                    ),
+                    torch.ones_like(demand),
+                )
+                moved_diff = raw_diff * torch.gather(scale, 0, source_matrix)
+                delta = torch.zeros_like(values[:, 1:])
+                delta.scatter_add_(0, source_matrix, -moved_diff)
+                delta.scatter_add_(0, dst_idx[:, None].expand_as(moved_diff), moved_diff)
+                values[:, 1:] += delta
+                mixture[:, 1:] += moved_diff
+
+            edge_ids = torch.tensor(arc_edge, dtype=torch.long, device=device)
+            valid = edge_ids >= 0
+            if bool(valid.any()):
+                selected_edges = edge_ids[valid]
+                signs = torch.tensor(arc_sign, dtype=dtype, device=device)[valid]
+                edge_flow.index_add_(0, selected_edges, moved_bulk[valid] * signs)
+                edge_components.index_add_(
+                    0, selected_edges, mixture[valid] * signs[:, None]
+                )
+          self.last_fluid_proof = {
+              "tick": self.tick_count,
+              "worker": "server",
+              "conservation_residual": float(
+                  torch.max(
+                      torch.abs(initial_values.sum(dim=0) - values.sum(dim=0))
+                  ).item()
+              ),
+              "substeps": max(1, int(cfg.fluid_solver_substeps)),
+          }
+
+        values = values.clamp_min(0.0)
+        final_volume = values.sum(dim=1)
+        final_pressure = (
+            values[:, 0]
+            + cfg.fluid_osmotic_pressure
+            * values[:, 1:].sum(dim=1) / values[:, 0].clamp_min(1e-6)
+        ) / compliance_t
+        cpu_values = values.detach().cpu().tolist()
+        cpu_pressure = final_pressure.detach().cpu().tolist()
+        for row_index, ((kind, owner, segment_index), row, pressure_value) in enumerate(
+            zip(compartments, cpu_values, cpu_pressure)
+        ):
+            solubles = {
+                name: row[column]
+                for column, name in enumerate(component_names[1:], start=1)
+                if row[column] > 1e-12
+            }
+            if kind == "node":
+                owner.solvent, owner.solubles, owner.pressure = row[0], solubles, pressure_value
+            elif kind == "bath":
+                owner.clear()
+                if row[0] > 1e-12:
+                    owner["solvent"] = row[0]
+                owner.update(solubles)
+            elif kind == "hull":
+                owner.hull_solvent, owner.hull_solubles, owner.hull_pressure = row[0], solubles, pressure_value
+            else:
+                owner.segment_solvent[segment_index] = row[0]
+                owner.segment_solubles[segment_index] = solubles
+                owner.segment_pressures[segment_index] = pressure_value
+
+        delivered_cpu = delivered.detach().cpu().tolist()
+        for arc_index, sub, end_id in terminal_arcs:
+            destination = self.nodes[end_id]
+            before = max(destination.volume - delivered_cpu[arc_index], 1e-12)
+            need = max(
+                0.0,
+                cfg.growth_target_ion_concentration
+                - sum(destination.solubles.values()) / before,
+            )
+            sub.delivered_utility = delivered_cpu[arc_index] * need
+        flow_rows = edge_flow.detach().cpu().tolist()
+        component_rows = edge_components.detach().cpu().tolist()
+        for (_, edge), flow, row in zip(edge_items, flow_rows, component_rows):
+            edge.flow = flow
+            edge.component_flows = {
+                name: row[column]
+                for column, name in enumerate(component_names)
+                if abs(row[column]) > 1e-12
+            }
 
     def _transport_subedges_scalar(self) -> None:
         """One pass of volume transport through every traversal's subedges.
@@ -5014,9 +6644,8 @@ class FluxGraph:
         availability limiting, mixture movement, and path-flow accumulation
         are tensor operations.
         """
-        if torch is None:
-            self._transport_subedges_scalar()
-            return
+        self._solve_coupled_fluid_system()
+        return
 
         self._reset_edge_flow()
         network_roots = self.orthogonal_network_roots()
@@ -5369,6 +6998,29 @@ class FluxGraph:
             na, nb = self.nodes.get(a), self.nodes.get(b)
             edge.pressure_drop = (na.pressure - nb.pressure) if na and nb else 0.0
 
+    def _update_branch_maturity(self) -> None:
+        """Harden branches only when their tubes relieve terminal scarcity."""
+        retention = max(
+            0.0, min(1.0, float(self.config.branch_maturity_retention))
+        )
+        gain = max(0.0, float(self.config.branch_maturity_gain))
+        utility_by_edge: Dict[Tuple[int, int], float] = {}
+        for traversal in self.traversals.values():
+            for sub in traversal.subedges:
+                if sub.delivered_utility <= 0.0:
+                    continue
+                for edge_key in sub.segment_edge_keys:
+                    utility_by_edge[edge_key] = (
+                        utility_by_edge.get(edge_key, 0.0)
+                        + sub.delivered_utility
+                    )
+        for edge_key, edge in self.edges.items():
+            signal = 1.0 - math.exp(-utility_by_edge.get(edge_key, 0.0))
+            edge.maturity = max(
+                0.0,
+                min(1.0, retention * edge.maturity + gain * signal),
+            )
+
     def _record_edge_flow(
         self, node_ids: List[int], downward: bool, amount: float,
         mixture: Optional[Dict[str, float]] = None,
@@ -5509,6 +7161,7 @@ class FluxGraph:
                 continue
             circulation = dict(node.solubles)
             circulation["solvent"] = node.solvent
+            local_bath = self.bath_by_node.setdefault(node.id, {})
             changed_circulation = False
             for factory in node.factories:
                 if not factory.enabled or factory.throughput <= 0.0:
@@ -5517,13 +7170,13 @@ class FluxGraph:
                 remaining = factory.throughput
                 if medium in ("circulatory", "both"):
                     used = self._run_factory_reaction(
-                        node, factory, circulation, remaining, self.bath
+                        node, factory, circulation, remaining, local_bath
                     )
                     remaining -= used
                     changed_circulation = changed_circulation or used > 0.0
                 if medium in ("csf", "both") and remaining > 0.0:
                     self._run_factory_reaction(
-                        node, factory, self.bath, remaining, self.bath
+                        node, factory, local_bath, remaining, local_bath
                     )
                 elif medium not in ("circulatory", "csf", "both"):
                     raise ValueError(
@@ -5547,7 +7200,11 @@ class FluxGraph:
         if heart is None:
             heart = Heart()
             heart.set_script(self.config.heart_script)
-            heart.attach("csf_link", when="post", scope="total", fn=self._csf_link_hook)
+            heart.attach(
+                "csf_link", when="post", scope="total",
+                fn=lambda chambers, region=region:
+                    self._csf_link_hook(chambers, region),
+            )
             self.hearts[region] = heart
         self._bind_heart_learning(region, heart)
         return heart
@@ -5584,21 +7241,31 @@ class FluxGraph:
         )
         return heart
 
-    def _csf_link_hook(self, chambers: Dict[str, Dict[str, float]]) -> None:
+    def _csf_link_hook(
+        self, chambers: Dict[str, Dict[str, float]], region: str = "main"
+    ) -> None:
         """Exchange every chamber's contents with the CSF bath toward
         equalizing concentration, throttled by config.csf_link_rate.
         Dormant (a no-op) while the rate is 0."""
         rate = self.config.csf_link_rate
         if rate <= 0.0:
             return
+        heart = self.hearts.get(region)
+        locality = (
+            heart.seed_owner_id if heart is not None
+            and heart.seed_owner_id in self.nodes else self.anchor_id
+        )
+        local_bath = self.bath_by_node.setdefault(locality, {})
         for mix in chambers.values():
-            names = set(mix) | set(self.bath)
+            names = set(mix) | set(local_bath)
             for name in names:
-                delta = rate * (mix.get(name, 0.0) - self.bath.get(name, 0.0))
+                delta = rate * (
+                    mix.get(name, 0.0) - local_bath.get(name, 0.0)
+                )
                 if delta == 0.0:
                     continue
                 mix[name] = mix.get(name, 0.0) - delta
-                self.bath[name] = self.bath.get(name, 0.0) + delta
+                local_bath[name] = local_bath.get(name, 0.0) + delta
 
     def _pump_csf_to_rhizome(self) -> None:
         """Let only the active seed clean global CSF into one rhizome.
@@ -5613,11 +7280,16 @@ class FluxGraph:
         rate = max(0.0, min(1.0, self.config.rhizome_csf_pump_rate))
         if rate <= 0.0:
             return
+        local_bath = self.bath_by_node.setdefault(self.anchor_id, {})
         for name, amount in list(self.bath.items()):
+            if amount:
+                local_bath[name] = local_bath.get(name, 0.0) + amount
+        self.bath.clear()
+        for name, amount in list(local_bath.items()):
             if name == "solvent" or amount <= 0.0:
                 continue
             moved = amount * rate
-            self.bath[name] = amount - moved
+            local_bath[name] = amount - moved
             self.rhizome[name] = self.rhizome.get(name, 0.0) + moved
 
     def _exude_rhizome_to_soil(self) -> None:
@@ -5667,14 +7339,19 @@ class FluxGraph:
         heart = self.hearts.pop(region, None)
         if heart is None:
             return
+        locality = (
+            heart.seed_owner_id
+            if heart.seed_owner_id in self.nodes else self.anchor_id
+        )
+        local_bath = self.bath_by_node.setdefault(locality, {})
         for mixture in heart.chambers.values():
             for name, amount in mixture.items():
                 if amount:
-                    self.bath[name] = self.bath.get(name, 0.0) + amount
+                    local_bath[name] = local_bath.get(name, 0.0) + amount
         for reservoir in heart.reservoirs.values():
             for name, amount in reservoir.drain().items():
                 if amount:
-                    self.bath[name] = self.bath.get(name, 0.0) + amount
+                    local_bath[name] = local_bath.get(name, 0.0) + amount
 
     def _reap_dead_hearts(self, live_regions: "set[str]") -> None:
         """Spill hearts that no longer belong to a live level-zero seed.
@@ -5704,8 +7381,8 @@ class FluxGraph:
         reservoir exchange, contractions, osmotic rebalance, squeeze).
         The pump node's own solubles are never touched -- chambers and
         reservoirs hold supply, the node doesn't."""
-        inflow_routes: Dict[str, List[Tuple[SubEdge, FluxNode]]] = {}
-        outflow_routes: Dict[str, List[Tuple[SubEdge, FluxNode]]] = {}
+        inflow_routes: Dict[str, List[Tuple[SubEdge, int]]] = {}
+        outflow_routes: Dict[str, List[Tuple[SubEdge, int]]] = {}
         for traversal in self.traversals.values():
             start_id, end_id = traversal.start_id, traversal.end_id
             if pump_id not in (start_id, end_id):
@@ -5722,8 +7399,15 @@ class FluxGraph:
                 slices = self._node_slice(far_id, far, network_roots)
                 if slices is None:
                     continue
+                # The heart touches the lumen cross-section at its own
+                # terminal. It never drains or fills the remote endpoint.
+                segment_index = (
+                    len(sub.segment_edge_keys) - 1 if is_inflow else 0
+                )
+                if segment_index < 0:
+                    continue
                 routes = inflow_routes if is_inflow else outflow_routes
-                routes.setdefault(slices[0], []).append((sub, far))
+                routes.setdefault(slices[0], []).append((sub, segment_index))
 
         if not inflow_routes and not outflow_routes and region not in self.hearts:
             return  # nothing to pump and no heart yet -- don't materialize one
@@ -5762,7 +7446,8 @@ class FluxGraph:
         the main heart's in-chambers; dormant while lymph_return_rate is
         0 or the main heart hasn't formed yet."""
         rate = self.config.lymph_return_rate
-        if rate <= 0.0 or not self.bath:
+        local_bath = self.bath_by_node.setdefault(self.anchor_id, {})
+        if rate <= 0.0 or not local_bath:
             return
         heart = self.hearts.get("main")
         if heart is None:
@@ -5771,11 +7456,11 @@ class FluxGraph:
         if not in_keys:
             return
         share = 1.0 / len(in_keys)
-        for name, amount in list(self.bath.items()):
+        for name, amount in list(local_bath.items()):
             drained = amount * rate
             if drained == 0.0:
                 continue
-            self.bath[name] = amount - drained
+            local_bath[name] = amount - drained
             for key in in_keys:
                 heart.chambers[key][name] = heart.chambers[key].get(name, 0.0) + drained * share
 
@@ -5783,7 +7468,7 @@ class FluxGraph:
         self,
         phase: HeartPhase,
         contractions: Dict[str, float],
-        outflow_routes: Dict[str, List[Tuple["SubEdge", FluxNode]]],
+        outflow_routes: Dict[str, List[Tuple["SubEdge", int]]],
         heart: "Heart",
     ) -> None:
         """Contracting out-chambers expel to the network: their own
@@ -5819,32 +7504,79 @@ class FluxGraph:
                 expelled[name] = moved
             if not expelled:
                 continue
-            for sub, far in routes:
+            for sub, segment_index in routes:
                 opening = self._learned_subedge_opening(sub)
-                self._deposit_mixture(
-                    far, expelled, scale=opening / total_constriction
+                self._deposit_segment_mixture(
+                    sub, segment_index, expelled,
+                    scale=opening / total_constriction,
                 )
 
     def _chamber_intake_plan(
-        self, inflow: List[Tuple["SubEdge", FluxNode]], anchor: FluxNode
-    ) -> List[Tuple[FluxNode, float]]:
+        self, inflow: List[Tuple["SubEdge", int]], anchor: FluxNode
+    ) -> List[Tuple[SubEdge, int, float]]:
         """What one chamber's inflow subedges would draw this beat --
         computed exactly like ordinary transport (anchor standing in as
         the destination), purely read-only, so every chamber can be
         measured from the same snapshot before anything is drained.
         """
-        return [
-            (far, amount)
-            for sub, far in inflow
-            if (amount := self._subedge_flow_amount(sub, far, anchor)) > 0.0
-        ]
+        plan = []
+        for sub, segment_index in inflow:
+            segment_volume = (
+                sub.segment_solvent[segment_index]
+                + sum(sub.segment_solubles[segment_index].values())
+            )
+            drive = (
+                sub.segment_pressures[segment_index] - anchor.pressure
+                + segment_volume - anchor.volume
+            )
+            amount = self._learned_subedge_opening(sub) * max(0.0, drive)
+            if amount > 0.0:
+                plan.append((sub, segment_index, amount))
+        return plan
 
-    def _drain_plan(self, plan: List[Tuple[FluxNode, float]]) -> Dict[str, float]:
+    def _drain_plan(
+        self, plan: List[Tuple[SubEdge, int, float]]
+    ) -> Dict[str, float]:
         """Apply a measured intake plan, pooling every drained mix
         (solvent and solubles together) into one chamber-load."""
         pooled: Dict[str, float] = {}
-        for far, amount in plan:
-            for name, moved in self._drain_mixture(far, amount).items():
+        for sub, segment_index, amount in plan:
+            for name, moved in self._drain_segment_mixture(
+                sub, segment_index, amount
+            ).items():
                 pooled[name] = pooled.get(name, 0.0) + moved
         return pooled
+
+    @staticmethod
+    def _drain_segment_mixture(
+        sub: SubEdge, segment_index: int, amount: float
+    ) -> Dict[str, float]:
+        solvent = sub.segment_solvent[segment_index]
+        solubles = sub.segment_solubles[segment_index]
+        total = solvent + sum(solubles.values())
+        if total <= 0.0 or amount <= 0.0:
+            return {}
+        fraction = min(1.0, amount / total)
+        mixture = {"solvent": solvent * fraction}
+        sub.segment_solvent[segment_index] -= mixture["solvent"]
+        for name, held in list(solubles.items()):
+            moved = held * fraction
+            solubles[name] = held - moved
+            if moved:
+                mixture[name] = moved
+        return mixture
+
+    @staticmethod
+    def _deposit_segment_mixture(
+        sub: SubEdge, segment_index: int, mixture: Dict[str, float],
+        scale: float = 1.0,
+    ) -> None:
+        sub.segment_solvent[segment_index] += (
+            mixture.get("solvent", 0.0) * scale
+        )
+        solubles = sub.segment_solubles[segment_index]
+        for name, amount in mixture.items():
+            if name == "solvent":
+                continue
+            solubles[name] = solubles.get(name, 0.0) + amount * scale
 

--- a/speaktome/flux_radar/index.html
+++ b/speaktome/flux_radar/index.html
@@ -69,6 +69,18 @@ h1{
 .fg-btn:hover{ background: var(--grid-dim); border-color: var(--fwd); }
 .fg-btn:disabled{ opacity:0.4; cursor:default; }
 .fg-error{ color: var(--danger); font-size:12px; margin-top:8px; display:none; }
+.fg-growth-estimate{
+  font-size:12px; margin-bottom:10px; padding:8px 12px;
+  border-radius:6px; border:0.5px solid var(--grid); background: var(--panel-bg-dark);
+}
+.fg-growth-estimate .headline{ color: var(--ink-bright); }
+.fg-growth-estimate .detail{ color: var(--ink); font-size:11px; margin-top:2px; }
+.fg-growth-estimate.tier-ok{ border-color: var(--grid); }
+.fg-growth-estimate.tier-ok .headline{ color: var(--readout); }
+.fg-growth-estimate.tier-warn{ border-color: var(--bwd-dim); }
+.fg-growth-estimate.tier-warn .headline{ color: var(--bwd); }
+.fg-growth-estimate.tier-bonkers{ border-color: var(--danger); background: rgba(255,128,128,0.08); }
+.fg-growth-estimate.tier-bonkers .headline{ color: var(--danger); font-weight:600; }
 .fg-readout{
   display:flex; align-items:baseline; gap:10px; flex-wrap:wrap;
   padding: 8px 12px; margin-bottom: 10px;
@@ -390,6 +402,14 @@ h1{
           <label for="fAnchorDecay">anchor can decay</label>
           <input type="checkbox" id="fAnchorDecay" />
         </div>
+        <div class="fg-field">
+          <label for="fRerootMargin" title="How decisively a challenger must beat the anchor's own pressure before it can displace it. 0 = any epsilon wins, the old behavior.">reroot margin</label>
+          <input type="number" id="fRerootMargin" value="0.05" min="0" max="5" step="0.01" />
+        </div>
+        <div class="fg-field">
+          <label for="fRerootCooldown" title="Minimum ticks a newly-rooted lineage gets to hold the causal center before it can be displaced again. Does not apply to the forced anchor_can_decay replacement.">reroot cooldown (ticks)</label>
+          <input type="number" id="fRerootCooldown" value="3" min="0" max="50" />
+        </div>
       </div>
     </div>
 
@@ -501,6 +521,11 @@ h1{
           <input type="number" id="fOsmoticPressure" value="0.25" min="0" max="10" step="0.01" />
         </div>
       </div>
+    </div>
+
+    <div class="fg-growth-estimate tier-ok" id="fGrowthEstimate">
+      <div class="headline" id="fGrowthEstimateHeadline"></div>
+      <div class="detail" id="fGrowthEstimateDetail"></div>
     </div>
 
     <div class="fg-section">
@@ -2044,6 +2069,8 @@ const FIELD_SPECS = [
   ['fExplorationConstant', 'exploration_constant', 'number'],
   ['fBalanceWeight', 'balance_weight', 'number'],
   ['fAnchorDecay', 'anchor_can_decay', 'checkbox'],
+  ['fRerootMargin', 'reroot_margin', 'number'],
+  ['fRerootCooldown', 'reroot_cooldown_ticks', 'number'],
   ['fDictionaryEnabled', 'dictionary_enabled', 'checkbox'],
   ['fDictionarySize', 'dictionary_size', 'number'],
   ['fMinWordLen', 'min_word_len', 'number'],
@@ -2122,7 +2149,90 @@ function applyParamsToForm(params){
     else el.value = params[key];
   }
   refreshSliderOutputs();
+  refreshGrowthEstimate();
 }
+
+// Fields whose combination determines how many new nodes a single tick
+// can create -- see estimateGrowthLoad(). Any edit to these should
+// re-run the estimate live, before the user ever hits run/go live.
+const GROWTH_ESTIMATE_FIELD_IDS = [
+  'fBudget', 'fBranch', 'fHotLoopDepth',
+  'fFwdBranch', 'fBwdBranch', 'fFwdHotLoopDepth', 'fBwdHotLoopDepth',
+  'fFwdBudget', 'fBwdBudget',
+  'fSproutBranch', 'fSproutDepth', 'fAirRootBranch', 'fAirRootDepth',
+];
+
+// Worst-case per-tick node count implied by the current form, mirroring
+// how the server actually spends one tick's compute budget (see
+// FluxGraph._expand_top_pressure_nodes / _expand_batch_hot_loop):
+// each direction picks its share of budget, and every picked candidate
+// then runs its own hot loop, injecting up to branch_factor**hot_loop_depth
+// new nodes by itself -- so the real cost is (per-direction budget) *
+// branch**depth, added across forward, backward, sprout, and air-root
+// growth. A shared knob (not a per-direction override, i.e. left at 0)
+// falls back to an even floor-split of the shared budget, exactly like
+// the server's own default-budget-split behavior.
+function estimateGrowthLoad(){
+  const val = (id) => +document.getElementById(id).value || 0;
+  const sharedBudget = val('fBudget');
+  const sharedBranch = val('fBranch');
+  const sharedDepth = val('fHotLoopDepth');
+
+  const fwdBudget = val('fFwdBudget') || Math.ceil(sharedBudget / 2);
+  const bwdBudget = val('fBwdBudget') || Math.floor(sharedBudget / 2);
+  const fwdBranch = val('fFwdBranch') || sharedBranch;
+  const bwdBranch = val('fBwdBranch') || sharedBranch;
+  const fwdDepth = val('fFwdHotLoopDepth') || sharedDepth;
+  const bwdDepth = val('fBwdHotLoopDepth') || sharedDepth;
+
+  const fwdNodes = fwdBudget * Math.pow(fwdBranch, fwdDepth);
+  const bwdNodes = bwdBudget * Math.pow(bwdBranch, bwdDepth);
+  const sproutNodes = Math.pow(val('fSproutBranch') || 1, val('fSproutDepth') || 1);
+  const airRootNodes = Math.pow(val('fAirRootBranch') || 1, val('fAirRootDepth') || 1);
+
+  return {
+    total: fwdNodes + bwdNodes + sproutNodes + airRootNodes,
+    fwdNodes, bwdNodes, sproutNodes, airRootNodes,
+    fwdBranch, fwdDepth, bwdBranch, bwdDepth,
+  };
+}
+
+const GROWTH_WARN_THRESHOLD = 500;
+const GROWTH_BONKERS_THRESHOLD = 20000;
+
+function refreshGrowthEstimate(){
+  const el = document.getElementById('fGrowthEstimate');
+  const headline = document.getElementById('fGrowthEstimateHeadline');
+  const detail = document.getElementById('fGrowthEstimateDetail');
+  const est = estimateGrowthLoad();
+  const fmt = (n) => Math.round(n).toLocaleString();
+
+  el.classList.remove('tier-ok', 'tier-warn', 'tier-bonkers');
+  if (est.total > GROWTH_BONKERS_THRESHOLD){
+    el.classList.add('tier-bonkers');
+    headline.textContent =
+      `⚠ bonkers: ~${fmt(est.total)} new nodes estimated this single tick`;
+    detail.textContent =
+      `branch**hot_loop_depth grows exponentially -- forward ${est.fwdBranch}^${est.fwdDepth}, ` +
+      `backward ${est.bwdBranch}^${est.bwdDepth}. This tick will run for a very long time (hours, ` +
+      `possibly never finishing) instead of seconds. Lower branch or hot loop depth before running live.`;
+  } else if (est.total > GROWTH_WARN_THRESHOLD){
+    el.classList.add('tier-warn');
+    headline.textContent = `~${fmt(est.total)} new nodes estimated this tick -- getting expensive`;
+    detail.textContent =
+      `forward ${est.fwdBranch}^${est.fwdDepth}, backward ${est.bwdBranch}^${est.bwdDepth}. ` +
+      `Fine to run, but watch actual tick time once live.`;
+  } else {
+    el.classList.add('tier-ok');
+    headline.textContent = `~${fmt(est.total)} new nodes estimated this tick`;
+    detail.textContent = 'normal range for one tick\'s compute budget.';
+  }
+}
+
+for (const id of GROWTH_ESTIMATE_FIELD_IDS){
+  document.getElementById(id).addEventListener('input', refreshGrowthEstimate);
+}
+refreshGrowthEstimate();
 
 async function loadEngineOptions(){
   try {
@@ -2659,12 +2769,13 @@ async function loadLastParams(){
 // On page load: restore last-used settings, then reattach to an
 // already-running live session if there is one (the server itself may
 // have resumed a saved live session on its own restart -- see
-// LiveSession.resume), otherwise kick off a one-shot run.
+// LiveSession.resume). If not, wait for the user to pick "run new
+// scenario" (fixed one-shot) or "go live" themselves -- this page no
+// longer kicks off a run on its own.
 (async function boot(){
   await loadEngineOptions();
   await loadLastParams();
-  const reattached = await tryReattachLive();
-  if (!reattached) runScenario();
+  await tryReattachLive();
 })();
 })();
 </script>

--- a/speaktome/flux_radar/index.html
+++ b/speaktome/flux_radar/index.html
@@ -80,6 +80,22 @@ h1{
 .fg-readout .val{ font-size:14px; color:var(--readout); }
 .fg-readout .path{ font-size:14px; color:var(--ink-bright); flex:1; min-width:200px; }
 .fg-stage{ width:100%; background: var(--panel-bg-dark); border:0.5px solid var(--grid); border-radius:8px; overflow:hidden; position:relative; }
+.fg-webgl{
+  position:absolute; inset:0; z-index:0; width:100%; height:100%;
+  display:block; pointer-events:none;
+}
+#fgSvg{ position:relative; z-index:1; }
+.fg-webgl-active .fg-edge,
+.fg-webgl-active .fg-pressure,
+.fg-webgl-active .fg-material-flow,
+.fg-webgl-active .fg-layer-fluid circle{
+  opacity:0 !important;
+}
+.fg-webgl-active .fg-layer-nodes circle{
+  fill:transparent !important;
+  stroke:transparent !important;
+  opacity:0.001 !important;
+}
 .fg-node-label{ font-size:9px; fill: var(--ink); pointer-events:none; }
 .fg-heart-hud{
   position:absolute; top:10px; right:10px; z-index:4;
@@ -236,6 +252,7 @@ h1{
           <select id="fFwdSelectionMode">
             <option value="topk">topk</option>
             <option value="topp">topp (nucleus)</option>
+            <option value="stddev">stddev (stratified)</option>
           </select>
         </div>
         <div class="fg-field">
@@ -247,6 +264,7 @@ h1{
           <select id="fBwdSelectionMode">
             <option value="topk">topk</option>
             <option value="topp">topp (nucleus)</option>
+            <option value="stddev">stddev (stratified)</option>
           </select>
         </div>
         <div class="fg-field">
@@ -336,17 +354,8 @@ h1{
       </div>
     </div>
     <div class="fg-section">
-      <div class="fg-section-title">physics</div>
+      <div class="fg-section-title">growth selection &amp; physical survival</div>
       <div class="fg-form">
-        <div class="fg-field">
-          <label for="fFoundBonus">found bonus</label>
-          <input type="number" id="fFoundBonus" value="0.05" min="0" max="5" step="0.01" />
-        </div>
-        <div class="fg-field">
-          <label for="fDamping">damping</label>
-          <input type="range" id="fDamping" min="0" max="1" step="0.05" value="0.5" />
-          <output id="fDampingOut">0.50</output>
-        </div>
         <div class="fg-field">
           <label for="fStarvationFloor">starvation floor</label>
           <input type="number" id="fStarvationFloor" value="0.08" min="0" max="5" step="0.01" />
@@ -360,24 +369,12 @@ h1{
           <input type="number" id="fBurnAfterTicks" value="3" min="1" max="50" />
         </div>
         <div class="fg-field">
-          <label for="fMaxRelaxIter">max relaxation iterations</label>
-          <input type="number" id="fMaxRelaxIter" value="25" min="1" max="500" />
-        </div>
-        <div class="fg-field">
-          <label for="fRelaxTolerance">relaxation tolerance</label>
-          <input type="number" id="fRelaxTolerance" value="0.0001" min="0" step="0.0001" />
-        </div>
-        <div class="fg-field">
           <label for="fRollupWeight">rollup weight</label>
           <input type="number" id="fRollupWeight" value="0.3" min="0" max="5" step="0.05" />
         </div>
         <div class="fg-field">
           <label for="fExplorationConstant">exploration constant</label>
           <input type="number" id="fExplorationConstant" value="0.05" min="0" max="5" step="0.01" />
-        </div>
-        <div class="fg-field">
-          <label for="fHeadPressure">head pressure coefficient</label>
-          <input type="number" id="fHeadPressure" value="0" min="0" max="5" step="0.01" />
         </div>
         <div class="fg-field">
           <label for="fBalanceWeight" title="Corrects forward/backward asymmetry: whichever side's frontier is behind the other gets an expansion-priority boost proportional to the gap. 0 disables it.">balance weight</label>
@@ -387,27 +384,11 @@ h1{
     </div>
 
     <div class="fg-section">
-      <div class="fg-section-title">decay &amp; population</div>
+      <div class="fg-section-title">anchor survival</div>
       <div class="fg-form">
         <div class="fg-field">
           <label for="fAnchorDecay">anchor can decay</label>
           <input type="checkbox" id="fAnchorDecay" />
-        </div>
-        <div class="fg-field">
-          <label for="fDecayRate">decay rate (0=off)</label>
-          <input type="number" id="fDecayRate" value="0" min="0" max="1" step="0.01" />
-        </div>
-        <div class="fg-field">
-          <label for="fPopulationTarget">population target (0=off)</label>
-          <input type="number" id="fPopulationTarget" value="0" min="0" max="5000" />
-        </div>
-        <div class="fg-field">
-          <label for="fSharedTokenPressure">shared token pressure</label>
-          <input type="checkbox" id="fSharedTokenPressure" checked />
-        </div>
-        <div class="fg-field">
-          <label for="fReturnConductance" title="First step toward directional edges: scales how much a child's own pressure reports back to its parent (the 'return' leg). Delivery (parent to child) is always unscaled. 1.0 = symmetric, today's behavior; below 1.0, growth still gets full support flowing outward but success no longer automatically inflates its whole ancestry just by existing.">return conductance scale</label>
-          <input type="number" id="fReturnConductance" value="1" min="0" max="2" step="0.05" />
         </div>
       </div>
     </div>
@@ -473,6 +454,56 @@ h1{
     </div>
 
     <div class="fg-section">
+      <div class="fg-section-title">development and habitat</div>
+      <div class="fg-form">
+        <div class="fg-field">
+          <label for="fCommitmentGain">commitment gain</label>
+          <input type="number" id="fCommitmentGain" value="1" min="0" max="10" step="0.05" />
+        </div>
+        <div class="fg-field">
+          <label for="fCommitmentRetention">commitment retention</label>
+          <input type="number" id="fCommitmentRetention" value="0.85" min="0" max="1" step="0.01" />
+        </div>
+        <div class="fg-field">
+          <label for="fCommitmentThreshold">committed threshold</label>
+          <input type="number" id="fCommitmentThreshold" value="3" min="0" max="100" step="0.1" />
+        </div>
+        <div class="fg-field">
+          <label for="fHabitatIonAmount">new habitat ions / side</label>
+          <input type="number" id="fHabitatIonAmount" value="4" min="0" max="1000" step="0.25" />
+        </div>
+        <div class="fg-field">
+          <label for="fRingUptake">ring uptake rate</label>
+          <input type="number" id="fRingUptake" value="1" min="0" max="1" step="0.05" />
+        </div>
+        <div class="fg-field">
+          <label for="fMaturityGain">branch hardening gain</label>
+          <input type="number" id="fMaturityGain" value="0.1" min="0" max="1" step="0.01" />
+        </div>
+        <div class="fg-field">
+          <label for="fMaturityBonus">mature conductance bonus</label>
+          <input type="number" id="fMaturityBonus" value="1" min="0" max="10" step="0.1" />
+        </div>
+        <div class="fg-field">
+          <label for="fFluidSubsteps">visible fluid substeps</label>
+          <input type="number" id="fFluidSubsteps" value="8" min="1" max="100" step="1" />
+        </div>
+        <div class="fg-field">
+          <label for="fBulkConductance">bulk current speed</label>
+          <input type="number" id="fBulkConductance" value="0.35" min="0" max="10" step="0.01" />
+        </div>
+        <div class="fg-field">
+          <label for="fIonDiffusion" title="Independent of bulk current: ions can disperse down concentration gradients while net water current is zero.">ion dispersion speed</label>
+          <input type="number" id="fIonDiffusion" value="0.6" min="0" max="10" step="0.01" />
+        </div>
+        <div class="fg-field">
+          <label for="fOsmoticPressure">osmotic pressure scale</label>
+          <input type="number" id="fOsmoticPressure" value="0.25" min="0" max="10" step="0.01" />
+        </div>
+      </div>
+    </div>
+
+    <div class="fg-section">
       <div class="fg-section-title">live mode</div>
       <div class="fg-form">
         <div class="fg-field">
@@ -503,6 +534,7 @@ h1{
   </div>
 
   <div class="fg-stage">
+    <canvas class="fg-webgl" id="fgWebGL" aria-label="WebGL2 vascular renderer"></canvas>
     <svg id="fgSvg" viewBox="0 0 900 560" style="width:100%; display:block;"></svg>
     <div class="fg-heart-hud" id="fgHeartHud">
       <div class="fg-heart-hud-title" id="fgHeartHudTitle">heart array</div>
@@ -551,13 +583,18 @@ h1{
     <span><span class="sw" style="background:var(--anchor)"></span>anchor</span>
     <span>node size = pressure &middot; node brightness = score &middot; ring = generation depth</span>
     <span>colored wedges = re-rooted sibling/cousin networks &middot; wedge width = share of that side's live pressure</span>
-    <span>edge color = avg causal-path quality through that edge (red low &rarr; green high) &middot; edge width = how many traversals use it, recomputed every tick</span>
+    <span>edge color = avg causal-path quality &middot; edge width = traversal use plus slow material-flow hardening</span>
     <span><span class="sw" style="background:hsl(200,85%,68%)"></span>blue dashes = water &middot; separately colored dashes = individual ions</span>
     <span id="fgIonLegend">active ions: none</span>
     <span>dash direction/speed = material transport &middot; red halo = pressure drop &middot; pressure length factor = pipe housing expansion &middot; inner fill = node volume</span>
   </div>
 </div>
 
+<script type="module">
+import { FluxWebGLRenderer } from "/static/webgl/webgl_renderer.js";
+window.FluxWebGLRenderer = FluxWebGLRenderer;
+window.dispatchEvent(new Event("flux-webgl-ready"));
+</script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
 <script>
 (function(){
@@ -572,11 +609,11 @@ let currentRingRadii = [0]; // index d -> pixel radius for display_radius d, see
 const bathLayer = svg.append('g');   // faint full-stage wash: the CSF everything sits in
 const wedgeLayer = svg.append('g');
 const guideLayer = svg.append('g');
-const edgeLayer = svg.append('g');
+const edgeLayer = svg.append('g').attr('class', 'fg-layer-edges');
 const flowLayer = svg.append('g');   // blue marching dashes: bulk water
 const ionFlowLayer = svg.append('g'); // one independently colored lane per dissolved ion
-const nodeLayer = svg.append('g');
-const fluidLayer = svg.append('g');  // inner liquid-level fill inside each node
+const nodeLayer = svg.append('g').attr('class', 'fg-layer-nodes');
+const fluidLayer = svg.append('g').attr('class', 'fg-layer-fluid');  // inner liquid-level fill inside each node
 const heartLayer = svg.append('g');  // four-lobe pump glyphs at each region's pump node
 const labelLayer = svg.append('g');
 
@@ -588,12 +625,33 @@ let currentReservoirs = {}; // region -> ion name -> storage telemetry
 let currentBath = {};    // soluble name -> amount
 let currentRhizome = {}; // single active-seed-owned ion/waste store
 let currentRhizomeOwner = null;
+let currentHabitat = {};
+let currentHabitatId = null;
+let currentHabitatPhrase = '';
+let currentMovementCount = 0;
 let currentPhysiology = {};
+let currentTubeState = [];
 let currentLinks = [];    // every causal parent->child connection in the active snapshot
 let currentPressureData = [], currentWaterData = [], currentIonData = [];
 let currentFluidData = [], currentLabelData = [];
 let currentMaxEdgeCount = 1, currentMaxDrop = 1e-4, currentMaxWater = 1e-5, currentMaxIon = 1e-5, currentMaxVolume = 1e-6;
 let basePipeLength = 58;
+let webglRenderer = null;
+
+function initializeWebGLRenderer(){
+  if (webglRenderer || !window.FluxWebGLRenderer) return;
+  try {
+    webglRenderer = new window.FluxWebGLRenderer(
+      document.getElementById('fgWebGL')
+    );
+    window.fluxWebGLRenderer = webglRenderer;
+    document.querySelector('.fg-stage').classList.add('fg-webgl-active');
+  } catch (error) {
+    console.warn('WebGL2 renderer unavailable; retaining SVG fallback', error);
+  }
+}
+window.addEventListener('flux-webgl-ready', initializeWebGLRenderer);
+initializeWebGLRenderer();
 let pressureLengthFactor = 12;
 let flowPhase = 0;       // advances every frame so dashes march
 function isAnchor(n){ return n.is_anchor === true; }
@@ -673,6 +731,12 @@ function renderHeartHud(){
   globalNode.appendChild(globalHead);
   addHudRow(globalNode, 'CSF / lymph', chamberHudValue(currentBath), 'one graph-global bath shared by every cousin heart');
   addHudRow(globalNode, 'rhizome', chamberHudValue(currentRhizome), 'single store owned by the active seed');
+  addHudRow(
+    globalNode,
+    `habitat ${currentHabitatId == null ? '—' : currentHabitatId}`,
+    chamberHudValue(currentHabitat),
+    `“${currentHabitatPhrase}” · finite seed-relative ring inventory · ${currentMovementCount} seed movements`
+  );
   const physiologySummary = currentPhysiology.enabled
     ? `${currentPhysiology.parameter_count || 0} gates · step ${currentPhysiology.steps || 0} · loss ${Number(currentPhysiology.loss || 0).toFixed(5)} · score ${Number(currentPhysiology.best_score || 0).toFixed(4)}`
     : 'disabled';
@@ -869,21 +933,22 @@ function updateRingElasticity(nodesArr){
 const MIN_ARC_PER_NODE = 16;
 
 function computeRingRadii(liveNodes, wedgeLayout, maxDepth){
-  const countAt = new Map(); // "wedgeKey:depth" -> live node count sharing that ring band
+  const requiredArcAt = new Map(); // "wedgeKey:depth" -> physical arc length occupied by node bodies
   for (const n of liveNodes){
     if (isCenter(n)) continue;
     const d = n.display_radius != null ? n.display_radius : n.depth;
     const key = wedgeKey(n) + ':' + d;
-    countAt.set(key, (countAt.get(key) || 0) + 1);
+    const bodyArc = Math.max(MIN_ARC_PER_NODE, 2 * pressureRadius(n.pressure) + 6);
+    requiredArcAt.set(key, (requiredArcAt.get(key) || 0) + bodyArc);
   }
   const radii = [0];
   for (let d = 1; d <= Math.max(1, maxDepth); d++){
     let required = 0;
     for (const [wk, w] of wedgeLayout){
-      const count = countAt.get(wk + ':' + d) || 0;
-      if (count <= 1) continue; // one node never needs elbow room
+      const occupiedArc = requiredArcAt.get(wk + ':' + d) || 0;
+      if (occupiedArc <= 0) continue;
       const angularWidth = Math.max(0.02, w.end - w.start);
-      required = Math.max(required, (count * MIN_ARC_PER_NODE) / angularWidth);
+      required = Math.max(required, occupiedArc / angularWidth);
     }
     radii.push(Math.max(radii[d - 1] + RING_SPACING, required));
   }
@@ -1085,6 +1150,25 @@ function drawWedgeGuides(layout, rOuter){
     .attr('text-anchor', 'middle')
     .attr('fill', d => d.color)
     .text(d => d.text);
+
+  const dividerData = [];
+  for (const dirSuffix of ['forward', 'backward']){
+    for (let i = 1; i < currentGroupOrder.length; i++){
+      const angle = rayAngles.get(dirSuffix + ':' + i);
+      if (angle == null) continue;
+      dividerData.push({
+        key: dirSuffix + ':' + i,
+        x2: CX + rOuter * Math.cos(angle),
+        y2: CY + rOuter * Math.sin(angle),
+      });
+    }
+  }
+  wedgeLayer.selectAll('line.fg-divider').data(dividerData, d => d.key).join('line')
+    .attr('class', 'fg-divider')
+    .attr('x1', CX).attr('y1', CY)
+    .attr('x2', d => d.x2).attr('y2', d => d.y2)
+    .attr('stroke', 'var(--ink)').attr('stroke-width', 1.35)
+    .attr('stroke-opacity', 0.68);
 }
 
 // display_radius (see snapshot_graph): depth for an ordinary node --
@@ -1116,12 +1200,10 @@ function scoreBrightness(le){ return Math.max(0.25, Math.min(1, Math.exp(le))); 
 
 let currentWedgeLayout = new Map();
 
-// Continuous regional binding plus predictive wall contact. Link/collision
-// forces may rearrange a branch inside its wedge, but every node has a
-// stable angular slot and its full circle must remain behind both rays.
-// Contact is an exchange: the node receives inward tangential impulse and
-// the shared internal ray receives the equal outward load.
-function regionBindingForce(slotStrength, wallStrength){
+// Soft angular organization inside a region. Actual membership is enforced
+// separately by enforceNetworkGeometry: links may choose where inside the
+// wedge a node settles, but they cannot negotiate which wedge or ring owns it.
+function regionBindingForce(slotStrength){
   let nodes;
   function force(alpha){
     for (const n of nodes){
@@ -1143,34 +1225,113 @@ function regionBindingForce(slotStrength, wallStrength){
       const slotImpulse = r * slotDelta * slotStrength * alpha;
       n.vx += tangentX * slotImpulse;
       n.vy += tangentY * slotImpulse;
+    }
+  }
+  force.initialize = (_nodes) => { nodes = _nodes; };
+  return force;
+}
 
-      // Predict contact using the node's angular half-width, so its visible
-      // body stays in-region rather than waiting for its center to cross.
-      const angularRadius = Math.asin(Math.min(0.95, (n.r + 2) / r));
-      let safeStart = w.start + angularRadius + 0.015;
-      let safeEnd = w.end - angularRadius - 0.015;
-      if (safeStart > safeEnd){ safeStart = safeEnd = (w.start + w.end) / 2; }
-      let wallDelta = 0, boundaryIndex = null;
-      const dirSuffix = n.data.direction === 'backward' ? 'backward' : 'forward';
-      const groupIndex = currentGroupOrder.indexOf(groupKey(n.data));
-      if (angle < safeStart){ wallDelta = safeStart - angle; boundaryIndex = groupIndex; }
-      else if (angle > safeEnd){ wallDelta = safeEnd - angle; boundaryIndex = groupIndex + 1; }
-      if (wallDelta === 0) continue;
+function angleInsideWedge(angle, wedge){
+  while (angle < wedge.start) angle += Math.PI * 2;
+  while (angle >= wedge.start + Math.PI * 2) angle -= Math.PI * 2;
+  return angle;
+}
 
-      const wallImpulse = r * wallDelta * wallStrength * (0.35 + alpha);
-      n.vx += tangentX * wallImpulse;
-      n.vy += tangentY * wallImpulse;
-
-      // Hemisphere dividers remain fixed; only genuine inter-region rays
-      // accept the equal-and-opposite reaction.
-      if (boundaryIndex > 0 && boundaryIndex < currentGroupOrder.length){
-        const pressure = Math.max(0.05, Number(n.data.pressure) || 0.05);
-        addRayLoad(dirSuffix + ':' + boundaryIndex, -wallDelta * pressure);
+// Collision among nodes sharing one physical annular sector. Nodes in
+// different sectors never collide through a divider; their reaction is with
+// the divider itself. Because ring radius is a hard coordinate, separation is
+// tangential—the one remaining movement dimension on that ring.
+function ringWedgeCollisionForce(strength){
+  let nodes;
+  function force(alpha){
+    const groups = new Map();
+    for (const node of nodes){
+      if (isCenter(node.data)) continue;
+      const depth = node.data.display_radius != null ? node.data.display_radius : node.data.depth;
+      const key = wedgeKey(node.data) + ':' + depth;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key).push(node);
+    }
+    for (const members of groups.values()){
+      const wedge = currentWedgeLayout.get(wedgeKey(members[0].data));
+      if (!wedge) continue;
+      for (let i = 0; i < members.length; i++){
+        const a = members[i];
+        const ar = Math.max(1, a.targetR || targetRadius(a.data));
+        const aa = angleInsideWedge(Math.atan2(a.y - CY, a.x - CX), wedge);
+        for (let j = i + 1; j < members.length; j++){
+          const b = members[j];
+          const br = Math.max(1, b.targetR || targetRadius(b.data));
+          const ba = angleInsideWedge(Math.atan2(b.y - CY, b.x - CX), wedge);
+          const radius = Math.max(1, (ar + br) / 2);
+          const delta = ba - aa;
+          const minimum = (a.r + b.r + 4) / radius;
+          const overlap = minimum - Math.abs(delta);
+          if (overlap <= 0) continue;
+          const sign = delta < 0 ? -1 : 1;
+          const impulse = overlap * radius * strength * (0.4 + alpha) * 0.5;
+          const atx = -Math.sin(aa), aty = Math.cos(aa);
+          const btx = -Math.sin(ba), bty = Math.cos(ba);
+          a.vx -= atx * impulse * sign;
+          a.vy -= aty * impulse * sign;
+          b.vx += btx * impulse * sign;
+          b.vy += bty * impulse * sign;
+        }
       }
     }
   }
   force.initialize = (_nodes) => { nodes = _nodes; };
   return force;
+}
+
+// Holonomic containment applied after D3 integrates a tick. A non-center
+// node has exactly two legal coordinates: its assigned ring radius and an
+// angle between its network's two divider rays. We project illegal motion
+// back onto that manifold, remove velocity into the contacted wall, and pass
+// the equal reaction to an internal divider. Internal dividers can rotate
+// only; the two hemisphere dividers are fixed.
+function enforceNetworkGeometry(nodesArr){
+  for (const node of nodesArr){
+    if (isCenter(node.data)){
+      node.x = CX; node.y = CY;
+      node.vx = 0; node.vy = 0;
+      continue;
+    }
+    const wedge = currentWedgeLayout.get(wedgeKey(node.data));
+    if (!wedge) continue;
+    const radius = Math.max(1, node.targetR || targetRadius(node.data));
+    let angle = angleInsideWedge(
+      Math.atan2(node.y - CY, node.x - CX), wedge
+    );
+    const angularRadius = Math.asin(Math.min(0.95, (node.r + 2) / radius));
+    let safeStart = wedge.start + angularRadius + 0.01;
+    let safeEnd = wedge.end - angularRadius - 0.01;
+    if (safeStart > safeEnd) safeStart = safeEnd = wedge.mid;
+    const clamped = Math.max(safeStart, Math.min(safeEnd, angle));
+    const correction = clamped - angle;
+
+    const radialX = Math.cos(clamped), radialY = Math.sin(clamped);
+    const tangentX = -radialY, tangentY = radialX;
+    let tangentVelocity = (node.vx || 0) * tangentX + (node.vy || 0) * tangentY;
+    if ((clamped === safeStart && tangentVelocity < 0)
+        || (clamped === safeEnd && tangentVelocity > 0)){
+      tangentVelocity = 0;
+    }
+    node.vx = tangentX * tangentVelocity;
+    node.vy = tangentY * tangentVelocity;
+    node.x = CX + radius * radialX;
+    node.y = CY + radius * radialY;
+
+    if (correction !== 0){
+      const groupIndex = currentGroupOrder.indexOf(groupKey(node.data));
+      const boundaryIndex = clamped === safeStart ? groupIndex : groupIndex + 1;
+      if (boundaryIndex > 0 && boundaryIndex < currentGroupOrder.length){
+        const direction = node.data.direction === 'backward' ? 'backward' : 'forward';
+        const pressure = Math.max(0.05, Number(node.data.pressure) || 0.05);
+        addRayLoad(direction + ':' + boundaryIndex, -correction * radius * pressure);
+      }
+    }
+  }
 }
 
 // A bend in a flowing pipe experiences a straightening moment. Use the
@@ -1285,8 +1446,8 @@ let simulation = d3.forceSimulation([])
   // Every seed-layer cousin occupies the same center. Give centers zero
   // collision radius so this force does not contradict that geometry by
   // pushing them apart; ordinary non-center nodes still keep spacing.
-  .force('collide', d3.forceCollide(d => isCenter(d.data) ? 0 : d.r + 3))
-  .force('region', regionBindingForce(0.10, 0.9))
+  .force('collide', ringWedgeCollisionForce(0.92))
+  .force('region', regionBindingForce(0.10))
   .force('pipeStraighten', pipeStraighteningForce(0.32))
   .alphaDecay(0.06)
   .velocityDecay(0.55)
@@ -1384,7 +1545,12 @@ function applySnapshot(snap){
   currentBath = snap.bath || {};
   currentRhizome = snap.rhizome || {};
   currentRhizomeOwner = snap.rhizome_owner_id == null ? null : snap.rhizome_owner_id;
+  currentHabitat = snap.current_habitat || {};
+  currentHabitatId = snap.current_habitat_id == null ? null : snap.current_habitat_id;
+  currentHabitatPhrase = String(snap.current_habitat_phrase || '');
+  currentMovementCount = Number(snap.movement_count) || 0;
   currentPhysiology = snap.physiology || {};
+  currentTubeState = snap.tube_state || [];
   renderHeartHud();
 
   document.getElementById('fgTick').textContent = snap.tick;
@@ -1413,6 +1579,7 @@ function render(){
   // bow its own ray outward rather than being invisibly teleported back.
   updateRayElasticity();
   currentWedgeLayout = physicalWedgeLayoutFrom();
+  enforceNetworkGeometry(nodesArr);
   drawWedgeGuides(currentWedgeLayout, currentRingRadii[currentRingRadii.length - 1] + 20);
 
   // Ring d is the exact radius targeted by every node d edge hops from
@@ -1454,7 +1621,10 @@ function render(){
     })
     .attr('stroke-width', d => {
       const inf = d.influence;
-      return inf ? 1.5 + 7 * Math.sqrt((Number(inf.count) || 0) / currentMaxEdgeCount) : 1;
+      const maturity = inf ? Math.max(0, Math.min(1, Number(inf.maturity) || 0)) : 0;
+      return inf
+        ? (1.5 + 7 * Math.sqrt((Number(inf.count) || 0) / currentMaxEdgeCount)) * (1 + 0.5*maturity)
+        : 1;
     })
     .attr('stroke-linecap', 'round')
     .attr('opacity', d => {
@@ -1534,6 +1704,16 @@ function render(){
     .text(d => d.data.text.trim().slice(0, 14));
 
   drawBath();
+
+  if (webglRenderer){
+    webglRenderer.update({
+      width: W,
+      height: H,
+      nodes: nodesArr,
+      links: currentLinks,
+      tubes: currentTubeState,
+    });
+  }
 }
 
 // The pump node for each region: the anchor for "main", the node whose
@@ -1652,7 +1832,7 @@ function showTooltip(event, d){
     '<div><span class="k">pressure</span> ' + n.pressure.toFixed(3) + '</div>' +
     '<div><span class="k">local evidence</span> ' + n.local_evidence.toFixed(3) + '</div>' +
     '<div><span class="k">path mean</span> ' + n.path_mean.toFixed(3) + '</div>' +
-    '<div><span class="k">root demand</span> backward ' + (n.backward_growth_interest || 0).toFixed(2) +
+    '<div><span class="k">growth commitment</span> backward ' + (n.backward_growth_interest || 0).toFixed(2) +
       ', forward ' + (n.forward_growth_interest || 0).toFixed(2) + '</div>' +
     '<div><span class="k">volume</span> ' + (n.volume != null ? n.volume.toFixed(3) : '0') +
       ' (solvent ' + (n.solvent != null ? n.solvent.toFixed(2) : '0') + ')</div>' +
@@ -1799,22 +1979,13 @@ const FIELD_SPECS = [
   ['fMaxSubwordSteps', 'max_subword_steps', 'number'],
   ['fExpandChunk', 'expand_batch_chunk_size', 'number'],
   ['fMaxExpandElements', 'max_expand_elements', 'number'],
-  ['fFoundBonus', 'found_bonus', 'number'],
-  ['fDamping', 'damping', 'number'],
   ['fStarvationFloor', 'starvation_floor', 'number'],
   ['fOverpressureCeiling', 'overpressure_ceiling', 'number'],
   ['fBurnAfterTicks', 'burn_after_ticks', 'number'],
-  ['fMaxRelaxIter', 'max_relaxation_iterations', 'number'],
-  ['fRelaxTolerance', 'relaxation_tolerance', 'number'],
   ['fRollupWeight', 'rollup_weight', 'number'],
   ['fExplorationConstant', 'exploration_constant', 'number'],
-  ['fHeadPressure', 'head_pressure_coefficient', 'number'],
   ['fBalanceWeight', 'balance_weight', 'number'],
   ['fAnchorDecay', 'anchor_can_decay', 'checkbox'],
-  ['fDecayRate', 'decay_rate', 'number'],
-  ['fPopulationTarget', 'population_target', 'number'],
-  ['fSharedTokenPressure', 'shared_token_pressure_enabled', 'checkbox'],
-  ['fReturnConductance', 'return_conductance_scale', 'number'],
   ['fDictionaryEnabled', 'dictionary_enabled', 'checkbox'],
   ['fDictionarySize', 'dictionary_size', 'number'],
   ['fMinWordLen', 'min_word_len', 'number'],
@@ -1825,6 +1996,17 @@ const FIELD_SPECS = [
   ['fPoeticShortlist', 'poetic_shortlist_k', 'number'],
   ['fAuxinSuppression', 'auxin_suppression', 'number'],
   ['fAuxinDecay', 'auxin_decay', 'number'],
+  ['fCommitmentGain', 'growth_commitment_gain', 'number'],
+  ['fCommitmentRetention', 'growth_commitment_retention', 'number'],
+  ['fCommitmentThreshold', 'growth_commitment_threshold', 'number'],
+  ['fHabitatIonAmount', 'habitat_ring_ion_amount', 'number'],
+  ['fRingUptake', 'ring_uptake_rate', 'number'],
+  ['fMaturityGain', 'branch_maturity_gain', 'number'],
+  ['fMaturityBonus', 'branch_maturity_conductance_bonus', 'number'],
+  ['fFluidSubsteps', 'fluid_solver_substeps', 'number'],
+  ['fBulkConductance', 'fluid_bulk_conductance', 'number'],
+  ['fIonDiffusion', 'fluid_diffusion_conductance', 'number'],
+  ['fOsmoticPressure', 'fluid_osmotic_pressure', 'number'],
 ];
 // [input id, output id, decimals] -- range inputs whose paired <output>
 // needs refreshing both on user drag (via the 'input' event) and
@@ -1834,7 +2016,6 @@ const SLIDER_OUTPUTS = [
   ['fAlpha', 'fAlphaOut', 2],
   ['fBeta', 'fBetaOut', 1],
   ['fPoeticScale', 'fPoeticScaleOut', 1],
-  ['fDamping', 'fDampingOut', 2],
   ['fAuxinDecay', 'fAuxinDecayOut', 2],
 ];
 
@@ -1927,9 +2108,12 @@ function startRunProgressPolling(engineLabel){
       const work = Number.isFinite(mid.current) && Number.isFinite(mid.total) && mid.total > 0
         ? ` ${mid.current}/${mid.total}` : '';
       const detail = mid.detail ? ` — ${mid.detail}` : '';
+      const phaseSeconds = Number.isFinite(+mid.phase_elapsed_seconds)
+        ? ` · phase ${(+mid.phase_elapsed_seconds).toFixed(1)}s` : '';
       loadingTextEl.textContent =
         `running ${engineLabel} — tick ${mid.tick}/${progress.total_ticks} — ` +
-        `${mid.phase}${work}${detail} — ${mid.live_nodes} live — ${(+mid.elapsed_seconds).toFixed(1)}s`;
+        `${mid.phase}${work}${detail}${phaseSeconds} — ${mid.live_nodes} live — ` +
+        `${(+mid.elapsed_seconds).toFixed(1)}s total`;
       if (Number.isFinite(mid.current) && Number.isFinite(mid.total) && mid.total > 0){
         midTickProgressEl.max = mid.total;
         midTickProgressEl.value = mid.current;
@@ -1985,6 +2169,204 @@ let liveActive = false;
 let livePollTimer = null;
 let liveRunKey = null;
 let liveLastSnapshotTick = -1;
+let activeFluidWorkId = null;
+
+const nextAnimationFrame = () => new Promise(resolve => requestAnimationFrame(resolve));
+
+async function solveFluidWork(work){
+  const values = work.values.map(row => Float64Array.from(row));
+  const initial = work.values.map(row => Float64Array.from(row));
+  const n = values.length, m = work.components.length;
+  const src = work.arcs.source, dst = work.arcs.destination;
+  const geometry = work.arcs.conductance;
+  const arcCount = src.length;
+  const p = work.parameters;
+  const arcBulk = new Float64Array(arcCount);
+  const arcComponents = Array.from({length: arcCount}, () => new Float64Array(m));
+  const tubeByKey = new Map(currentTubeState.map(tube => [
+    tube.traversal.join(',') + ':' + tube.direction,
+    tube,
+  ]));
+
+  for (let step = 0; step < p.substeps; step++){
+    const volume = new Float64Array(n);
+    const pressure = new Float64Array(n);
+    for (let i = 0; i < n; i++){
+      let total = 0, solute = 0;
+      for (let c = 0; c < m; c++) total += values[i][c];
+      for (let c = 1; c < m; c++) solute += values[i][c];
+      volume[i] = total;
+      pressure[i] = (
+        values[i][0] + p.osmotic_pressure * solute / Math.max(1e-6, values[i][0])
+      ) / Math.max(1e-6, work.compliance[i]);
+    }
+    const raw = new Float64Array(arcCount);
+    const demand = new Float64Array(n);
+    for (let a = 0; a < arcCount; a++){
+      raw[a] = Math.max(0, pressure[src[a]] - pressure[dst[a]])
+        * geometry[a] * p.bulk_conductance * p.time_step;
+      demand[src[a]] += raw[a];
+    }
+    const moved = new Float64Array(arcCount);
+    const mixture = Array.from({length: arcCount}, () => new Float64Array(m));
+    for (let a = 0; a < arcCount; a++){
+      const scale = demand[src[a]] > 0
+        ? Math.min(1, volume[src[a]] / Math.max(1e-12, demand[src[a]])) : 1;
+      moved[a] = raw[a] * scale;
+      arcBulk[a] += moved[a];
+      if (volume[src[a]] > 0){
+        for (let c = 0; c < m; c++){
+          mixture[a][c] = values[src[a]][c] / volume[src[a]] * moved[a];
+        }
+      }
+    }
+    const visibleEdgeFlow = new Map();
+    for (let a = 0; a < arcCount; a++){
+      const edge = work.arcs.edge[a];
+      if (!edge) continue;
+      const key = edge[0] + ':' + edge[1];
+      visibleEdgeFlow.set(
+        key,
+        (visibleEdgeFlow.get(key) || 0) + moved[a] * work.arcs.sign[a],
+      );
+    }
+    for (let a = 0; a < arcCount; a++){
+      for (let c = 0; c < m; c++){
+        values[src[a]][c] -= mixture[a][c];
+        values[dst[a]][c] += mixture[a][c];
+        arcComponents[a][c] += mixture[a][c];
+      }
+    }
+
+    if (m > 1){
+      const postVolume = new Float64Array(n);
+      for (let i = 0; i < n; i++){
+        for (let c = 0; c < m; c++) postVolume[i] += values[i][c];
+      }
+      const diffRaw = Array.from({length: arcCount}, () => new Float64Array(m));
+      const diffDemand = Array.from({length: n}, () => new Float64Array(m));
+      for (let a = 0; a < arcCount; a++){
+        for (let c = 1; c < m; c++){
+          const gradient = values[src[a]][c] / Math.max(1e-12, postVolume[src[a]])
+            - values[dst[a]][c] / Math.max(1e-12, postVolume[dst[a]]);
+          const amount = Math.max(0, gradient) * geometry[a]
+            * p.ion_diffusion * p.time_step;
+          diffRaw[a][c] = amount;
+          diffDemand[src[a]][c] += amount;
+        }
+      }
+      for (let a = 0; a < arcCount; a++){
+        for (let c = 1; c < m; c++){
+          const demandHere = diffDemand[src[a]][c];
+          const amount = diffRaw[a][c] * (
+            demandHere > 0
+              ? Math.min(1, values[src[a]][c] / Math.max(1e-12, demandHere))
+              : 1
+          );
+          values[src[a]][c] -= amount;
+          values[dst[a]][c] += amount;
+          arcComponents[a][c] += amount;
+          const edge = work.arcs.edge[a];
+          if (edge){
+            const edgeKey = edge[0] + ':' + edge[1];
+            visibleEdgeFlow.set(
+              edgeKey,
+              (visibleEdgeFlow.get(edgeKey) || 0)
+                + amount * work.arcs.sign[a],
+            );
+          }
+        }
+      }
+    }
+    liveStatusEl.textContent =
+      `● LIVE · client relaxation ${step + 1}/${p.substeps} · ions ${p.ion_diffusion} / current ${p.bulk_conductance}`;
+    // The visible node bodies are the actual rows being relaxed. Updating
+    // them before yielding makes the animation a view of computation, not a
+    // replay fabricated after the proof has already been returned.
+    for (let i = 0; i < n; i++){
+      const descriptor = work.compartments[i];
+      if (!descriptor) continue;
+      if (descriptor.kind === 'tube'){
+        const tube = tubeByKey.get(
+          descriptor.traversal.join(',') + ':' + descriptor.direction
+        );
+        if (tube){
+          const segment = descriptor.segment;
+          const solubles = {};
+          for (let c = 1; c < m; c++){
+            if (values[i][c] > 1e-12) solubles[work.components[c]] = values[i][c];
+          }
+          tube.solvent[segment] = values[i][0];
+          tube.solubles[segment] = solubles;
+          let solute = 0;
+          for (let c = 1; c < m; c++) solute += values[i][c];
+          tube.pressures[segment] = (
+            values[i][0] + p.osmotic_pressure * solute / Math.max(1e-6, values[i][0])
+          ) / Math.max(1e-6, work.compliance[i]);
+        }
+        continue;
+      }
+      if (descriptor.kind !== 'node') continue;
+      const simNode = simNodes.get(descriptor.node_id);
+      if (!simNode) continue;
+      let total = 0, solute = 0;
+      for (let c = 0; c < m; c++) total += values[i][c];
+      for (let c = 1; c < m; c++) solute += values[i][c];
+      simNode.data.volume = total;
+      simNode.data.solvent = values[i][0];
+      simNode.data.pressure = (
+        values[i][0] + p.osmotic_pressure * solute / Math.max(1e-6, values[i][0])
+      ) / Math.max(1e-6, work.compliance[i]);
+      simNode.r = isCenter(simNode.data) ? 13 : pressureRadius(simNode.data.pressure);
+    }
+    for (const link of currentLinks){
+      const influence = link.influence || {};
+      const key = influence.from + ':' + influence.to;
+      if (visibleEdgeFlow.has(key)) influence.flow = visibleEdgeFlow.get(key);
+    }
+    midTickProgressEl.style.display = 'block';
+    midTickProgressEl.max = p.substeps;
+    midTickProgressEl.value = step + 1;
+    render();
+    await nextAnimationFrame();
+  }
+
+  let residual = 0;
+  for (let c = 0; c < m; c++){
+    let before = 0, after = 0;
+    for (let i = 0; i < n; i++){
+      before += initial[i][c];
+      after += values[i][c];
+    }
+    residual = Math.max(residual, Math.abs(before - after));
+  }
+  return {
+    work_id: work.work_id,
+    values: values.map(row => Array.from(row)),
+    arc_bulk: Array.from(arcBulk),
+    arc_components: arcComponents.map(row => Array.from(row)),
+    conservation_residual: residual,
+  };
+}
+
+async function processFluidWork(work){
+  if (!work || work.work_id === activeFluidWorkId) return;
+  activeFluidWorkId = work.work_id;
+  try {
+    const fluid_result = await solveFluidWork(work);
+    const resp = await fetch('/api/live/physics', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ domain: 'client', fluid_result }),
+    });
+    if (!resp.ok) throw new Error((await resp.json()).error || 'fluid proof rejected');
+  } catch (err) {
+    activeFluidWorkId = null;
+    throw err;
+  } finally {
+    midTickProgressEl.style.display = 'none';
+  }
+}
 
 function liveParams(){
   return {
@@ -2013,8 +2395,13 @@ function applyLiveState(state){
     const mid = state.mid_tick || {};
     const work = Number.isFinite(mid.current) && Number.isFinite(mid.total) && mid.total > 0
       ? ` ${mid.current}/${mid.total}` : '';
+    const phaseSeconds = Number.isFinite(+mid.phase_elapsed_seconds)
+      ? ` · ${(+mid.phase_elapsed_seconds).toFixed(1)}s` : '';
+    const proof = state.fluid_proof && state.fluid_proof.worker === 'client'
+      ? ` · proof ε=${Number(state.fluid_proof.conservation_residual || 0).toExponential(1)}`
+      : '';
     liveStatusEl.textContent = mid.phase
-      ? `● LIVE · ${mid.phase}${work} · ${mid.live_nodes} nodes`
+      ? `● LIVE · ${mid.phase}${work}${phaseSeconds}${proof} · ${mid.live_nodes} nodes`
       : '● LIVE';
   }
 
@@ -2060,6 +2447,7 @@ async function pollLive(){
     // silently re-show a "LIVE" badge for a session that's already gone.
     if (!liveActive) return;
     applyLiveState(state);
+    await processFluidWork(state.fluid_work);
     pushClientPhysics();
   } catch (err) {
     // Transient poll hiccup -- skip this tick rather than spamming the

--- a/speaktome/flux_radar/index.html
+++ b/speaktome/flux_radar/index.html
@@ -530,6 +530,8 @@ h1{
     <span class="tag">score</span><span class="val" id="fgScore">0.000</span>
     <span class="val" id="fgLiveStatus" style="color:var(--danger); display:none;">● LIVE</span>
     <span class="tag">traversals</span><span class="val" id="fgTraversals">0</span>
+    <span class="tag" title="All mechanics are solved in network-local dimensions; S² is only the observation lens.">nD force → S² lens</span>
+    <span class="val" id="fgShellDimensions"></span>
     <span class="path" id="fgPath"></span>
   </div>
 
@@ -556,19 +558,19 @@ h1{
       <output id="fgTickOut">0</output>
     </div>
     <div class="grp">
-      <label for="fgStiff">spring stiffness</label>
-      <input type="range" id="fgStiff" min="0.05" max="1" value="0.55" step="0.01" />
-      <output id="fgStiffOut">0.55</output>
+      <label for="fgStiff">nD pipe stiffness</label>
+      <input type="range" id="fgStiff" min="0.05" max="2" value="0.72" step="0.01" />
+      <output id="fgStiffOut">0.72</output>
     </div>
     <div class="grp">
-      <label for="fgRest">resting length</label>
-      <input type="range" id="fgRest" min="30" max="110" value="58" step="1" />
-      <output id="fgRestOut">58</output>
+      <label for="fgRest">nD resting length</label>
+      <input type="range" id="fgRest" min="0.4" max="2" value="1.05" step="0.01" />
+      <output id="fgRestOut">1.05</output>
     </div>
     <div class="grp">
-      <label for="fgPressureLength">pressure length factor</label>
-      <input type="range" id="fgPressureLength" min="0" max="30" value="12" step="0.5" />
-      <output id="fgPressureLengthOut">12.0</output>
+      <label for="fgPressureLength">nD pressure expansion</label>
+      <input type="range" id="fgPressureLength" min="0" max="0.3" value="0.06" step="0.005" />
+      <output id="fgPressureLengthOut">0.060</output>
     </div>
     <div class="grp">
       <label for="fgLabelPct">hide labels below percentile</label>
@@ -591,8 +593,14 @@ h1{
 </div>
 
 <script type="module">
-import { FluxWebGLRenderer } from "/static/webgl/webgl_renderer.js";
+import {
+  FluxWebGLRenderer,
+  HypersphereProjector,
+  NDForceAssembly,
+} from "/static/webgl/webgl_renderer.js";
 window.FluxWebGLRenderer = FluxWebGLRenderer;
+window.HypersphereProjector = HypersphereProjector;
+window.NDForceAssembly = NDForceAssembly;
 window.dispatchEvent(new Event("flux-webgl-ready"));
 </script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/7.8.5/d3.min.js"></script>
@@ -609,6 +617,7 @@ let currentRingRadii = [0]; // index d -> pixel radius for display_radius d, see
 const bathLayer = svg.append('g');   // faint full-stage wash: the CSF everything sits in
 const wedgeLayer = svg.append('g');
 const guideLayer = svg.append('g');
+const shellGuideLayer = svg.append('g').attr('class', 'fg-shell-guides');
 const edgeLayer = svg.append('g').attr('class', 'fg-layer-edges');
 const flowLayer = svg.append('g');   // blue marching dashes: bulk water
 const ionFlowLayer = svg.append('g'); // one independently colored lane per dissolved ion
@@ -637,21 +646,39 @@ let currentFluidData = [], currentLabelData = [];
 let currentMaxEdgeCount = 1, currentMaxDrop = 1e-4, currentMaxWater = 1e-5, currentMaxIon = 1e-5, currentMaxVolume = 1e-6;
 let basePipeLength = 58;
 let webglRenderer = null;
+let ndForceAssembly = null;
+let shellProjector = null;
+const shellLensEnabled = true;
+let shellObservation = null;
+let shellObservationById = new Map();
+let shellObservationDirty = true;
 
 function initializeWebGLRenderer(){
-  if (webglRenderer || !window.FluxWebGLRenderer) return;
+  if (
+    webglRenderer
+    || !window.FluxWebGLRenderer
+    || !window.HypersphereProjector
+    || !window.NDForceAssembly
+  ) return;
   try {
     webglRenderer = new window.FluxWebGLRenderer(
       document.getElementById('fgWebGL')
     );
+    shellProjector = new window.HypersphereProjector();
+    ndForceAssembly = new window.NDForceAssembly(2, 4);
     window.fluxWebGLRenderer = webglRenderer;
     document.querySelector('.fg-stage').classList.add('fg-webgl-active');
+    if (simNodes.size){
+      solveNDForceAssembly(Array.from(simNodes.values()), 48);
+      render();
+    }
   } catch (error) {
     console.warn('WebGL2 renderer unavailable; retaining SVG fallback', error);
   }
 }
 window.addEventListener('flux-webgl-ready', initializeWebGLRenderer);
 initializeWebGLRenderer();
+const shellDimensionsOut = document.getElementById('fgShellDimensions');
 let pressureLengthFactor = 12;
 let flowPhase = 0;       // advances every frame so dashes march
 function isAnchor(n){ return n.is_anchor === true; }
@@ -797,14 +824,23 @@ const pumpNode = pumpNodeForRegion(region);
 let currentEdgeInfluence = new Map();
 let labelHidePercentile = 0;
 
+function visualPoint(node){
+  if (shellLensEnabled){
+    const observation = shellObservationById.get(node.id);
+    if (observation) return observation.screen;
+  }
+  return { x: node.x, y: node.y, depth: 0, scale: 1 };
+}
+
 const materialKey = d => linkKey(d.link) + '|' + d.name;
 function materialPoint(d, endpoint){
   const source = linkSource(d.link), target = linkTarget(d.link);
   if (!source || !target) return { x: CX, y: CY };
-  const dx = target.x - source.x, dy = target.y - source.y;
+  const sourcePoint = visualPoint(source), targetPoint = visualPoint(target);
+  const dx = targetPoint.x - sourcePoint.x, dy = targetPoint.y - sourcePoint.y;
   const length = Math.hypot(dx, dy) || 1;
   const offset = d.lane * 4;
-  const base = endpoint === 'source' ? source : target;
+  const base = endpoint === 'source' ? sourcePoint : targetPoint;
   return { x: base.x - dy/length*offset, y: base.y + dx/length*offset };
 }
 function rebuildLabelCache(nodesArr){
@@ -844,6 +880,18 @@ function rebuildSnapshotRenderCaches(nodesArr){
   currentMaxVolume = Math.max(1e-6, ...nodesArr.map(d => d.data.volume || 0));
   currentFluidData = nodesArr.filter(d => (d.data.volume || 0) > 1e-4);
   rebuildLabelCache(nodesArr);
+}
+
+function solveNDForceAssembly(nodesArr, substeps){
+  if (!ndForceAssembly) return null;
+  ndForceAssembly.sync(nodesArr, currentLinks);
+  const proof = ndForceAssembly.relax(substeps);
+  for (const node of nodesArr){
+    node.data.latent_coordinates = ndForceAssembly.coordinates(node.id);
+  }
+  window.fluxNDPhysicsFrame = ndForceAssembly.snapshot();
+  shellObservationDirty = true;
+  return proof;
 }
 
 function arcPath(cx, cy, rOuter, startAngle, endAngle){
@@ -1437,22 +1485,6 @@ function depthRingRecoveryForce(strength, damping){
   force.initialize = (_nodes) => { nodes = _nodes; };
   return force;
 }
-const RADIAL_GIVE = 0.72;
-const RADIAL_DAMPING = 0.68;
-
-let simulation = d3.forceSimulation([])
-  .force('radial', depthRingRecoveryForce(RADIAL_GIVE, RADIAL_DAMPING))
-  .force('link', d3.forceLink([]).id(d => d.id).distance(pipeRestLength).strength(0.55))
-  // Every seed-layer cousin occupies the same center. Give centers zero
-  // collision radius so this force does not contradict that geometry by
-  // pushing them apart; ordinary non-center nodes still keep spacing.
-  .force('collide', ringWedgeCollisionForce(0.92))
-  .force('region', regionBindingForce(0.10))
-  .force('pipeStraighten', pipeStraighteningForce(0.32))
-  .alphaDecay(0.06)
-  .velocityDecay(0.55)
-  .on('tick', render);
-
 let currentTickIdx = 0;
 let lastAppliedSnapshotKey = null;
 
@@ -1464,24 +1496,9 @@ function applySnapshot(snap){
   const snapshotKey = (activeRun ? activeRun.key : 'detached') + ':' + snap.tick;
   const snapshotChanged = snapshotKey !== lastAppliedSnapshotKey;
 
-  // Recomputed fresh every snapshot -- each network's wedge target tracks
-  // its current live pressure, not whatever it was when first drawn. The
-  // rays themselves don't jump straight there though (see
-  // updateRayElasticity/render()); this just updates what they're aiming
-  // for. One synchronous ease step here so currentWedgeLayout is already
-  // sane for the per-node loop below, before render() has even run once.
-  const structural = computeStructuralBoundaries(liveNodes.map(n => ({ data: n })));
-  currentGroupOrder = structural.groupOrder;
-  currentBoundaries = structural.boundaries;
-  rayLoads.clear(); // never carry wall impulse across snapshots/runs
-  updateRayElasticity();
-  currentWedgeLayout = physicalWedgeLayoutFrom();
-
-  const maxDepth = Math.max(1, ...liveNodes.map(n => n.display_radius != null ? n.display_radius : n.depth));
-  currentRingRadii = computeRingRadii(liveNodes, currentWedgeLayout, maxDepth);
-  updateViewBoxForRadius(currentRingRadii[maxDepth]); // must happen before anything below reads CX/CY/W/H
-  syncRingRadiiArrays(maxDepth);
-  drawCenterDivider();
+  // The viewport is only an observation surface. Its dimensions no longer
+  // participate in mechanics; all positions are owned by NDForceAssembly.
+  updateViewBoxForRadius(BASE_H / 2 - STAGE_MARGIN);
 
   for (const id of Array.from(simNodes.keys())){
     if (!liveIds.has(id)) simNodes.delete(id);
@@ -1489,22 +1506,14 @@ function applySnapshot(snap){
   for (const n of liveNodes){
     let sn = simNodes.get(n.id);
     if (!sn){
-      // Start on the intended ring/wedge instead of stacking every new
-      // node on its parent and relying on a high-alpha explosion to prise
-      // the pile apart.
-      const initialAngle = targetAngle(n, currentWedgeLayout);
-      const initialRadius = targetRadius(n);
       sn = {
         id: n.id,
-        x: CX + initialRadius*Math.cos(initialAngle),
-        y: CY + initialRadius*Math.sin(initialAngle),
-        angle: initialAngle,
+        x: CX,
+        y: CY,
       };
       simNodes.set(n.id, sn);
     }
     sn.data = n;
-    sn.targetR = targetRadius(n);
-    if (sn.angle === undefined) sn.angle = targetAngle(n, currentWedgeLayout);
     sn.r = isCenter(n) ? 13 : pressureRadius(n.pressure);
   }
 
@@ -1524,17 +1533,11 @@ function applySnapshot(snap){
   currentEdgeInfluence = new Map((snap.edges || []).map(e => [e.from + '-' + e.to, e]));
   updateMaterialLegend();
   rebuildSnapshotRenderCaches(nodesArr);
-  simulation.nodes(nodesArr);
-  simulation.force('link').links(currentLinks).distance(pipeRestLength);
-  simulation.force('radial', depthRingRecoveryForce(RADIAL_GIVE, RADIAL_DAMPING));
-  // Live polling can deliver the same completed tick many times. The old
-  // unconditional alpha(0.9) restart kicked the user's settled graph on
-  // every poll. Reheat only for a genuinely new snapshot, and then just
-  // enough for new topology or hydraulic torque to ease into place.
   if (snapshotChanged){
-    const heat = topologyChanged ? 0.24 : (hasHydraulicActivity() ? 0.09 : 0.035);
-    simulation.alpha(Math.max(simulation.alpha(), heat)).restart();
+    solveNDForceAssembly(nodesArr, topologyChanged ? 72 : 28);
     lastAppliedSnapshotKey = snapshotKey;
+  } else if (!window.fluxNDPhysicsFrame) {
+    solveNDForceAssembly(nodesArr, 28);
   }
 
   // Edge appearance (color + width) is driven entirely by this tick's
@@ -1551,6 +1554,7 @@ function applySnapshot(snap){
   currentMovementCount = Number(snap.movement_count) || 0;
   currentPhysiology = snap.physiology || {};
   currentTubeState = snap.tube_state || [];
+  shellObservationDirty = true;
   renderHeartHud();
 
   document.getElementById('fgTick').textContent = snap.tick;
@@ -1558,6 +1562,7 @@ function applySnapshot(snap){
   document.getElementById('fgScore').textContent = snap.best_score.toFixed(3);
   document.getElementById('fgPath').textContent = snap.best_path;
   document.getElementById('fgTraversals').textContent = snap.traversal_count != null ? snap.traversal_count : 0;
+  render();
 }
 
 function colorFor(n){
@@ -1577,10 +1582,36 @@ function render(){
   // its assigned wedge while exchanging wall load back into soft rays,
   // so a node under real pressure can still visibly
   // bow its own ray outward rather than being invisibly teleported back.
-  updateRayElasticity();
-  currentWedgeLayout = physicalWedgeLayoutFrom();
-  enforceNetworkGeometry(nodesArr);
-  drawWedgeGuides(currentWedgeLayout, currentRingRadii[currentRingRadii.length - 1] + 20);
+  if (shellProjector && (shellObservationDirty || !shellObservation)){
+    const physicsDimensions = window.fluxNDPhysicsFrame
+      ? window.fluxNDPhysicsFrame.dimensions
+      : [];
+    shellObservation = shellProjector.observe(nodesArr, W, H, physicsDimensions);
+    shellObservationById = new Map(shellObservation.nodes.map(node => [node.id, node]));
+    shellObservationDirty = false;
+    window.fluxObservationFrame = shellObservation;
+  }
+  const forceProof = window.fluxNDPhysicsFrame && window.fluxNDPhysicsFrame.proof;
+  shellDimensionsOut.textContent = shellLensEnabled && shellObservation
+    ? `${shellObservation.dimensions.length}D → S²`
+      + (forceProof ? ` · force ε ${Number(forceProof.residual).toExponential(1)}` : '')
+    : '';
+  wedgeLayer.style('display', shellLensEnabled ? 'none' : null);
+  guideLayer.style('display', shellLensEnabled ? 'none' : null);
+  const shellGuideData = shellLensEnabled && shellObservation
+    ? [shellObservation.shellRadius]
+    : [];
+  shellGuideLayer.selectAll('circle.fg-shell-outline').data(shellGuideData).join('circle')
+    .attr('class', 'fg-shell-outline')
+    .attr('cx', CX).attr('cy', CY).attr('r', radius => radius)
+    .attr('fill', 'rgba(49, 94, 79, 0.10)')
+    .attr('stroke', 'var(--ink)').attr('stroke-width', 1.2).attr('opacity', 0.75);
+  shellGuideLayer.selectAll('ellipse.fg-shell-equator').data(shellGuideData).join('ellipse')
+    .attr('class', 'fg-shell-equator')
+    .attr('cx', CX).attr('cy', CY)
+    .attr('rx', radius => radius).attr('ry', radius => radius * 0.23)
+    .attr('fill', 'none').attr('stroke', 'var(--grid)')
+    .attr('stroke-width', 1).attr('stroke-dasharray', '4 7').attr('opacity', 0.72);
 
   // Ring d is the exact radius targeted by every node d edge hops from
   // its own network seed/center. Rings do not chase displaced nodes.
@@ -1610,10 +1641,10 @@ function render(){
   );
   edges.join('line')
     .attr('class', 'fg-edge')
-    .attr('x1', d => { const n = linkTarget(d); return n ? n.x : CX; })
-    .attr('y1', d => { const n = linkTarget(d); return n ? n.y : CY; })
-    .attr('x2', d => { const n = linkSource(d); return n ? n.x : CX; })
-    .attr('y2', d => { const n = linkSource(d); return n ? n.y : CY; })
+    .attr('x1', d => { const n = linkTarget(d); return n ? visualPoint(n).x : CX; })
+    .attr('y1', d => { const n = linkTarget(d); return n ? visualPoint(n).y : CY; })
+    .attr('x2', d => { const n = linkSource(d); return n ? visualPoint(n).x : CX; })
+    .attr('y2', d => { const n = linkSource(d); return n ? visualPoint(n).y : CY; })
     .attr('stroke', d => {
       const inf = d.influence;
       const target = linkTarget(d);
@@ -1638,10 +1669,10 @@ function render(){
   // color / count width channels above, so it reads as its own signal.
   edgeLayer.selectAll('line.fg-pressure').data(currentPressureData, linkKey).join('line')
     .attr('class', 'fg-pressure')
-    .attr('x1', d => { const n = linkTarget(d); return n ? n.x : CX; })
-    .attr('y1', d => { const n = linkTarget(d); return n ? n.y : CY; })
-    .attr('x2', d => { const n = linkSource(d); return n ? n.x : CX; })
-    .attr('y2', d => { const n = linkSource(d); return n ? n.y : CY; })
+    .attr('x1', d => { const n = linkTarget(d); return n ? visualPoint(n).x : CX; })
+    .attr('y1', d => { const n = linkTarget(d); return n ? visualPoint(n).y : CY; })
+    .attr('x2', d => { const n = linkSource(d); return n ? visualPoint(n).x : CX; })
+    .attr('y2', d => { const n = linkSource(d); return n ? visualPoint(n).y : CY; })
     .attr('stroke', 'var(--danger)').attr('stroke-linecap', 'round')
     .attr('stroke-width', 9)
     .attr('opacity', d => 0.05 + 0.2 * Math.abs(d.influence.pressure_drop) / currentMaxDrop);
@@ -1668,8 +1699,8 @@ function render(){
 
   const circles = nodeLayer.selectAll('circle').data(nodesArr, d => d.id);
   circles.join('circle')
-    .attr('cx', d => d.x).attr('cy', d => d.y)
-    .attr('r', d => d.r)
+    .attr('cx', d => visualPoint(d).x).attr('cy', d => visualPoint(d).y)
+    .attr('r', d => d.r * visualPoint(d).scale)
     .attr('fill', d => colorFor(d.data))
     .attr('opacity', d => isCenter(d.data) ? 1 : scoreBrightness(d.data.local_evidence))
     .style('cursor', 'pointer')
@@ -1681,8 +1712,8 @@ function render(){
   // tracks how much volume it's holding (relative to the busiest node),
   // tinted by its dominant soluble. You can see who's full and who's dry.
   fluidLayer.selectAll('circle').data(currentFluidData, d => d.id).join('circle')
-    .attr('cx', d => d.x).attr('cy', d => d.y)
-    .attr('r', d => d.r * Math.min(1, Math.sqrt((d.data.volume || 0) / currentMaxVolume)))
+    .attr('cx', d => visualPoint(d).x).attr('cy', d => visualPoint(d).y)
+    .attr('r', d => d.r * visualPoint(d).scale * Math.min(1, Math.sqrt((d.data.volume || 0) / currentMaxVolume)))
     .attr('fill', d => {
       const sol = d.data.solubles || {};
       const names = Object.keys(sol);
@@ -1699,18 +1730,41 @@ function render(){
 
   const labels = labelLayer.selectAll('text').data(currentLabelData, d => d.id);
   labels.join('text')
-    .attr('x', d => d.x + d.r + 3).attr('y', d => d.y + 3)
+    .attr('x', d => visualPoint(d).x + d.r * visualPoint(d).scale + 3)
+    .attr('y', d => visualPoint(d).y + 3)
     .attr('class', 'fg-node-label')
     .text(d => d.data.text.trim().slice(0, 14));
 
   drawBath();
 
   if (webglRenderer){
+    const renderNodes = shellLensEnabled
+      ? nodesArr.map(node => {
+          const point = visualPoint(node);
+          const observation = shellObservationById.get(node.id);
+          return {
+            ...node,
+            x: point.x,
+            y: point.y,
+            r: node.r * point.scale,
+            data: {
+              ...node.data,
+              projection_confidence: observation ? observation.confidence : 0,
+            },
+          };
+        })
+      : nodesArr;
     webglRenderer.update({
       width: W,
       height: H,
-      nodes: nodesArr,
-      links: currentLinks,
+      nodes: renderNodes,
+      links: shellLensEnabled
+        ? currentLinks.map(link => ({
+            ...link,
+            source: endpointId(link.source),
+            target: endpointId(link.target),
+          }))
+        : currentLinks,
       tubes: currentTubeState,
     });
   }
@@ -1746,7 +1800,8 @@ function drawHearts(){
       const lk = dir + '|' + stage;
       if (lk in lobes){ lobes[lk] += vol; total += vol; }
     }
-    glyphs.push({ region, x: pn.x, y: pn.y, lobes, total });
+    const point = visualPoint(pn);
+    glyphs.push({ region, x: point.x, y: point.y, lobes, total });
   }
   const g = heartLayer.selectAll('g.fg-heart').data(glyphs, d => d.region);
   const gEnter = g.enter().append('g').attr('class', 'fg-heart');
@@ -1861,20 +1916,23 @@ tickSlider.addEventListener('input', () => {
 document.getElementById('fgStiff').addEventListener('input', (e) => {
   const v = +e.target.value;
   document.getElementById('fgStiffOut').textContent = v.toFixed(2);
-  simulation.force('link').strength(v);
-  simulation.alpha(0.6).restart();
+  if (ndForceAssembly) ndForceAssembly.configure({ pipeStiffness: v });
+  solveNDForceAssembly(Array.from(simNodes.values()), 48);
+  render();
 });
 document.getElementById('fgRest').addEventListener('input', (e) => {
-  basePipeLength = +e.target.value;
-  document.getElementById('fgRestOut').textContent = basePipeLength;
-  simulation.force('link').distance(pipeRestLength);
-  simulation.alpha(0.25).restart();
+  const value = +e.target.value;
+  document.getElementById('fgRestOut').textContent = value.toFixed(2);
+  if (ndForceAssembly) ndForceAssembly.configure({ pipeRestLength: value });
+  solveNDForceAssembly(Array.from(simNodes.values()), 48);
+  render();
 });
 document.getElementById('fgPressureLength').addEventListener('input', (e) => {
-  pressureLengthFactor = +e.target.value;
-  document.getElementById('fgPressureLengthOut').textContent = pressureLengthFactor.toFixed(1);
-  simulation.force('link').distance(pipeRestLength);
-  simulation.alpha(0.25).restart();
+  const value = +e.target.value;
+  document.getElementById('fgPressureLengthOut').textContent = value.toFixed(3);
+  if (ndForceAssembly) ndForceAssembly.configure({ pressureExpansion: value });
+  solveNDForceAssembly(Array.from(simNodes.values()), 48);
+  render();
 });
 
 let playing = false, playTimer = null;
@@ -2448,33 +2506,35 @@ async function pollLive(){
     if (!liveActive) return;
     applyLiveState(state);
     await processFluidWork(state.fluid_work);
-    pushClientPhysics();
+    await pushClientPhysics();
   } catch (err) {
     // Transient poll hiccup -- skip this tick rather than spamming the
     // error banner; a real server-side failure surfaces via state.error.
   }
 }
 
-// The client's half of the physics exchange: this interface sim is its
-// own physics domain -- ring nearness only exists HERE, in the gamified
-// layout the user is actually watching (the backend has no positions) --
-// so each poll cycle publishes what it observed and the backend's ring
-// dispensing consumes it. Same door a shader domain would publish
-// through later (POST /api/live/physics with a different "domain").
+// The client owns one generalized nD mechanics domain. Habitat proximity is
+// measured in each network's local subspace; the projected S² screen position
+// never feeds biology. The proof and local observations are returned together.
 async function pushClientPhysics(){
-  if (!liveActive || !activeRun || activeRun.key !== liveRunKey) return;
-  const ring_proximity = {};
-  for (const d of simNodes.values()){
-    if (isCenter(d.data)) continue;
-    const r = Math.hypot(d.x - CX, d.y - CY);
-    const p = Math.max(0, 1 - Math.abs(r - d.targetR) / RING_SPACING);
-    if (p > 0) ring_proximity[d.data.id] = +p.toFixed(4);
-  }
+  if (
+    !liveActive
+    || !activeRun
+    || activeRun.key !== liveRunKey
+    || !ndForceAssembly
+  ) return;
+  solveNDForceAssembly(Array.from(simNodes.values()), 12);
+  const state = ndForceAssembly.snapshot();
   try {
     await fetch('/api/live/physics', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ domain: 'client', ring_proximity }),
+      body: JSON.stringify({
+        domain: 'client_nd',
+        habitat_proximity: ndForceAssembly.habitatProximity(),
+        force_proof: state.proof,
+        dimensions: state.dimensions,
+      }),
     });
   } catch (err) { /* dropped observation is fine -- next poll publishes fresh ones */ }
 }

--- a/speaktome/flux_radar/package-lock.json
+++ b/speaktome/flux_radar/package-lock.json
@@ -1,0 +1,970 @@
+{
+  "name": "speaktome-flux-radar-webgl",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "speaktome-flux-radar-webgl",
+      "dependencies": {
+        "three": "0.185.1"
+      },
+      "devDependencies": {
+        "@types/node": "24.10.1",
+        "@types/three": "0.185.0",
+        "typescript": "5.9.3",
+        "vite": "8.1.5"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
+      "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.185.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.185.0.tgz",
+      "integrity": "sha512-O2Uy8Cj4Nonr8dWUUbifMdPe8B0Mq7EdOHb89S4+kjUw/KhbjTZrUuYlrQ1bpUKG+EP9QJnN7qNxbHGlGoLHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.185.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.185.1.tgz",
+      "integrity": "sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/speaktome/flux_radar/package.json
+++ b/speaktome/flux_radar/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "speaktome-flux-radar-webgl",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build --config vite.config.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "three": "0.185.1"
+  },
+  "devDependencies": {
+    "@types/three": "0.185.0",
+    "@types/node": "24.10.1",
+    "typescript": "5.9.3",
+    "vite": "8.1.5"
+  }
+}

--- a/speaktome/flux_radar/package.json
+++ b/speaktome/flux_radar/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "vite build --config vite.config.ts",
+    "test:projection": "node tests/hypersphere_projection.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/speaktome/flux_radar/src/hypersphere_projection.ts
+++ b/speaktome/flux_radar/src/hypersphere_projection.ts
@@ -1,0 +1,327 @@
+export interface LatentRadarNode {
+  id: number;
+  data: {
+    network_root?: number | null;
+    direction?: string | null;
+    level?: number | null;
+    depth?: number;
+    pressure?: number;
+    volume?: number;
+    solvent?: number;
+    solubles?: Record<string, number>;
+    local_evidence?: number;
+    path_mean?: number;
+    backward_growth_interest?: number;
+    forward_growth_interest?: number;
+    is_anchor?: boolean;
+    is_center?: boolean;
+    latent_coordinates?: number[];
+    hyperspherical_angles?: number[];
+  };
+}
+
+export interface ProjectedObservationNode {
+  id: number;
+  network: string;
+  latent: number[];
+  unit: number[];
+  projected: [number, number, number];
+  shell: [number, number, number];
+  confidence: number;
+  screen: { x: number; y: number; depth: number; scale: number };
+}
+
+export interface HypersphereObservationFrame {
+  version: 1;
+  dimensions: string[];
+  projection: number[][];
+  networkCaps: Record<string, [number, number, number]>;
+  shellRadius: number;
+  nodes: ProjectedObservationNode[];
+}
+
+const EPSILON = 1e-9;
+const SHARED_DIMENSIONS = [
+  "shared:anchor",
+  "shared:direction",
+  "shared:level",
+  "shared:pressure",
+  "shared:hydration",
+  "shared:ion_load",
+  "shared:local_evidence",
+  "shared:path_mean",
+];
+const NETWORK_FEATURES = [
+  "membership",
+  "pressure",
+  "hydration",
+  "ion_load",
+  "forward_commitment",
+  "backward_commitment",
+];
+
+function finite(value: unknown): number {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function networkKey(node: LatentRadarNode): string {
+  return node.data.network_root == null
+    ? "main"
+    : `net:${node.data.network_root}`;
+}
+
+function hashText(value: string): number {
+  let hash = 2166136261;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+}
+
+function pseudoRandom(seed: number): () => number {
+  let state = seed || 0x9e3779b9;
+  return () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return ((state >>> 0) / 0xffffffff) * 2 - 1;
+  };
+}
+
+function dot(left: number[], right: number[]): number {
+  let value = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    value += left[index] * right[index];
+  }
+  return value;
+}
+
+function normalize(vector: number[]): number[] {
+  const length = Math.sqrt(dot(vector, vector));
+  if (length <= EPSILON) {
+    const fallback = new Array(vector.length).fill(0);
+    fallback[0] = 1;
+    return fallback;
+  }
+  return vector.map((value) => value / length);
+}
+
+export function hypersphericalToCartesian(angles: number[]): number[] {
+  const coordinates = new Array(angles.length + 1).fill(0);
+  let sineProduct = 1;
+  for (let index = 0; index < angles.length; index += 1) {
+    const angle = finite(angles[index]);
+    coordinates[index] = sineProduct * Math.cos(angle);
+    sineProduct *= Math.sin(angle);
+  }
+  coordinates[angles.length] = sineProduct;
+  return coordinates;
+}
+
+function intrinsicCoordinates(node: LatentRadarNode): number[] {
+  if (Array.isArray(node.data.latent_coordinates)) {
+    return node.data.latent_coordinates.map(finite);
+  }
+  if (Array.isArray(node.data.hyperspherical_angles)) {
+    return hypersphericalToCartesian(node.data.hyperspherical_angles);
+  }
+  return [];
+}
+
+function stableProjection(
+  labels: string[],
+  seed: string,
+): number[][] {
+  const rows = [[], [], []] as number[][];
+  for (const label of labels) {
+    const random = pseudoRandom(hashText(`${seed}|${label}`));
+    const column = normalize([random(), random(), random()]);
+    rows[0].push(column[0]);
+    rows[1].push(column[1]);
+    rows[2].push(column[2]);
+  }
+  return rows;
+}
+
+function fibonacciCaps(
+  networks: string[],
+): Record<string, [number, number, number]> {
+  const caps: Record<string, [number, number, number]> = {};
+  const goldenAngle = Math.PI * (3 - Math.sqrt(5));
+  networks.forEach((network, index) => {
+    if (networks.length === 1) {
+      caps[network] = [0, 0, 1];
+      return;
+    }
+    const y = 1 - (2 * (index + 0.5)) / networks.length;
+    const radius = Math.sqrt(Math.max(0, 1 - y * y));
+    const angle = index * goldenAngle;
+    caps[network] = [
+      Math.cos(angle) * radius,
+      y,
+      Math.sin(angle) * radius,
+    ];
+  });
+  return caps;
+}
+
+function packIntoCap(
+  direction: number[],
+  center: [number, number, number],
+  capAngle: number,
+): [number, number, number] {
+  const cosine = Math.max(-1, Math.min(1, dot(direction, center)));
+  const sourceAngle = Math.acos(cosine);
+  if (sourceAngle <= EPSILON) return [...center];
+  const tangent = normalize(direction.map(
+    (value, index) => value - cosine * center[index],
+  ));
+  const angle = capAngle * sourceAngle / Math.PI;
+  return [
+    Math.cos(angle) * center[0] + Math.sin(angle) * tangent[0],
+    Math.cos(angle) * center[1] + Math.sin(angle) * tangent[1],
+    Math.cos(angle) * center[2] + Math.sin(angle) * tangent[2],
+  ];
+}
+
+function nodeFeatures(node: LatentRadarNode): {
+  pressure: number;
+  hydration: number;
+  ionLoad: number;
+  forwardCommitment: number;
+  backwardCommitment: number;
+} {
+  const volume = Math.max(EPSILON, finite(node.data.volume));
+  const solvent = Math.max(0, finite(node.data.solvent));
+  const ions = Object.values(node.data.solubles ?? {}).reduce(
+    (sum, value) => sum + Math.max(0, finite(value)),
+    0,
+  );
+  return {
+    pressure: Math.tanh(Math.log1p(Math.max(0, finite(node.data.pressure)))),
+    hydration: Math.tanh(solvent / volume),
+    ionLoad: Math.tanh(ions / volume),
+    forwardCommitment: Math.tanh(
+      Math.max(0, finite(node.data.forward_growth_interest)) / 3,
+    ),
+    backwardCommitment: Math.tanh(
+      Math.max(0, finite(node.data.backward_growth_interest)) / 3,
+    ),
+  };
+}
+
+export class HypersphereProjector {
+  private readonly seed: string;
+
+  constructor(seed = "flux-radar-observation-v1") {
+    this.seed = seed;
+  }
+
+  observe(
+    nodes: LatentRadarNode[],
+    width: number,
+    height: number,
+    intrinsicLabels: string[] = [],
+  ): HypersphereObservationFrame {
+    const networks = Array.from(new Set(nodes.map(networkKey))).sort();
+    const intrinsicDimensionCount = nodes.reduce(
+      (maximum, node) => Math.max(maximum, intrinsicCoordinates(node).length),
+      0,
+    );
+    const hasMechanicalCoordinates = intrinsicDimensionCount > 0;
+    const intrinsicDimensions = Array.from({ length: intrinsicDimensionCount }, (_, index) =>
+      intrinsicLabels[index] ?? `intrinsic:${index}`
+    );
+    const dimensions = hasMechanicalCoordinates
+      ? intrinsicDimensions
+      : [
+          ...SHARED_DIMENSIONS,
+          ...networks.flatMap((network) => NETWORK_FEATURES.map(
+            (feature) => `${network}:${feature}`,
+          )),
+        ];
+    // Every dimension owns a deterministic random 3-vector. Adding a new
+    // network therefore appends columns without rotating any existing one.
+    const projection = stableProjection(dimensions, this.seed);
+    const networkCaps = fibonacciCaps(networks);
+    const capAngle = networks.length <= 1
+      ? Math.PI * 0.92
+      : Math.max(0.24, Math.min(0.68, 1.12 / Math.sqrt(networks.length)));
+    const shellRadius = Math.max(40, Math.min(width, height) * 0.39);
+    const centerX = width / 2;
+    const centerY = height / 2;
+
+    const observations = nodes.map((node): ProjectedObservationNode => {
+      const network = networkKey(node);
+      const features = nodeFeatures(node);
+      const latent = new Array(dimensions.length).fill(0);
+      if (hasMechanicalCoordinates) {
+        intrinsicCoordinates(node).forEach((value, index) => {
+          latent[index] = value;
+        });
+      } else {
+        latent[0] = node.data.is_anchor || node.data.is_center ? 1 : 0;
+        latent[1] = node.data.direction === "backward"
+          ? -1
+          : node.data.direction === "forward" ? 1 : 0;
+        latent[2] = Math.tanh(finite(node.data.level ?? node.data.depth) / 4);
+        latent[3] = features.pressure;
+        latent[4] = features.hydration;
+        latent[5] = features.ionLoad;
+        latent[6] = Math.tanh(finite(node.data.local_evidence));
+        latent[7] = Math.tanh(finite(node.data.path_mean));
+
+        const networkOffset = SHARED_DIMENSIONS.length
+          + networks.indexOf(network) * NETWORK_FEATURES.length;
+        latent[networkOffset] = 1;
+        latent[networkOffset + 1] = features.pressure;
+        latent[networkOffset + 2] = features.hydration;
+        latent[networkOffset + 3] = features.ionLoad;
+        latent[networkOffset + 4] = features.forwardCommitment;
+        latent[networkOffset + 5] = features.backwardCommitment;
+      }
+
+      const latentNorm = Math.sqrt(dot(latent, latent));
+      const unit = normalize(latent);
+      const projected = projection.map((row) => dot(row, unit)) as [
+        number,
+        number,
+        number,
+      ];
+      const confidence = latentNorm <= EPSILON
+        ? 0
+        : Math.sqrt(dot(projected, projected));
+      const cap = networkCaps[network] ?? [0, 0, 1];
+      const shell = confidence <= EPSILON
+        ? [...cap] as [number, number, number]
+        : packIntoCap(normalize(projected), cap, capAngle);
+      const perspective = 0.78 + 0.22 * ((shell[2] + 1) / 2);
+      return {
+        id: node.id,
+        network,
+        latent,
+        unit,
+        projected,
+        shell,
+        confidence: Math.min(1, confidence),
+        screen: {
+          x: centerX + shell[0] * shellRadius * perspective,
+          y: centerY - shell[1] * shellRadius * perspective,
+          depth: shell[2],
+          scale: perspective,
+        },
+      };
+    });
+
+    return {
+      version: 1,
+      dimensions,
+      projection,
+      networkCaps,
+      shellRadius,
+      nodes: observations,
+    };
+  }
+}

--- a/speaktome/flux_radar/src/nd_force_assembly.ts
+++ b/speaktome/flux_radar/src/nd_force_assembly.ts
@@ -1,0 +1,425 @@
+export interface NDForceNode {
+  id: number;
+  data: {
+    network_root?: number | null;
+    is_anchor?: boolean;
+    is_center?: boolean;
+    level?: number | null;
+    depth?: number;
+    direction?: string | null;
+    pressure?: number;
+    volume?: number;
+  };
+}
+
+export interface NDForceLink {
+  source: number | NDForceNode;
+  target: number | NDForceNode;
+}
+
+export interface NDRelaxationProof {
+  dimensions: number;
+  nodes: number;
+  edges: number;
+  substeps: number;
+  residual: number;
+  kineticEnergy: number;
+  potentialEnergy: number;
+}
+
+export interface NDForceSnapshot {
+  dimensions: string[];
+  networks: string[];
+  positions: Record<string, number[]>;
+  proof: NDRelaxationProof | null;
+}
+
+const EPSILON = 1e-7;
+
+function finite(value: unknown): number {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : 0;
+}
+
+function endpointId(endpoint: number | NDForceNode): number {
+  return typeof endpoint === "number" ? endpoint : endpoint.id;
+}
+
+function networkKey(node: NDForceNode): string {
+  return node.data.network_root == null
+    ? "main"
+    : `net:${node.data.network_root}`;
+}
+
+function hashUnit(id: number, salt: number): number {
+  let value = Math.imul((id ^ salt) >>> 0, 0x45d9f3b);
+  value = Math.imul((value ^ (value >>> 16)) >>> 0, 0x45d9f3b);
+  value ^= value >>> 16;
+  return (value >>> 0) / 0xffffffff;
+}
+
+function neighborOffsets(dimensions: number): number[][] {
+  let offsets: number[][] = [[]];
+  for (let dimension = 0; dimension < dimensions; dimension += 1) {
+    offsets = offsets.flatMap((prefix) => [-1, 0, 1].map(
+      (offset) => [...prefix, offset],
+    ));
+  }
+  return offsets;
+}
+
+export class NDForceAssembly {
+  readonly sharedDimensions: number;
+  readonly localDimensions: number;
+
+  private networks: string[] = [];
+  private dimensionLabels: string[] = [];
+  private nodes: NDForceNode[] = [];
+  private nodeIndex = new Map<number, number>();
+  private networkIndices = new Int32Array();
+  private fixed = new Uint8Array();
+  private levels = new Float32Array();
+  private pressures = new Float32Array();
+  private radii = new Float32Array();
+  private positions = new Float32Array();
+  private velocities = new Float32Array();
+  private sources = new Int32Array();
+  private targets = new Int32Array();
+  private lastProof: NDRelaxationProof | null = null;
+  private readonly collisionOffsets: number[][];
+  private pipeStiffness = 0.72;
+  private pipeRestLength = 1.05;
+  private pressureExpansion = 0.06;
+
+  constructor(sharedDimensions = 2, localDimensions = 4) {
+    this.sharedDimensions = Math.max(0, Math.floor(sharedDimensions));
+    this.localDimensions = Math.max(2, Math.floor(localDimensions));
+    this.collisionOffsets = neighborOffsets(this.localDimensions);
+  }
+
+  configure(parameters: {
+    pipeStiffness?: number;
+    pipeRestLength?: number;
+    pressureExpansion?: number;
+  }): void {
+    if (parameters.pipeStiffness != null) {
+      this.pipeStiffness = Math.max(0, finite(parameters.pipeStiffness));
+    }
+    if (parameters.pipeRestLength != null) {
+      this.pipeRestLength = Math.max(EPSILON, finite(parameters.pipeRestLength));
+    }
+    if (parameters.pressureExpansion != null) {
+      this.pressureExpansion = Math.max(
+        0,
+        finite(parameters.pressureExpansion),
+      );
+    }
+  }
+
+  private rebuildDimensionLabels(): void {
+    this.dimensionLabels = [
+      ...Array.from(
+        { length: this.sharedDimensions },
+        (_, index) => `world:${index}`,
+      ),
+      ...this.networks.flatMap((network) => Array.from(
+        { length: this.localDimensions },
+        (_, index) => `${network}:space:${index}`,
+      )),
+    ];
+  }
+
+  private localOffset(networkIndex: number): number {
+    return this.sharedDimensions + networkIndex * this.localDimensions;
+  }
+
+  sync(nodes: NDForceNode[], links: NDForceLink[]): void {
+    const oldLabels = this.dimensionLabels;
+    const oldPositions = this.positions;
+    const oldVelocities = this.velocities;
+    const oldNodeIndex = this.nodeIndex;
+    const oldDimensionCount = oldLabels.length;
+
+    for (const node of nodes) {
+      const network = networkKey(node);
+      if (!this.networks.includes(network)) this.networks.push(network);
+    }
+    this.rebuildDimensionLabels();
+    const dimensionCount = this.dimensionLabels.length;
+    const labelRemap = this.dimensionLabels.map((label) => oldLabels.indexOf(label));
+
+    this.nodes = [...nodes];
+    this.nodeIndex = new Map(nodes.map((node, index) => [node.id, index]));
+    this.networkIndices = new Int32Array(nodes.length);
+    this.fixed = new Uint8Array(nodes.length);
+    this.levels = new Float32Array(nodes.length);
+    this.pressures = new Float32Array(nodes.length);
+    this.radii = new Float32Array(nodes.length);
+    this.positions = new Float32Array(nodes.length * dimensionCount);
+    this.velocities = new Float32Array(nodes.length * dimensionCount);
+
+    nodes.forEach((node, nodeIndex) => {
+      const networkIndex = this.networks.indexOf(networkKey(node));
+      this.networkIndices[nodeIndex] = networkIndex;
+      this.fixed[nodeIndex] = node.data.is_anchor || node.data.is_center ? 1 : 0;
+      this.levels[nodeIndex] = finite(node.data.level ?? node.data.depth);
+      this.pressures[nodeIndex] = Math.max(0, finite(node.data.pressure));
+      this.radii[nodeIndex] = 0.16
+        + 0.08 * Math.sqrt(Math.max(0, finite(node.data.volume)));
+
+      const previousNode = oldNodeIndex.get(node.id);
+      if (previousNode != null && oldDimensionCount > 0) {
+        for (let dimension = 0; dimension < dimensionCount; dimension += 1) {
+          const oldDimension = labelRemap[dimension];
+          if (oldDimension < 0) continue;
+          this.positions[nodeIndex * dimensionCount + dimension]
+            = oldPositions[previousNode * oldDimensionCount + oldDimension];
+          this.velocities[nodeIndex * dimensionCount + dimension]
+            = oldVelocities[previousNode * oldDimensionCount + oldDimension];
+        }
+        return;
+      }
+
+      if (this.fixed[nodeIndex]) return;
+      const localOffset = this.localOffset(networkIndex);
+      const targetRadius = Math.max(0.7, Math.abs(this.levels[nodeIndex]) * 1.05);
+      let squaredLength = 0;
+      for (let local = 0; local < this.localDimensions; local += 1) {
+        const value = hashUnit(node.id, 0x9e37 + local * 0x85eb) * 2 - 1;
+        this.positions[nodeIndex * dimensionCount + localOffset + local] = value;
+        squaredLength += value * value;
+      }
+      const scale = targetRadius / Math.sqrt(Math.max(EPSILON, squaredLength));
+      for (let local = 0; local < this.localDimensions; local += 1) {
+        this.positions[nodeIndex * dimensionCount + localOffset + local] *= scale;
+      }
+      if (this.sharedDimensions > 0) {
+        this.positions[nodeIndex * dimensionCount]
+          = (hashUnit(node.id, 0x27d4) * 2 - 1) * 0.08;
+      }
+    });
+
+    const edgePairs = links.flatMap((link) => {
+      const source = this.nodeIndex.get(endpointId(link.source));
+      const target = this.nodeIndex.get(endpointId(link.target));
+      return source == null || target == null ? [] : [[source, target]];
+    });
+    this.sources = new Int32Array(edgePairs.map(([source]) => source));
+    this.targets = new Int32Array(edgePairs.map(([, target]) => target));
+  }
+
+  private addPipeForces(forces: Float32Array): number {
+    const dimensions = this.dimensionLabels.length;
+    let energy = 0;
+    for (let edge = 0; edge < this.sources.length; edge += 1) {
+      const source = this.sources[edge];
+      const target = this.targets[edge];
+      const sourceNetwork = this.networkIndices[source];
+      const targetNetwork = this.networkIndices[target];
+      const activeDimensions: number[] = Array.from(
+        { length: this.sharedDimensions },
+        (_, index) => index,
+      );
+      // A pipe inside one network acts in that network's local subspace.
+      // A bridge between networks acts only in explicitly shared world
+      // dimensions; it never drags either endpoint through foreign axes.
+      if (targetNetwork === sourceNetwork) {
+        for (let local = 0; local < this.localDimensions; local += 1) {
+          activeDimensions.push(this.localOffset(sourceNetwork) + local);
+        }
+      }
+
+      let distanceSquared = 0;
+      for (const dimension of activeDimensions) {
+        const delta = this.positions[target * dimensions + dimension]
+          - this.positions[source * dimensions + dimension];
+        distanceSquared += delta * delta;
+      }
+      const distance = Math.sqrt(Math.max(EPSILON, distanceSquared));
+      const pressureExpansion = this.pressureExpansion * Math.log1p(
+        (this.pressures[source] + this.pressures[target]) * 0.5,
+      );
+      const restLength = this.pipeRestLength + pressureExpansion;
+      const extension = distance - restLength;
+      const stiffness = this.pipeStiffness;
+      const magnitude = stiffness * extension / distance;
+      energy += 0.5 * stiffness * extension * extension;
+      for (const dimension of activeDimensions) {
+        const delta = this.positions[target * dimensions + dimension]
+          - this.positions[source * dimensions + dimension];
+        const force = magnitude * delta;
+        forces[source * dimensions + dimension] += force;
+        forces[target * dimensions + dimension] -= force;
+      }
+    }
+    return energy;
+  }
+
+  private addLocalShellForces(forces: Float32Array): number {
+    const dimensions = this.dimensionLabels.length;
+    let energy = 0;
+    for (let node = 0; node < this.nodes.length; node += 1) {
+      if (this.fixed[node]) continue;
+      const offset = this.localOffset(this.networkIndices[node]);
+      let radiusSquared = 0;
+      for (let local = 0; local < this.localDimensions; local += 1) {
+        const value = this.positions[node * dimensions + offset + local];
+        radiusSquared += value * value;
+      }
+      const radius = Math.sqrt(Math.max(EPSILON, radiusSquared));
+      const targetRadius = Math.max(0.7, Math.abs(this.levels[node]) * 1.05);
+      const displacement = radius - targetRadius;
+      const stiffness = 0.24;
+      energy += 0.5 * stiffness * displacement * displacement;
+      for (let local = 0; local < this.localDimensions; local += 1) {
+        const index = node * dimensions + offset + local;
+        forces[index] -= stiffness * displacement * this.positions[index] / radius;
+      }
+      for (let shared = 0; shared < this.sharedDimensions; shared += 1) {
+        const index = node * dimensions + shared;
+        forces[index] -= 0.025 * this.positions[index];
+      }
+    }
+    return energy;
+  }
+
+  private addCollisionForces(forces: Float32Array): number {
+    const dimensions = this.dimensionLabels.length;
+    const cellSize = 0.48;
+    const grids = this.networks.map(() => new Map<string, number[]>());
+    let energy = 0;
+    for (let node = 0; node < this.nodes.length; node += 1) {
+      const network = this.networkIndices[node];
+      const offset = this.localOffset(network);
+      const cell = Array.from({ length: this.localDimensions }, (_, local) =>
+        Math.floor(this.positions[node * dimensions + offset + local] / cellSize)
+      );
+      const grid = grids[network];
+      for (const neighborOffset of this.collisionOffsets) {
+        const key = cell.map(
+          (coordinate, dimension) => coordinate + neighborOffset[dimension],
+        ).join(",");
+        for (const other of grid.get(key) ?? []) {
+          let distanceSquared = 0;
+          for (let local = 0; local < this.localDimensions; local += 1) {
+            const dimension = offset + local;
+            const delta = this.positions[node * dimensions + dimension]
+              - this.positions[other * dimensions + dimension];
+            distanceSquared += delta * delta;
+          }
+          const distance = Math.sqrt(Math.max(EPSILON, distanceSquared));
+          const minimum = this.radii[node] + this.radii[other] + 0.08;
+          if (distance >= minimum) continue;
+          const overlap = minimum - distance;
+          const stiffness = 0.9;
+          energy += 0.5 * stiffness * overlap * overlap;
+          for (let local = 0; local < this.localDimensions; local += 1) {
+            const dimension = offset + local;
+            const delta = this.positions[node * dimensions + dimension]
+              - this.positions[other * dimensions + dimension];
+            const force = stiffness * overlap * delta / distance;
+            forces[node * dimensions + dimension] += force;
+            forces[other * dimensions + dimension] -= force;
+          }
+        }
+      }
+      const ownKey = cell.join(",");
+      const occupants = grid.get(ownKey) ?? [];
+      occupants.push(node);
+      grid.set(ownKey, occupants);
+    }
+    return energy;
+  }
+
+  relax(substeps = 32, timeStep = 0.035): NDRelaxationProof {
+    const dimensions = this.dimensionLabels.length;
+    const forces = new Float32Array(this.positions.length);
+    let potentialEnergy = 0;
+    let residual = 0;
+    for (let step = 0; step < substeps; step += 1) {
+      forces.fill(0);
+      potentialEnergy = this.addPipeForces(forces)
+        + this.addLocalShellForces(forces)
+        + this.addCollisionForces(forces);
+      let squaredResidual = 0;
+      const damping = Math.exp(-3.8 * timeStep);
+      for (let node = 0; node < this.nodes.length; node += 1) {
+        for (let dimension = 0; dimension < dimensions; dimension += 1) {
+          const index = node * dimensions + dimension;
+          if (this.fixed[node]) {
+            this.positions[index] = 0;
+            this.velocities[index] = 0;
+            continue;
+          }
+          squaredResidual += forces[index] * forces[index];
+          this.velocities[index] = (
+            this.velocities[index] + forces[index] * timeStep
+          ) * damping;
+          this.velocities[index] = Math.max(
+            -5,
+            Math.min(5, this.velocities[index]),
+          );
+          this.positions[index] += this.velocities[index] * timeStep;
+        }
+      }
+      residual = Math.sqrt(
+        squaredResidual / Math.max(1, this.nodes.length * dimensions),
+      );
+    }
+    let kineticEnergy = 0;
+    for (const velocity of this.velocities) {
+      kineticEnergy += 0.5 * velocity * velocity;
+    }
+    this.lastProof = {
+      dimensions,
+      nodes: this.nodes.length,
+      edges: this.sources.length,
+      substeps,
+      residual,
+      kineticEnergy,
+      potentialEnergy,
+    };
+    return this.lastProof;
+  }
+
+  coordinates(nodeId: number): number[] {
+    const node = this.nodeIndex.get(nodeId);
+    if (node == null) return [];
+    const dimensions = this.dimensionLabels.length;
+    return Array.from(
+      this.positions.subarray(node * dimensions, (node + 1) * dimensions),
+    );
+  }
+
+  habitatProximity(): Record<string, number> {
+    const dimensions = this.dimensionLabels.length;
+    const proximity: Record<string, number> = {};
+    for (let node = 0; node < this.nodes.length; node += 1) {
+      if (this.fixed[node]) continue;
+      const offset = this.localOffset(this.networkIndices[node]);
+      let radiusSquared = 0;
+      for (let local = 0; local < this.localDimensions; local += 1) {
+        const value = this.positions[node * dimensions + offset + local];
+        radiusSquared += value * value;
+      }
+      const radius = Math.sqrt(radiusSquared);
+      const targetRadius = Math.max(0.7, Math.abs(this.levels[node]) * 1.05);
+      proximity[String(this.nodes[node].id)] = Math.max(
+        0,
+        1 - Math.abs(radius - targetRadius) / 1.05,
+      );
+    }
+    return proximity;
+  }
+
+  snapshot(): NDForceSnapshot {
+    return {
+      dimensions: [...this.dimensionLabels],
+      networks: [...this.networks],
+      positions: Object.fromEntries(
+        this.nodes.map((node) => [String(node.id), this.coordinates(node.id)]),
+      ),
+      proof: this.lastProof,
+    };
+  }
+}

--- a/speaktome/flux_radar/src/webgl_renderer.ts
+++ b/speaktome/flux_radar/src/webgl_renderer.ts
@@ -1,4 +1,15 @@
 import * as THREE from "three";
+export {
+  HypersphereProjector,
+  hypersphericalToCartesian,
+  type HypersphereObservationFrame,
+  type ProjectedObservationNode,
+} from "./hypersphere_projection";
+export {
+  NDForceAssembly,
+  type NDForceSnapshot,
+  type NDRelaxationProof,
+} from "./nd_force_assembly";
 
 export interface RadarNode {
   id: number;

--- a/speaktome/flux_radar/src/webgl_renderer.ts
+++ b/speaktome/flux_radar/src/webgl_renderer.ts
@@ -1,0 +1,486 @@
+import * as THREE from "three";
+
+export interface RadarNode {
+  id: number;
+  x: number;
+  y: number;
+  r: number;
+  data: {
+    pressure?: number;
+    volume?: number;
+    solvent?: number;
+    solubles?: Record<string, number>;
+    local_evidence?: number;
+    direction?: string | null;
+    is_anchor?: boolean;
+    is_center?: boolean;
+    network_root?: number | null;
+  };
+}
+
+export interface RadarLink {
+  source: number | RadarNode;
+  target: number | RadarNode;
+  influence?: {
+    from?: number;
+    to?: number;
+    count?: number;
+    maturity?: number;
+    avg?: number;
+    flow?: number;
+    component_flows?: Record<string, number>;
+  } | null;
+}
+
+export interface TubeState {
+  traversal: number[];
+  direction: "forward" | "reverse";
+  edges: [number, number][];
+  solvent: number[];
+  solubles: Record<string, number>[];
+  pressures: number[];
+}
+
+export interface FluxRenderFrame {
+  width: number;
+  height: number;
+  nodes: RadarNode[];
+  links: RadarLink[];
+  tubes: TubeState[];
+}
+
+interface QuadVertexData {
+  positions: number[];
+  colors: number[];
+  along: number[];
+  flow: number[];
+  indices: number[];
+}
+
+const VERTEX_SHADER = `
+attribute vec3 color;
+attribute float along;
+attribute float flow;
+varying vec3 vColor;
+varying float vAlong;
+varying float vFlow;
+void main() {
+  vColor = color;
+  vAlong = along;
+  vFlow = flow;
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+}
+`;
+
+const FRAGMENT_SHADER = `
+precision highp float;
+uniform float time;
+uniform float opacity;
+varying vec3 vColor;
+varying float vAlong;
+varying float vFlow;
+void main() {
+  float moving = fract(vAlong * 7.0 - time * vFlow);
+  float pulse = smoothstep(0.02, 0.20, moving) *
+                (1.0 - smoothstep(0.30, 0.52, moving));
+  vec3 color = vColor * (0.64 + 0.72 * pulse);
+  gl_FragColor = vec4(color, opacity);
+}
+`;
+
+function cssColor(value: string): THREE.Color {
+  return new THREE.Color(value);
+}
+
+function solubleHue(name: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < name.length; i += 1) {
+    hash ^= name.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash) % 360;
+}
+
+function dominantFluid(
+  solvent: number,
+  solubles: Record<string, number>,
+): THREE.Color {
+  let dominantName = "";
+  let dominantAmount = 0;
+  for (const [name, amount] of Object.entries(solubles)) {
+    if (amount > dominantAmount) {
+      dominantName = name;
+      dominantAmount = amount;
+    }
+  }
+  if (!dominantName || solvent >= dominantAmount) {
+    return cssColor("hsl(200, 85%, 64%)");
+  }
+  return cssColor(`hsl(${solubleHue(dominantName)}, 86%, 61%)`);
+}
+
+function nodeColor(node: RadarNode): THREE.Color {
+  if (node.data.is_anchor || node.data.is_center) {
+    return cssColor("#f0cf65");
+  }
+  if (node.data.network_root != null) {
+    return cssColor(`hsl(${(node.data.network_root * 67) % 360}, 66%, 58%)`);
+  }
+  return node.data.direction === "backward"
+    ? cssColor("#d883d9")
+    : cssColor("#66d6a1");
+}
+
+function resolveNode(
+  endpoint: number | RadarNode,
+  lookup: Map<number, RadarNode>,
+): RadarNode | undefined {
+  return typeof endpoint === "number" ? lookup.get(endpoint) : endpoint;
+}
+
+function addQuad(
+  data: QuadVertexData,
+  ax: number,
+  ay: number,
+  bx: number,
+  by: number,
+  halfWidth: number,
+  offset: number,
+  color: THREE.Color,
+  flow: number,
+  z: number,
+): void {
+  const dx = bx - ax;
+  const dy = by - ay;
+  const length = Math.max(1e-6, Math.hypot(dx, dy));
+  const nx = -dy / length;
+  const ny = dx / length;
+  const ox = nx * offset;
+  const oy = ny * offset;
+  const wx = nx * halfWidth;
+  const wy = ny * halfWidth;
+  const base = data.positions.length / 3;
+  data.positions.push(
+    ax + ox - wx, ay + oy - wy, z,
+    ax + ox + wx, ay + oy + wy, z,
+    bx + ox + wx, by + oy + wy, z,
+    bx + ox - wx, by + oy - wy, z,
+  );
+  for (let i = 0; i < 4; i += 1) {
+    data.colors.push(color.r, color.g, color.b);
+    data.flow.push(flow);
+  }
+  data.along.push(0, 0, 1, 1);
+  data.indices.push(base, base + 1, base + 2, base, base + 2, base + 3);
+}
+
+function geometryFrom(data: QuadVertexData): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute(
+    "position",
+    new THREE.Float32BufferAttribute(data.positions, 3),
+  );
+  geometry.setAttribute(
+    "color",
+    new THREE.Float32BufferAttribute(data.colors, 3),
+  );
+  geometry.setAttribute(
+    "along",
+    new THREE.Float32BufferAttribute(data.along, 1),
+  );
+  geometry.setAttribute(
+    "flow",
+    new THREE.Float32BufferAttribute(data.flow, 1),
+  );
+  geometry.setIndex(data.indices);
+  geometry.computeBoundingSphere();
+  return geometry;
+}
+
+function emptyQuadData(): QuadVertexData {
+  return { positions: [], colors: [], along: [], flow: [], indices: [] };
+}
+
+export class FluxWebGLRenderer {
+  readonly renderer: THREE.WebGLRenderer;
+  readonly scene = new THREE.Scene();
+  readonly camera: THREE.OrthographicCamera;
+
+  private readonly hullMaterial: THREE.ShaderMaterial;
+  private readonly lumenMaterial: THREE.ShaderMaterial;
+  private readonly nodeMaterial: THREE.MeshBasicMaterial;
+  private readonly fluidMaterial: THREE.MeshBasicMaterial;
+  private hullMesh: THREE.Mesh | null = null;
+  private lumenMesh: THREE.Mesh | null = null;
+  private nodeMesh: THREE.InstancedMesh | null = null;
+  private fluidMesh: THREE.InstancedMesh | null = null;
+  private frame: FluxRenderFrame | null = null;
+  private animationHandle = 0;
+  private disposed = false;
+
+  constructor(canvas: HTMLCanvasElement) {
+    const context = canvas.getContext("webgl2", {
+      alpha: true,
+      antialias: true,
+      powerPreference: "high-performance",
+    });
+    if (!context) {
+      throw new Error("WebGL2 is unavailable");
+    }
+    this.renderer = new THREE.WebGLRenderer({
+      canvas,
+      context,
+      alpha: true,
+      antialias: true,
+      powerPreference: "high-performance",
+    });
+    this.renderer.setClearColor(0x000000, 0);
+    this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2));
+    this.camera = new THREE.OrthographicCamera(0, 900, 0, 560, 0.1, 100);
+    this.camera.position.z = 20;
+    this.camera.lookAt(0, 0, 0);
+
+    this.hullMaterial = new THREE.ShaderMaterial({
+      vertexShader: VERTEX_SHADER,
+      fragmentShader: FRAGMENT_SHADER,
+      uniforms: {
+        time: { value: 0 },
+        opacity: { value: 0.44 },
+      },
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.NormalBlending,
+    });
+    this.lumenMaterial = this.hullMaterial.clone();
+    this.lumenMaterial.uniforms.opacity.value = 0.92;
+    this.nodeMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.96,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
+    this.fluidMaterial = new THREE.MeshBasicMaterial({
+      color: 0xffffff,
+      transparent: true,
+      opacity: 0.88,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    });
+    this.animate();
+  }
+
+  update(frame: FluxRenderFrame): void {
+    this.frame = frame;
+    this.resize(frame.width, frame.height);
+    this.rebuildHulls(frame);
+    this.rebuildLumens(frame);
+    this.rebuildNodes(frame);
+  }
+
+  private resize(width: number, height: number): void {
+    const cssWidth = this.renderer.domElement.clientWidth || width;
+    const cssHeight = this.renderer.domElement.clientHeight || height;
+    this.renderer.setSize(cssWidth, cssHeight, false);
+    this.camera.left = 0;
+    this.camera.right = width;
+    this.camera.top = 0;
+    this.camera.bottom = height;
+    this.camera.updateProjectionMatrix();
+  }
+
+  private updateQuadMesh(
+    current: THREE.Mesh | null,
+    data: QuadVertexData,
+    material: THREE.Material,
+  ): THREE.Mesh {
+    const position = current?.geometry.getAttribute("position");
+    if (
+      current
+      && position
+      && position.count === data.positions.length / 3
+    ) {
+      (position.array as Float32Array).set(data.positions);
+      (current.geometry.getAttribute("color").array as Float32Array).set(data.colors);
+      (current.geometry.getAttribute("along").array as Float32Array).set(data.along);
+      (current.geometry.getAttribute("flow").array as Float32Array).set(data.flow);
+      position.needsUpdate = true;
+      current.geometry.getAttribute("color").needsUpdate = true;
+      current.geometry.getAttribute("along").needsUpdate = true;
+      current.geometry.getAttribute("flow").needsUpdate = true;
+      current.geometry.computeBoundingSphere();
+      return current;
+    }
+    if (current) {
+      this.scene.remove(current);
+      current.geometry.dispose();
+    }
+    const mesh = new THREE.Mesh(geometryFrom(data), material);
+    mesh.frustumCulled = false;
+    this.scene.add(mesh);
+    return mesh;
+  }
+
+  private rebuildHulls(frame: FluxRenderFrame): void {
+    const lookup = new Map(frame.nodes.map((node) => [node.id, node]));
+    const data = emptyQuadData();
+    for (const link of frame.links) {
+      const source = resolveNode(link.source, lookup);
+      const target = resolveNode(link.target, lookup);
+      if (!source || !target) continue;
+      const influence = link.influence ?? {};
+      const count = Math.max(1, Number(influence.count) || 1);
+      const maturity = Math.max(0, Math.min(1, Number(influence.maturity) || 0));
+      const quality = Math.max(0, Math.min(1, Number(influence.avg) || 0));
+      const width = 2.6 + Math.sqrt(count) * 1.6 + maturity * 2.4;
+      const color = new THREE.Color().setHSL(quality * 0.32, 0.72, 0.42);
+      addQuad(
+        data,
+        source.x, source.y, target.x, target.y,
+        width, 0, color, Number(influence.flow) || 0, 0,
+      );
+    }
+    this.hullMesh = this.updateQuadMesh(
+      this.hullMesh,
+      data,
+      this.hullMaterial,
+    );
+  }
+
+  private rebuildLumens(frame: FluxRenderFrame): void {
+    const lookup = new Map(frame.nodes.map((node) => [node.id, node]));
+    const perEdge = new Map<string, Array<{
+      tube: TubeState;
+      segment: number;
+      edge: [number, number];
+    }>>();
+    for (const tube of frame.tubes) {
+      tube.edges.forEach((edge, segment) => {
+        const key = `${edge[0]}:${edge[1]}`;
+        const list = perEdge.get(key) ?? [];
+        list.push({ tube, segment, edge });
+        perEdge.set(key, list);
+      });
+    }
+
+    const data = emptyQuadData();
+    for (const entries of perEdge.values()) {
+      const laneSpacing = Math.min(
+        1.7,
+        12 / Math.max(1, entries.length - 1),
+      );
+      entries.forEach(({ tube, segment, edge }, lane) => {
+        const source = lookup.get(edge[0]);
+        const target = lookup.get(edge[1]);
+        if (!source || !target) return;
+        const laneOffset = (
+          lane - (entries.length - 1) / 2
+        ) * laneSpacing;
+        const solvent = Number(tube.solvent[segment]) || 0;
+        const solubles = tube.solubles[segment] ?? {};
+        const pressure = Number(tube.pressures[segment]) || 0;
+        const amount = solvent + Object.values(solubles).reduce(
+          (sum, value) => sum + Number(value || 0), 0,
+        );
+        const flow = (tube.direction === "forward" ? 1 : -1)
+          * (0.25 + Math.min(4, pressure + amount));
+        addQuad(
+          data,
+          source.x, source.y, target.x, target.y,
+          Math.min(
+            0.58 + Math.min(1.4, Math.sqrt(Math.max(0, amount)) * 0.32),
+            Math.max(0.12, laneSpacing * 0.38),
+          ),
+          laneOffset,
+          dominantFluid(solvent, solubles),
+          flow,
+          2,
+        );
+      });
+    }
+    this.lumenMesh = this.updateQuadMesh(
+      this.lumenMesh,
+      data,
+      this.lumenMaterial,
+    );
+  }
+
+  private rebuildNodes(frame: FluxRenderFrame): void {
+    const count = frame.nodes.length;
+    if (!this.nodeMesh || this.nodeMesh.count !== count) {
+      if (this.nodeMesh) {
+        this.scene.remove(this.nodeMesh);
+        this.nodeMesh.geometry.dispose();
+      }
+      if (this.fluidMesh) {
+        this.scene.remove(this.fluidMesh);
+        this.fluidMesh.geometry.dispose();
+      }
+      const geometry = new THREE.CircleGeometry(1, 24);
+      this.nodeMesh = new THREE.InstancedMesh(
+        geometry, this.nodeMaterial, count,
+      );
+      this.fluidMesh = new THREE.InstancedMesh(
+        geometry.clone(), this.fluidMaterial, count,
+      );
+      this.nodeMesh.frustumCulled = false;
+      this.fluidMesh.frustumCulled = false;
+      this.scene.add(this.nodeMesh, this.fluidMesh);
+    }
+    const maxVolume = Math.max(
+      1e-9,
+      ...frame.nodes.map((node) => Number(node.data.volume) || 0),
+    );
+    const nodeMesh = this.nodeMesh;
+    const fluidMesh = this.fluidMesh;
+    if (!nodeMesh || !fluidMesh) return;
+    const matrix = new THREE.Matrix4();
+    frame.nodes.forEach((node, index) => {
+      matrix.makeTranslation(node.x, node.y, 4);
+      matrix.scale(new THREE.Vector3(node.r, node.r, 1));
+      nodeMesh.setMatrixAt(index, matrix);
+      nodeMesh.setColorAt(index, nodeColor(node));
+
+      const volume = Math.max(0, Number(node.data.volume) || 0);
+      const fluidScale = node.r * Math.min(0.9, Math.sqrt(volume / maxVolume));
+      matrix.makeTranslation(node.x, node.y, 5);
+      matrix.scale(new THREE.Vector3(fluidScale, fluidScale, 1));
+      fluidMesh.setMatrixAt(index, matrix);
+      fluidMesh.setColorAt(
+        index,
+        dominantFluid(
+          Number(node.data.solvent) || 0,
+          node.data.solubles ?? {},
+        ),
+      );
+    });
+    nodeMesh.instanceMatrix.needsUpdate = true;
+    fluidMesh.instanceMatrix.needsUpdate = true;
+    if (nodeMesh.instanceColor) nodeMesh.instanceColor.needsUpdate = true;
+    if (fluidMesh.instanceColor) fluidMesh.instanceColor.needsUpdate = true;
+  }
+
+  private animate = (): void => {
+    if (this.disposed) return;
+    const elapsed = performance.now() / 1000;
+    this.hullMaterial.uniforms.time.value = elapsed;
+    this.lumenMaterial.uniforms.time.value = elapsed;
+    this.renderer.render(this.scene, this.camera);
+    this.animationHandle = requestAnimationFrame(this.animate);
+  };
+
+  dispose(): void {
+    this.disposed = true;
+    cancelAnimationFrame(this.animationHandle);
+    this.hullMesh?.geometry.dispose();
+    this.lumenMesh?.geometry.dispose();
+    this.nodeMesh?.geometry.dispose();
+    this.fluidMesh?.geometry.dispose();
+    this.hullMaterial.dispose();
+    this.lumenMaterial.dispose();
+    this.nodeMaterial.dispose();
+    this.fluidMaterial.dispose();
+    this.renderer.dispose();
+  }
+}

--- a/speaktome/flux_radar/tests/hypersphere_projection.test.mjs
+++ b/speaktome/flux_radar/tests/hypersphere_projection.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import {
+  HypersphereProjector,
+  NDForceAssembly,
+  hypersphericalToCartesian,
+} from "../webgl/webgl_renderer.js";
+
+const close = (left, right, tolerance = 1e-9) => {
+  assert.ok(Math.abs(left - right) <= tolerance, `${left} != ${right}`);
+};
+const norm = (vector) => Math.hypot(...vector);
+
+const pole = hypersphericalToCartesian([Math.PI / 2, Math.PI / 2]);
+close(pole[0], 0);
+close(pole[1], 0);
+close(pole[2], 1);
+
+const projector = new HypersphereProjector("projection-test");
+const main = {
+  id: 1,
+  data: {
+    direction: "forward",
+    level: 2,
+    pressure: 1.25,
+    volume: 2,
+    solvent: 1.5,
+    solubles: { sodium: 0.25 },
+    local_evidence: 0.4,
+    path_mean: 0.3,
+    latent_coordinates: [0.2, -0.5, 0.7, 0.1],
+  },
+};
+const cousin = {
+  id: 2,
+  data: {
+    ...main.data,
+    network_root: 42,
+    direction: "backward",
+    hyperspherical_angles: [Math.PI / 3, Math.PI / 4, Math.PI / 6],
+    latent_coordinates: undefined,
+  },
+};
+
+const first = projector.observe([main], 900, 560);
+const repeated = projector.observe([main], 900, 560);
+assert.deepEqual(first, repeated);
+assert.equal(first.nodes[0].latent.length, first.dimensions.length);
+close(norm(first.nodes[0].unit), 1);
+close(norm(first.nodes[0].shell), 1);
+assert.ok(Number.isFinite(first.nodes[0].screen.x));
+assert.ok(first.nodes[0].confidence >= 0 && first.nodes[0].confidence <= 1);
+
+const expanded = projector.observe([main, cousin], 900, 560);
+assert.equal(Object.keys(expanded.networkCaps).length, 2);
+for (const label of first.dimensions) {
+  const before = first.dimensions.indexOf(label);
+  const after = expanded.dimensions.indexOf(label);
+  assert.ok(after >= 0, `missing stable dimension ${label}`);
+  for (let row = 0; row < 3; row += 1) {
+    close(first.projection[row][before], expanded.projection[row][after]);
+  }
+}
+for (const node of expanded.nodes) close(norm(node.shell), 1);
+
+const force = new NDForceAssembly(2, 4);
+const forceNodes = [
+  {
+    id: 10,
+    data: {
+      is_anchor: true,
+      level: 0,
+      pressure: 1,
+      volume: 1,
+    },
+  },
+  {
+    id: 11,
+    data: {
+      level: 1,
+      direction: "forward",
+      pressure: 1.5,
+      volume: 1,
+    },
+  },
+  {
+    id: 20,
+    data: {
+      network_root: 20,
+      is_center: true,
+      level: 0,
+      pressure: 1,
+      volume: 1,
+    },
+  },
+  {
+    id: 21,
+    data: {
+      network_root: 20,
+      level: -1,
+      direction: "backward",
+      pressure: 0.8,
+      volume: 1,
+    },
+  },
+];
+force.sync(forceNodes, [
+  { source: 10, target: 11 },
+  { source: 20, target: 21 },
+]);
+const proof = force.relax(80);
+assert.equal(proof.dimensions, 10);
+assert.equal(proof.nodes, 4);
+assert.equal(proof.edges, 2);
+assert.ok(Number.isFinite(proof.residual));
+assert.ok(Number.isFinite(proof.potentialEnergy));
+assert.deepEqual(force.coordinates(10), new Array(10).fill(0));
+assert.deepEqual(force.coordinates(20), new Array(10).fill(0));
+for (const id of [11, 21]) {
+  assert.equal(force.coordinates(id).length, 10);
+  assert.ok(force.coordinates(id).every(Number.isFinite));
+}
+const forceSnapshot = force.snapshot();
+assert.deepEqual(forceSnapshot.networks, ["main", "net:20"]);
+assert.equal(Object.keys(force.habitatProximity()).length, 2);
+const mechanicalObservation = projector.observe(
+  forceNodes.map((node) => ({
+    ...node,
+    data: {
+      ...node.data,
+      latent_coordinates: force.coordinates(node.id),
+    },
+  })),
+  900,
+  560,
+  forceSnapshot.dimensions,
+);
+assert.deepEqual(mechanicalObservation.dimensions, forceSnapshot.dimensions);
+assert.equal(mechanicalObservation.nodes.find((node) => node.id === 10).confidence, 0);
+
+console.log("hypersphere projection tests passed");

--- a/speaktome/flux_radar/tsconfig.json
+++ b/speaktome/flux_radar/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["three"]
+  },
+  "include": ["src/**/*.ts", "vite.config.ts"]
+}

--- a/speaktome/flux_radar/vite.config.ts
+++ b/speaktome/flux_radar/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+import { resolve } from "node:path";
+
+export default defineConfig({
+  build: {
+    emptyOutDir: true,
+    outDir: "webgl",
+    lib: {
+      entry: resolve(__dirname, "src/webgl_renderer.ts"),
+      name: "FluxRadarWebGL",
+      formats: ["es"],
+      fileName: () => "webgl_renderer.js",
+    },
+    sourcemap: false,
+    minify: "oxc",
+  },
+});

--- a/speaktome/flux_radar/webgl/webgl_renderer.js
+++ b/speaktome/flux_radar/webgl/webgl_renderer.js
@@ -1,24 +1,24 @@
-var e = 1e3, t = 1001, n = 1002, r = 1003, i = 1006, a = 1008, o = 1009, s = 1012, c = 1014, l = 1015, u = 1016, d = 1017, f = 1018, p = 1020, m = 1023, h = 1026, g = 1027, _ = 1028, v = 1029, y = 1030, b = 1031, x = 1033, S = 2300, C = 2301, w = 2302, T = 2303, E = 2400, D = 2401, O = 2402, k = "srgb", A = "srgb-linear", ee = "linear", j = "srgb", M = 7680, te = 2e3;
-function ne(e) {
+var e = 1e3, t = 1001, n = 1002, r = 1003, i = 1006, a = 1008, o = 1009, s = 1012, c = 1014, l = 1015, u = 1016, d = 1017, f = 1018, p = 1020, m = 1023, h = 1026, g = 1027, _ = 1028, v = 1029, y = 1030, b = 1031, x = 1033, S = 2300, C = 2301, w = 2302, T = 2303, E = 2400, D = 2401, O = 2402, k = "srgb", A = "srgb-linear", j = "linear", M = "srgb", N = 7680, ee = 2e3;
+function te(e) {
 	for (let t = e.length - 1; t >= 0; --t) if (e[t] >= 65535) return !0;
 	return !1;
 }
-function N(e) {
+function P(e) {
 	return ArrayBuffer.isView(e) && !(e instanceof DataView);
 }
-function re(e) {
+function ne(e) {
 	return document.createElementNS("http://www.w3.org/1999/xhtml", e);
 }
-function ie() {
-	let e = re("canvas");
+function re() {
+	let e = ne("canvas");
 	return e.style.display = "block", e;
 }
-var P = {};
-function ae(...e) {
+var F = {};
+function ie(...e) {
 	let t = "THREE." + e.shift();
 	console.log(t, ...e);
 }
-function oe(e) {
+function ae(e) {
 	let t = e[0];
 	if (typeof t == "string" && t.startsWith("TSL:")) {
 		let t = e[1];
@@ -26,27 +26,27 @@ function oe(e) {
 	}
 	return e;
 }
-function F(...e) {
-	e = oe(e);
+function I(...e) {
+	e = ae(e);
 	let t = "THREE." + e.shift();
 	{
 		let n = e[0];
 		n && n.isStackTrace ? console.warn(n.getError(t)) : console.warn(t, ...e);
 	}
 }
-function I(...e) {
-	e = oe(e);
+function L(...e) {
+	e = ae(e);
 	let t = "THREE." + e.shift();
 	{
 		let n = e[0];
 		n && n.isStackTrace ? console.error(n.getError(t)) : console.error(t, ...e);
 	}
 }
-function L(...e) {
+function R(...e) {
 	let t = e.join(" ");
-	t in P || (P[t] = !0, F(...e));
+	t in F || (F[t] = !0, I(...e));
 }
-function se(e, t, n) {
+function oe(e, t, n) {
 	return new Promise(function(r, i) {
 		function a() {
 			switch (e.clientWaitSync(t, e.SYNC_FLUSH_COMMANDS_BIT, 0)) {
@@ -62,7 +62,7 @@ function se(e, t, n) {
 		setTimeout(a, n);
 	});
 }
-var ce = {
+var se = {
 	0: 1,
 	2: 6,
 	4: 7,
@@ -71,7 +71,7 @@ var ce = {
 	6: 2,
 	7: 4,
 	5: 3
-}, R = class {
+}, z = class {
 	addEventListener(e, t) {
 		this._listeners === void 0 && (this._listeners = {});
 		let n = this._listeners;
@@ -101,10 +101,10 @@ var ce = {
 			e.target = null;
 		}
 	}
-}, z = /* @__PURE__ */ "00.01.02.03.04.05.06.07.08.09.0a.0b.0c.0d.0e.0f.10.11.12.13.14.15.16.17.18.19.1a.1b.1c.1d.1e.1f.20.21.22.23.24.25.26.27.28.29.2a.2b.2c.2d.2e.2f.30.31.32.33.34.35.36.37.38.39.3a.3b.3c.3d.3e.3f.40.41.42.43.44.45.46.47.48.49.4a.4b.4c.4d.4e.4f.50.51.52.53.54.55.56.57.58.59.5a.5b.5c.5d.5e.5f.60.61.62.63.64.65.66.67.68.69.6a.6b.6c.6d.6e.6f.70.71.72.73.74.75.76.77.78.79.7a.7b.7c.7d.7e.7f.80.81.82.83.84.85.86.87.88.89.8a.8b.8c.8d.8e.8f.90.91.92.93.94.95.96.97.98.99.9a.9b.9c.9d.9e.9f.a0.a1.a2.a3.a4.a5.a6.a7.a8.a9.aa.ab.ac.ad.ae.af.b0.b1.b2.b3.b4.b5.b6.b7.b8.b9.ba.bb.bc.bd.be.bf.c0.c1.c2.c3.c4.c5.c6.c7.c8.c9.ca.cb.cc.cd.ce.cf.d0.d1.d2.d3.d4.d5.d6.d7.d8.d9.da.db.dc.dd.de.df.e0.e1.e2.e3.e4.e5.e6.e7.e8.e9.ea.eb.ec.ed.ee.ef.f0.f1.f2.f3.f4.f5.f6.f7.f8.f9.fa.fb.fc.fd.fe.ff".split("."), le = Math.PI / 180, ue = 180 / Math.PI;
+}, ce = /* @__PURE__ */ "00.01.02.03.04.05.06.07.08.09.0a.0b.0c.0d.0e.0f.10.11.12.13.14.15.16.17.18.19.1a.1b.1c.1d.1e.1f.20.21.22.23.24.25.26.27.28.29.2a.2b.2c.2d.2e.2f.30.31.32.33.34.35.36.37.38.39.3a.3b.3c.3d.3e.3f.40.41.42.43.44.45.46.47.48.49.4a.4b.4c.4d.4e.4f.50.51.52.53.54.55.56.57.58.59.5a.5b.5c.5d.5e.5f.60.61.62.63.64.65.66.67.68.69.6a.6b.6c.6d.6e.6f.70.71.72.73.74.75.76.77.78.79.7a.7b.7c.7d.7e.7f.80.81.82.83.84.85.86.87.88.89.8a.8b.8c.8d.8e.8f.90.91.92.93.94.95.96.97.98.99.9a.9b.9c.9d.9e.9f.a0.a1.a2.a3.a4.a5.a6.a7.a8.a9.aa.ab.ac.ad.ae.af.b0.b1.b2.b3.b4.b5.b6.b7.b8.b9.ba.bb.bc.bd.be.bf.c0.c1.c2.c3.c4.c5.c6.c7.c8.c9.ca.cb.cc.cd.ce.cf.d0.d1.d2.d3.d4.d5.d6.d7.d8.d9.da.db.dc.dd.de.df.e0.e1.e2.e3.e4.e5.e6.e7.e8.e9.ea.eb.ec.ed.ee.ef.f0.f1.f2.f3.f4.f5.f6.f7.f8.f9.fa.fb.fc.fd.fe.ff".split("."), le = Math.PI / 180, ue = 180 / Math.PI;
 function B() {
 	let e = Math.random() * 4294967295 | 0, t = Math.random() * 4294967295 | 0, n = Math.random() * 4294967295 | 0, r = Math.random() * 4294967295 | 0;
-	return (z[e & 255] + z[e >> 8 & 255] + z[e >> 16 & 255] + z[e >> 24 & 255] + "-" + z[t & 255] + z[t >> 8 & 255] + "-" + z[t >> 16 & 15 | 64] + z[t >> 24 & 255] + "-" + z[n & 63 | 128] + z[n >> 8 & 255] + "-" + z[n >> 16 & 255] + z[n >> 24 & 255] + z[r & 255] + z[r >> 8 & 255] + z[r >> 16 & 255] + z[r >> 24 & 255]).toLowerCase();
+	return (ce[e & 255] + ce[e >> 8 & 255] + ce[e >> 16 & 255] + ce[e >> 24 & 255] + "-" + ce[t & 255] + ce[t >> 8 & 255] + "-" + ce[t >> 16 & 15 | 64] + ce[t >> 24 & 255] + "-" + ce[n & 63 | 128] + ce[n >> 8 & 255] + "-" + ce[n >> 16 & 255] + ce[n >> 24 & 255] + ce[r & 255] + ce[r >> 8 & 255] + ce[r >> 16 & 255] + ce[r >> 24 & 255]).toLowerCase();
 }
 function V(e, t, n) {
 	return Math.max(t, Math.min(n, e));
@@ -410,7 +410,7 @@ var U = class e {
 			case "XZY":
 				this._x = d * l * u - c * f * p, this._y = c * f * u - d * l * p, this._z = c * l * p + d * f * u, this._w = c * l * u + d * f * p;
 				break;
-			default: F("Quaternion: .setFromEuler() encountered an unknown order: " + a);
+			default: I("Quaternion: .setFromEuler() encountered an unknown order: " + a);
 		}
 		return t === !0 && this._onChangeCallback(), this;
 	}
@@ -857,13 +857,13 @@ var U = class e {
 		return this.set(n * s, n * c, -n * (s * a + c * o) + a + e, -r * c, r * s, -r * (-c * a + s * o) + o + t, 0, 0, 1), this;
 	}
 	scale(e, t) {
-		return L("Matrix3: .scale() is deprecated. Use .makeScale() instead."), this.premultiply(_e.makeScale(e, t)), this;
+		return R("Matrix3: .scale() is deprecated. Use .makeScale() instead."), this.premultiply(_e.makeScale(e, t)), this;
 	}
 	rotate(e) {
-		return L("Matrix3: .rotate() is deprecated. Use .makeRotation() instead."), this.premultiply(_e.makeRotation(-e)), this;
+		return R("Matrix3: .rotate() is deprecated. Use .makeRotation() instead."), this.premultiply(_e.makeRotation(-e)), this;
 	}
 	translate(e, t) {
-		return L("Matrix3: .translate() is deprecated. Use .makeTranslation() instead."), this.premultiply(_e.makeTranslation(e, t)), this;
+		return R("Matrix3: .translate() is deprecated. Use .makeTranslation() instead."), this.premultiply(_e.makeTranslation(e, t)), this;
 	}
 	makeTranslation(e, t) {
 		return e.isVector2 ? this.set(1, 0, e.x, 0, 1, e.y, 0, 0, 1) : this.set(1, 0, e, 0, 1, t, 0, 0, 1), this;
@@ -910,7 +910,7 @@ function be() {
 			return this.spaces[e].primaries;
 		},
 		getTransfer: function(e) {
-			return e === "" ? ee : this.spaces[e].transfer;
+			return e === "" ? j : this.spaces[e].transfer;
 		},
 		getToneMappingMode: function(e) {
 			return this.spaces[e].outputColorSpaceConfig.toneMappingMode || "standard";
@@ -931,10 +931,10 @@ function be() {
 			return this.spaces[e].workingColorSpaceConfig.unpackColorSpace;
 		},
 		fromWorkingColorSpace: function(t, n) {
-			return L("ColorManagement: .fromWorkingColorSpace() has been renamed to .workingToColorSpace()."), e.workingToColorSpace(t, n);
+			return R("ColorManagement: .fromWorkingColorSpace() has been renamed to .workingToColorSpace()."), e.workingToColorSpace(t, n);
 		},
 		toWorkingColorSpace: function(t, n) {
-			return L("ColorManagement: .toWorkingColorSpace() has been renamed to .colorSpaceToWorking()."), e.colorSpaceToWorking(t, n);
+			return R("ColorManagement: .toWorkingColorSpace() has been renamed to .colorSpaceToWorking()."), e.colorSpaceToWorking(t, n);
 		}
 	}, t = [
 		.64,
@@ -952,7 +952,7 @@ function be() {
 		[A]: {
 			primaries: t,
 			whitePoint: r,
-			transfer: ee,
+			transfer: j,
 			toXYZ: ve,
 			fromXYZ: ye,
 			luminanceCoefficients: n,
@@ -962,7 +962,7 @@ function be() {
 		[k]: {
 			primaries: t,
 			whitePoint: r,
-			transfer: j,
+			transfer: M,
 			toXYZ: ve,
 			fromXYZ: ye,
 			luminanceCoefficients: n,
@@ -983,7 +983,7 @@ var Ce, we = class {
 		let n;
 		if (e instanceof HTMLCanvasElement) n = e;
 		else {
-			Ce === void 0 && (Ce = re("canvas")), Ce.width = e.width, Ce.height = e.height;
+			Ce === void 0 && (Ce = ne("canvas")), Ce.width = e.width, Ce.height = e.height;
 			let t = Ce.getContext("2d");
 			e instanceof ImageData ? t.putImageData(e, 0, 0) : t.drawImage(e, 0, 0, e.width, e.height), n = Ce;
 		}
@@ -991,7 +991,7 @@ var Ce, we = class {
 	}
 	static sRGBToLinear(e) {
 		if (typeof HTMLImageElement < "u" && e instanceof HTMLImageElement || typeof HTMLCanvasElement < "u" && e instanceof HTMLCanvasElement || typeof ImageBitmap < "u" && e instanceof ImageBitmap) {
-			let t = re("canvas");
+			let t = ne("canvas");
 			t.width = e.width, t.height = e.height;
 			let n = t.getContext("2d");
 			n.drawImage(e, 0, 0, e.width, e.height);
@@ -1006,7 +1006,7 @@ var Ce, we = class {
 				width: e.width,
 				height: e.height
 			};
-		} else return F("ImageUtils.sRGBToLinear(): Unsupported image type. No color space conversion applied."), e;
+		} else return I("ImageUtils.sRGBToLinear(): Unsupported image type. No color space conversion applied."), e;
 	}
 }, Te = 0, Ee = class {
 	constructor(e = null) {
@@ -1043,9 +1043,9 @@ function De(e) {
 		width: e.width,
 		height: e.height,
 		type: e.data.constructor.name
-	} : (F("Texture: Unable to serialize Texture."), {});
+	} : (I("Texture: Unable to serialize Texture."), {});
 }
-var Oe = 0, ke = /*@__PURE__*/ new W(), Ae = class r extends R {
+var Oe = 0, ke = /*@__PURE__*/ new W(), Ae = class r extends z {
 	constructor(e = r.DEFAULT_IMAGE, n = r.DEFAULT_MAPPING, s = t, c = t, l = i, u = a, d = m, f = o, p = r.DEFAULT_ANISOTROPY, h = "") {
 		super(), this.isTexture = !0, Object.defineProperty(this, "id", { value: Oe++ }), this.uuid = B(), this.name = "", this.source = new Ee(e), this.mipmaps = [], this.mapping = n, this.channel = 0, this.wrapS = s, this.wrapT = c, this.magFilter = l, this.minFilter = u, this.anisotropy = p, this.format = d, this.internalFormat = null, this.type = f, this.offset = new U(0, 0), this.repeat = new U(1, 1), this.center = new U(0, 0), this.rotation = 0, this.matrixAutoUpdate = !0, this.matrix = new G(), this.generateMipmaps = !0, this.premultiplyAlpha = !1, this.flipY = !0, this.unpackAlignment = 4, this.colorSpace = h, this.userData = {}, this.updateRanges = [], this.version = 0, this.onUpdate = null, this.renderTarget = null, this.isRenderTargetTexture = !1, this.isArrayTexture = !!(e && e.depth && e.depth > 1), this.pmremVersion = 0, this.normalized = !1;
 	}
@@ -1086,12 +1086,12 @@ var Oe = 0, ke = /*@__PURE__*/ new W(), Ae = class r extends R {
 		for (let t in e) {
 			let n = e[t];
 			if (n === void 0) {
-				F(`Texture.setValues(): parameter '${t}' has value of undefined.`);
+				I(`Texture.setValues(): parameter '${t}' has value of undefined.`);
 				continue;
 			}
 			let r = this[t];
 			if (r === void 0) {
-				F(`Texture.setValues(): property '${t}' does not exist.`);
+				I(`Texture.setValues(): property '${t}' does not exist.`);
 				continue;
 			}
 			r && n && r.isVector2 && n.isVector2 || r && n && r.isVector3 && n.isVector3 || r && n && r.isMatrix3 && n.isMatrix3 ? r.copy(n) : this[t] = n;
@@ -1368,7 +1368,7 @@ var je = class e {
 	*[Symbol.iterator]() {
 		yield this.x, yield this.y, yield this.z, yield this.w;
 	}
-}, q = class extends R {
+}, q = class extends z {
 	constructor(e = 1, t = 1, n = {}) {
 		super(), n = Object.assign({
 			generateMipmaps: !1,
@@ -1560,8 +1560,8 @@ var je = class e {
 		return this.multiplyMatrices(e, this);
 	}
 	multiplyMatrices(e, t) {
-		let n = e.elements, r = t.elements, i = this.elements, a = n[0], o = n[4], s = n[8], c = n[12], l = n[1], u = n[5], d = n[9], f = n[13], p = n[2], m = n[6], h = n[10], g = n[14], _ = n[3], v = n[7], y = n[11], b = n[15], x = r[0], S = r[4], C = r[8], w = r[12], T = r[1], E = r[5], D = r[9], O = r[13], k = r[2], A = r[6], ee = r[10], j = r[14], M = r[3], te = r[7], ne = r[11], N = r[15];
-		return i[0] = a * x + o * T + s * k + c * M, i[4] = a * S + o * E + s * A + c * te, i[8] = a * C + o * D + s * ee + c * ne, i[12] = a * w + o * O + s * j + c * N, i[1] = l * x + u * T + d * k + f * M, i[5] = l * S + u * E + d * A + f * te, i[9] = l * C + u * D + d * ee + f * ne, i[13] = l * w + u * O + d * j + f * N, i[2] = p * x + m * T + h * k + g * M, i[6] = p * S + m * E + h * A + g * te, i[10] = p * C + m * D + h * ee + g * ne, i[14] = p * w + m * O + h * j + g * N, i[3] = _ * x + v * T + y * k + b * M, i[7] = _ * S + v * E + y * A + b * te, i[11] = _ * C + v * D + y * ee + b * ne, i[15] = _ * w + v * O + y * j + b * N, this;
+		let n = e.elements, r = t.elements, i = this.elements, a = n[0], o = n[4], s = n[8], c = n[12], l = n[1], u = n[5], d = n[9], f = n[13], p = n[2], m = n[6], h = n[10], g = n[14], _ = n[3], v = n[7], y = n[11], b = n[15], x = r[0], S = r[4], C = r[8], w = r[12], T = r[1], E = r[5], D = r[9], O = r[13], k = r[2], A = r[6], j = r[10], M = r[14], N = r[3], ee = r[7], te = r[11], P = r[15];
+		return i[0] = a * x + o * T + s * k + c * N, i[4] = a * S + o * E + s * A + c * ee, i[8] = a * C + o * D + s * j + c * te, i[12] = a * w + o * O + s * M + c * P, i[1] = l * x + u * T + d * k + f * N, i[5] = l * S + u * E + d * A + f * ee, i[9] = l * C + u * D + d * j + f * te, i[13] = l * w + u * O + d * M + f * P, i[2] = p * x + m * T + h * k + g * N, i[6] = p * S + m * E + h * A + g * ee, i[10] = p * C + m * D + h * j + g * te, i[14] = p * w + m * O + h * M + g * P, i[3] = _ * x + v * T + y * k + b * N, i[7] = _ * S + v * E + y * A + b * ee, i[11] = _ * C + v * D + y * j + b * te, i[15] = _ * w + v * O + y * M + b * P, this;
 	}
 	multiplyScalar(e) {
 		let t = this.elements;
@@ -1636,7 +1636,7 @@ var je = class e {
 		let c = 1 / a, l = 1 / o, u = 1 / s;
 		return J.elements[0] *= c, J.elements[1] *= c, J.elements[2] *= c, J.elements[4] *= l, J.elements[5] *= l, J.elements[6] *= l, J.elements[8] *= u, J.elements[9] *= u, J.elements[10] *= u, t.setFromRotationMatrix(J), n.x = a, n.y = o, n.z = s, this;
 	}
-	makePerspective(e, t, n, r, i, a, o = te, s = !1) {
+	makePerspective(e, t, n, r, i, a, o = ee, s = !1) {
 		let c = this.elements, l = 2 * i / (t - e), u = 2 * i / (n - r), d = (t + e) / (t - e), f = (n + r) / (n - r), p, m;
 		if (s) p = i / (a - i), m = a * i / (a - i);
 		else if (o === 2e3) p = -(a + i) / (a - i), m = -2 * a * i / (a - i);
@@ -1644,7 +1644,7 @@ var je = class e {
 		else throw Error("THREE.Matrix4.makePerspective(): Invalid coordinate system: " + o);
 		return c[0] = l, c[4] = 0, c[8] = d, c[12] = 0, c[1] = 0, c[5] = u, c[9] = f, c[13] = 0, c[2] = 0, c[6] = 0, c[10] = p, c[14] = m, c[3] = 0, c[7] = 0, c[11] = -1, c[15] = 0, this;
 	}
-	makeOrthographic(e, t, n, r, i, a, o = te, s = !1) {
+	makeOrthographic(e, t, n, r, i, a, o = ee, s = !1) {
 		let c = this.elements, l = 2 / (t - e), u = 2 / (n - r), d = -(t + e) / (t - e), f = -(n + r) / (n - r), p, m;
 		if (s) p = 1 / (a - i), m = a / (a - i);
 		else if (o === 2e3) p = -2 / (a - i), m = -(a + i) / (a - i);
@@ -1723,7 +1723,7 @@ var je = class e {
 			case "XZY":
 				this._z = Math.asin(-V(a, -1, 1)), Math.abs(a) < .9999999 ? (this._x = Math.atan2(d, c), this._y = Math.atan2(o, i)) : (this._x = Math.atan2(-l, f), this._y = 0);
 				break;
-			default: F("Euler: .setFromRotationMatrix() encountered an unknown order: " + t);
+			default: I("Euler: .setFromRotationMatrix() encountered an unknown order: " + t);
 		}
 		return this._order = t, n === !0 && this._onChangeCallback(), this;
 	}
@@ -1788,7 +1788,7 @@ var Ue = class {
 }, it = {
 	type: "childremoved",
 	child: null
-}, at = class e extends R {
+}, at = class e extends z {
 	constructor() {
 		super(), this.isObject3D = !0, Object.defineProperty(this, "id", { value: We++ }), this.uuid = B(), this.name = "", this.type = "Object3D", this.parent = null, this.children = [], this.up = e.DEFAULT_UP.clone();
 		let t = new W(), n = new He(), r = new me(), i = new W(1, 1, 1);
@@ -1888,7 +1888,7 @@ var Ue = class {
 			for (let e = 0; e < arguments.length; e++) this.add(arguments[e]);
 			return this;
 		}
-		return e === this ? (I("Object3D.add: object can't be added as a child of itself.", e), this) : (e && e.isObject3D ? (e.removeFromParent(), e.parent = this, this.children.push(e), e.dispatchEvent(tt), rt.child = e, this.dispatchEvent(rt), rt.child = null) : I("Object3D.add: object not an instance of THREE.Object3D.", e), this);
+		return e === this ? (L("Object3D.add: object can't be added as a child of itself.", e), this) : (e && e.isObject3D ? (e.removeFromParent(), e.parent = this, this.children.push(e), e.dispatchEvent(tt), rt.child = e, this.dispatchEvent(rt), rt.child = null) : L("Object3D.add: object not an instance of THREE.Object3D.", e), this);
 	}
 	remove(e) {
 		if (arguments.length > 1) {
@@ -2320,7 +2320,7 @@ var Z = class {
 	}
 	setStyle(e, t = k) {
 		function n(t) {
-			t !== void 0 && parseFloat(t) < 1 && F("Color: Alpha component of " + e + " will be ignored.");
+			t !== void 0 && parseFloat(t) < 1 && I("Color: Alpha component of " + e + " will be ignored.");
 		}
 		let r;
 		if (r = /^(\w+)\(([^\)]*)\)/.exec(e)) {
@@ -2335,19 +2335,19 @@ var Z = class {
 				case "hsla":
 					if (i = /^\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\%\s*,\s*(\d*\.?\d+)\%\s*(?:,\s*(\d*\.?\d+)\s*)?$/.exec(o)) return n(i[4]), this.setHSL(parseFloat(i[1]) / 360, parseFloat(i[2]) / 100, parseFloat(i[3]) / 100, t);
 					break;
-				default: F("Color: Unknown color model " + e);
+				default: I("Color: Unknown color model " + e);
 			}
 		} else if (r = /^\#([A-Fa-f\d]+)$/.exec(e)) {
 			let n = r[1], i = n.length;
 			if (i === 3) return this.setRGB(parseInt(n.charAt(0), 16) / 15, parseInt(n.charAt(1), 16) / 15, parseInt(n.charAt(2), 16) / 15, t);
 			if (i === 6) return this.setHex(parseInt(n, 16), t);
-			F("Color: Invalid hex color " + e);
+			I("Color: Invalid hex color " + e);
 		} else if (e && e.length > 0) return this.setColorName(e, t);
 		return this;
 	}
 	setColorName(e, t = k) {
 		let n = lt[e.toLowerCase()];
-		return n === void 0 ? F("Color: Unknown color " + e) : this.setHex(n, t), this;
+		return n === void 0 ? I("Color: Unknown color " + e) : this.setHex(n, t), this;
 	}
 	clone() {
 		return new this.constructor(this.r, this.g, this.b);
@@ -2751,7 +2751,7 @@ function Ut(e, t, n, r, i) {
 	}
 	return !0;
 }
-var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class extends R {
+var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class extends z {
 	constructor(e, t, n = !1) {
 		if (super(), Array.isArray(e)) throw TypeError("THREE.BufferAttribute: array should be a Typed Array.");
 		this.isBufferAttribute = !0, Object.defineProperty(this, "id", { value: Kt++ }), this.name = "", this.array = e, this.itemSize = t, this.count = e === void 0 ? 0 : e.length / t, this.normalized = n, this.usage = 35044, this.updateRanges = [], this.gpuType = l, this.version = 0;
@@ -2957,7 +2957,7 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 	fromJSON(e) {
 		return this.radius = e.radius, this.center.fromArray(e.center), this;
 	}
-}, tn = 0, nn = /*@__PURE__*/ new Fe(), rn = /*@__PURE__*/ new at(), an = /*@__PURE__*/ new W(), on = /*@__PURE__*/ new kt(), sn = /*@__PURE__*/ new kt(), cn = /*@__PURE__*/ new W(), ln = class e extends R {
+}, tn = 0, nn = /*@__PURE__*/ new Fe(), rn = /*@__PURE__*/ new at(), an = /*@__PURE__*/ new W(), on = /*@__PURE__*/ new kt(), sn = /*@__PURE__*/ new kt(), cn = /*@__PURE__*/ new W(), ln = class e extends z {
 	constructor() {
 		super(), this.isBufferGeometry = !0, Object.defineProperty(this, "id", { value: tn++ }), this.uuid = B(), this.name = "", this.type = "BufferGeometry", this.index = null, this.indirect = null, this.indirectOffset = 0, this.attributes = {}, this.morphAttributes = {}, this.morphTargetsRelative = !1, this.groups = [], this.boundingBox = null, this.boundingSphere = null, this.drawRange = {
 			start: 0,
@@ -2968,7 +2968,7 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 		return this.index;
 	}
 	setIndex(e) {
-		return Array.isArray(e) ? this.index = new (ne(e) ? Yt : Jt)(e, 1) : this.index = e, this;
+		return Array.isArray(e) ? this.index = new (te(e) ? Yt : Jt)(e, 1) : this.index = e, this;
 	}
 	setIndirect(e, t = 0) {
 		return this.indirect = e, this.indirectOffset = t, this;
@@ -3051,7 +3051,7 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 				let n = e[r];
 				t.setXYZ(r, n.x, n.y, n.z || 0);
 			}
-			e.length > t.count && F("BufferGeometry: Buffer size too small for points data. Use .dispose() and create a new geometry."), t.needsUpdate = !0;
+			e.length > t.count && I("BufferGeometry: Buffer size too small for points data. Use .dispose() and create a new geometry."), t.needsUpdate = !0;
 		}
 		return this;
 	}
@@ -3059,7 +3059,7 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 		this.boundingBox === null && (this.boundingBox = new kt());
 		let e = this.attributes.position, t = this.morphAttributes.position;
 		if (e && e.isGLBufferAttribute) {
-			I("BufferGeometry.computeBoundingBox(): GLBufferAttribute requires a manual bounding box.", this), this.boundingBox.set(new W(-Infinity, -Infinity, -Infinity), new W(Infinity, Infinity, Infinity));
+			L("BufferGeometry.computeBoundingBox(): GLBufferAttribute requires a manual bounding box.", this), this.boundingBox.set(new W(-Infinity, -Infinity, -Infinity), new W(Infinity, Infinity, Infinity));
 			return;
 		}
 		if (e !== void 0) {
@@ -3068,13 +3068,13 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 				on.setFromBufferAttribute(n), this.morphTargetsRelative ? (cn.addVectors(this.boundingBox.min, on.min), this.boundingBox.expandByPoint(cn), cn.addVectors(this.boundingBox.max, on.max), this.boundingBox.expandByPoint(cn)) : (this.boundingBox.expandByPoint(on.min), this.boundingBox.expandByPoint(on.max));
 			}
 		} else this.boundingBox.makeEmpty();
-		(isNaN(this.boundingBox.min.x) || isNaN(this.boundingBox.min.y) || isNaN(this.boundingBox.min.z)) && I("BufferGeometry.computeBoundingBox(): Computed min/max have NaN values. The \"position\" attribute is likely to have NaN values.", this);
+		(isNaN(this.boundingBox.min.x) || isNaN(this.boundingBox.min.y) || isNaN(this.boundingBox.min.z)) && L("BufferGeometry.computeBoundingBox(): Computed min/max have NaN values. The \"position\" attribute is likely to have NaN values.", this);
 	}
 	computeBoundingSphere() {
 		this.boundingSphere === null && (this.boundingSphere = new en());
 		let e = this.attributes.position, t = this.morphAttributes.position;
 		if (e && e.isGLBufferAttribute) {
-			I("BufferGeometry.computeBoundingSphere(): GLBufferAttribute requires a manual bounding sphere.", this), this.boundingSphere.set(new W(), Infinity);
+			L("BufferGeometry.computeBoundingSphere(): GLBufferAttribute requires a manual bounding sphere.", this), this.boundingSphere.set(new W(), Infinity);
 			return;
 		}
 		if (e) {
@@ -3090,13 +3090,13 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 				let a = t[i], o = this.morphTargetsRelative;
 				for (let t = 0, i = a.count; t < i; t++) cn.fromBufferAttribute(a, t), o && (an.fromBufferAttribute(e, t), cn.add(an)), r = Math.max(r, n.distanceToSquared(cn));
 			}
-			this.boundingSphere.radius = Math.sqrt(r), isNaN(this.boundingSphere.radius) && I("BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The \"position\" attribute is likely to have NaN values.", this);
+			this.boundingSphere.radius = Math.sqrt(r), isNaN(this.boundingSphere.radius) && L("BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The \"position\" attribute is likely to have NaN values.", this);
 		}
 	}
 	computeTangents() {
 		let e = this.index, t = this.attributes;
 		if (e === null || t.position === void 0 || t.normal === void 0 || t.uv === void 0) {
-			I("BufferGeometry: .computeTangents() failed. Missing required attributes (index, position, normal or uv)");
+			L("BufferGeometry: .computeTangents() failed. Missing required attributes (index, position, normal or uv)");
 			return;
 		}
 		let n = t.position, r = t.normal, i = t.uv, a = this.getAttribute("tangent");
@@ -3160,7 +3160,7 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 			}
 			return new qt(a, r, i);
 		}
-		if (this.index === null) return F("BufferGeometry.toNonIndexed(): BufferGeometry is already non-indexed."), this;
+		if (this.index === null) return I("BufferGeometry.toNonIndexed(): BufferGeometry is already non-indexed."), this;
 		let n = new e(), r = this.index.array, i = this.attributes;
 		for (let e in i) {
 			let a = i[e], o = t(a, r);
@@ -3254,9 +3254,9 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 	dispose() {
 		this.dispatchEvent({ type: "dispose" });
 	}
-}, un = 0, dn = class extends R {
+}, un = 0, dn = class extends z {
 	constructor() {
-		super(), this.isMaterial = !0, Object.defineProperty(this, "id", { value: un++ }), this.uuid = B(), this.name = "", this.type = "Material", this.blending = 1, this.side = 0, this.vertexColors = !1, this.opacity = 1, this.transparent = !1, this.alphaHash = !1, this.blendSrc = 204, this.blendDst = 205, this.blendEquation = 100, this.blendSrcAlpha = null, this.blendDstAlpha = null, this.blendEquationAlpha = null, this.blendColor = new Z(0, 0, 0), this.blendAlpha = 0, this.depthFunc = 3, this.depthTest = !0, this.depthWrite = !0, this.stencilWriteMask = 255, this.stencilFunc = 519, this.stencilRef = 0, this.stencilFuncMask = 255, this.stencilFail = M, this.stencilZFail = M, this.stencilZPass = M, this.stencilWrite = !1, this.clippingPlanes = null, this.clipIntersection = !1, this.clipShadows = !1, this.shadowSide = null, this.colorWrite = !0, this.precision = null, this.polygonOffset = !1, this.polygonOffsetFactor = 0, this.polygonOffsetUnits = 0, this.dithering = !1, this.alphaToCoverage = !1, this.premultipliedAlpha = !1, this.forceSinglePass = !1, this.allowOverride = !0, this.visible = !0, this.toneMapped = !0, this.userData = {}, this.version = 0, this._alphaTest = 0;
+		super(), this.isMaterial = !0, Object.defineProperty(this, "id", { value: un++ }), this.uuid = B(), this.name = "", this.type = "Material", this.blending = 1, this.side = 0, this.vertexColors = !1, this.opacity = 1, this.transparent = !1, this.alphaHash = !1, this.blendSrc = 204, this.blendDst = 205, this.blendEquation = 100, this.blendSrcAlpha = null, this.blendDstAlpha = null, this.blendEquationAlpha = null, this.blendColor = new Z(0, 0, 0), this.blendAlpha = 0, this.depthFunc = 3, this.depthTest = !0, this.depthWrite = !0, this.stencilWriteMask = 255, this.stencilFunc = 519, this.stencilRef = 0, this.stencilFuncMask = 255, this.stencilFail = N, this.stencilZFail = N, this.stencilZPass = N, this.stencilWrite = !1, this.clippingPlanes = null, this.clipIntersection = !1, this.clipShadows = !1, this.shadowSide = null, this.colorWrite = !0, this.precision = null, this.polygonOffset = !1, this.polygonOffsetFactor = 0, this.polygonOffsetUnits = 0, this.dithering = !1, this.alphaToCoverage = !1, this.premultipliedAlpha = !1, this.forceSinglePass = !1, this.allowOverride = !0, this.visible = !0, this.toneMapped = !0, this.userData = {}, this.version = 0, this._alphaTest = 0;
 	}
 	get alphaTest() {
 		return this._alphaTest;
@@ -3273,12 +3273,12 @@ var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class e
 		if (e !== void 0) for (let t in e) {
 			let n = e[t];
 			if (n === void 0) {
-				F(`Material: parameter '${t}' has value of undefined.`);
+				I(`Material: parameter '${t}' has value of undefined.`);
 				continue;
 			}
 			let r = this[t];
 			if (r === void 0) {
-				F(`Material: '${t}' is not a property of THREE.${this.type}.`);
+				I(`Material: '${t}' is not a property of THREE.${this.type}.`);
 				continue;
 			}
 			r && r.isColor ? r.set(n) : r && r.isVector2 && n && n.isVector2 || r && r.isEuler && n && n.isEuler || r && r.isVector3 && n && n.isVector3 ? r.copy(n) : this[t] = n;
@@ -3704,7 +3704,7 @@ var Fn = class extends Ae {
 		for (let n = 0; n < 6; n++) t[n].copy(e.planes[n]);
 		return this;
 	}
-	setFromProjectionMatrix(e, t = te, n = !1) {
+	setFromProjectionMatrix(e, t = ee, n = !1) {
 		let r = this.planes, i = e.elements, a = i[0], o = i[1], s = i[2], c = i[3], l = i[4], u = i[5], d = i[6], f = i[7], p = i[8], m = i[9], h = i[10], g = i[11], _ = i[12], v = i[13], y = i[14], b = i[15];
 		if (r[0].setComponents(c - a, f - l, g - p, b - _).normalize(), r[1].setComponents(c + a, f + l, g + p, b + _).normalize(), r[2].setComponents(c + o, f + u, g + m, b + v).normalize(), r[3].setComponents(c - o, f - u, g - m, b - v).normalize(), n) r[4].setComponents(s, d, h, y).normalize(), r[5].setComponents(c - s, f - d, g - h, b - y).normalize();
 		else if (r[4].setComponents(c - s, f - d, g - h, b - y).normalize(), t === 2e3) r[5].setComponents(c + s, f + d, g + h, b + y).normalize();
@@ -3890,7 +3890,7 @@ function or(e) {
 		t[n] = {};
 		for (let r in e[n]) {
 			let i = e[n][r];
-			if (cr(i)) i.isRenderTargetTexture ? (F("UniformsUtils: Textures of render targets cannot be cloned via cloneUniforms() or mergeUniforms()."), t[n][r] = null) : t[n][r] = i.clone();
+			if (cr(i)) i.isRenderTargetTexture ? (I("UniformsUtils: Textures of render targets cannot be cloned via cloneUniforms() or mergeUniforms()."), t[n][r] = null) : t[n][r] = i.clone();
 			else if (Array.isArray(i)) if (cr(i[0])) {
 				let e = [];
 				for (let t = 0, n = i.length; t < n; t++) e[t] = i[t].clone();
@@ -4213,7 +4213,7 @@ var yr = class {
 			let t = "unsupported interpolation for " + this.ValueTypeName + " keyframe track named " + this.name;
 			if (this.createInterpolant === void 0) if (e !== this.DefaultInterpolation) this.setInterpolation(this.DefaultInterpolation);
 			else throw Error(t);
-			return F("KeyframeTrack:", t), this;
+			return I("KeyframeTrack:", t), this;
 		}
 		return this.createInterpolant = t, this;
 	}
@@ -4255,26 +4255,26 @@ var yr = class {
 	}
 	validate() {
 		let e = !0, t = this.getValueSize();
-		t - Math.floor(t) !== 0 && (I("KeyframeTrack: Invalid value size in track.", this), e = !1);
+		t - Math.floor(t) !== 0 && (L("KeyframeTrack: Invalid value size in track.", this), e = !1);
 		let n = this.times, r = this.values, i = n.length;
-		i === 0 && (I("KeyframeTrack: Track is empty.", this), e = !1);
+		i === 0 && (L("KeyframeTrack: Track is empty.", this), e = !1);
 		let a = null;
 		for (let t = 0; t !== i; t++) {
 			let r = n[t];
 			if (typeof r == "number" && isNaN(r)) {
-				I("KeyframeTrack: Time is not a valid number.", this, t, r), e = !1;
+				L("KeyframeTrack: Time is not a valid number.", this, t, r), e = !1;
 				break;
 			}
 			if (a !== null && a > r) {
-				I("KeyframeTrack: Out of order keys.", this, t, r, a), e = !1;
+				L("KeyframeTrack: Out of order keys.", this, t, r, a), e = !1;
 				break;
 			}
 			a = r;
 		}
-		if (r !== void 0 && N(r)) for (let t = 0, n = r.length; t !== n; ++t) {
+		if (r !== void 0 && P(r)) for (let t = 0, n = r.length; t !== n; ++t) {
 			let n = r[t];
 			if (isNaN(n)) {
-				I("KeyframeTrack: Value is not a valid number.", this, t, n), e = !1;
+				L("KeyframeTrack: Value is not a valid number.", this, t, n), e = !1;
 				break;
 			}
 		}
@@ -4430,7 +4430,7 @@ var Mr = /*@__PURE__*/ new class {
 Nr.DEFAULT_MATERIAL_NAME = "__DEFAULT";
 var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ new W(), Lr = class extends at {
 	constructor() {
-		super(), this.isCamera = !0, this.type = "Camera", this.matrixWorldInverse = new Fe(), this.projectionMatrix = new Fe(), this.projectionMatrixInverse = new Fe(), this.coordinateSystem = te, this._reversedDepth = !1;
+		super(), this.isCamera = !0, this.type = "Camera", this.matrixWorldInverse = new Fe(), this.projectionMatrix = new Fe(), this.projectionMatrixInverse = new Fe(), this.coordinateSystem = ee, this._reversedDepth = !1;
 	}
 	get reversedDepth() {
 		return this._reversedDepth;
@@ -4718,7 +4718,7 @@ var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ 
 	bind() {
 		let t = this.node, n = this.parsedPath, r = n.objectName, i = n.propertyName, a = n.propertyIndex;
 		if (t || (t = e.findNode(this.rootNode, n.nodeName), this.node = t), this.getValue = this._getValue_unavailable, this.setValue = this._setValue_unavailable, !t) {
-			F("PropertyBinding: No target node found for track: " + this.path + ".");
+			I("PropertyBinding: No target node found for track: " + this.path + ".");
 			return;
 		}
 		if (r) {
@@ -4726,18 +4726,18 @@ var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ 
 			switch (r) {
 				case "materials":
 					if (!t.material) {
-						I("PropertyBinding: Can not bind to material as node does not have a material.", this);
+						L("PropertyBinding: Can not bind to material as node does not have a material.", this);
 						return;
 					}
 					if (!t.material.materials) {
-						I("PropertyBinding: Can not bind to material.materials as node.material does not have a materials array.", this);
+						L("PropertyBinding: Can not bind to material.materials as node.material does not have a materials array.", this);
 						return;
 					}
 					t = t.material.materials;
 					break;
 				case "bones":
 					if (!t.skeleton) {
-						I("PropertyBinding: Can not bind to bones as node does not have a skeleton.", this);
+						L("PropertyBinding: Can not bind to bones as node does not have a skeleton.", this);
 						return;
 					}
 					t = t.skeleton.bones;
@@ -4752,25 +4752,25 @@ var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ 
 						break;
 					}
 					if (!t.material) {
-						I("PropertyBinding: Can not bind to material as node does not have a material.", this);
+						L("PropertyBinding: Can not bind to material as node does not have a material.", this);
 						return;
 					}
 					if (!t.material.map) {
-						I("PropertyBinding: Can not bind to material.map as node.material does not have a map.", this);
+						L("PropertyBinding: Can not bind to material.map as node.material does not have a map.", this);
 						return;
 					}
 					t = t.material.map;
 					break;
 				default:
 					if (t[r] === void 0) {
-						I("PropertyBinding: Can not bind to objectName of node undefined.", this);
+						L("PropertyBinding: Can not bind to objectName of node undefined.", this);
 						return;
 					}
 					t = t[r];
 			}
 			if (e !== void 0) {
 				if (t[e] === void 0) {
-					I("PropertyBinding: Trying to bind to objectIndex of objectName, but is undefined.", this, t);
+					L("PropertyBinding: Trying to bind to objectIndex of objectName, but is undefined.", this, t);
 					return;
 				}
 				t = t[e];
@@ -4779,7 +4779,7 @@ var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ 
 		let o = t[i];
 		if (o === void 0) {
 			let e = n.nodeName;
-			I("PropertyBinding: Trying to update property for track: " + e + "." + i + " but it wasn't found.", t);
+			L("PropertyBinding: Trying to update property for track: " + e + "." + i + " but it wasn't found.", t);
 			return;
 		}
 		let s = this.Versioning.None;
@@ -4788,11 +4788,11 @@ var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ 
 		if (a !== void 0) {
 			if (i === "morphTargetInfluences") {
 				if (!t.geometry) {
-					I("PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.", this);
+					L("PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.", this);
 					return;
 				}
 				if (!t.geometry.morphAttributes) {
-					I("PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.morphAttributes.", this);
+					L("PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.morphAttributes.", this);
 					return;
 				}
 				t.morphTargetDictionary[a] !== void 0 && (a = t.morphTargetDictionary[a]);
@@ -4946,7 +4946,7 @@ function oi(e) {
 	}
 	throw Error(`THREE.TextureUtils: Unknown texture type ${e}.`);
 }
-typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("register", { detail: { revision: "185" } })), typeof window < "u" && (window.__THREE__ ? F("WARNING: Multiple instances of Three.js being imported.") : window.__THREE__ = "185");
+typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("register", { detail: { revision: "185" } })), typeof window < "u" && (window.__THREE__ ? I("WARNING: Multiple instances of Three.js being imported.") : window.__THREE__ = "185");
 //#endregion
 //#region node_modules/three/build/three.module.js
 function si() {
@@ -5663,7 +5663,7 @@ function pi(e, t, n, r, i, a) {
 			this.matrixWorld.copyPosition(n.matrixWorld);
 		}, Object.defineProperty(l.material, "envMap", { get: function() {
 			return this.uniforms.envMap.value;
-		} }), r.update(l)), l.material.uniforms.envMap.value = i, l.material.uniforms.backgroundBlurriness.value = n.backgroundBlurriness, l.material.uniforms.backgroundIntensity.value = n.backgroundIntensity, l.material.uniforms.backgroundRotation.value.setFromMatrix4(di.makeRotationFromEuler(n.backgroundRotation)).transpose(), i.isCubeTexture && i.isRenderTargetTexture === !1 && l.material.uniforms.backgroundRotation.value.premultiply(fi), l.material.toneMapped = K.getTransfer(i.colorSpace) !== j, (u !== i || d !== i.version || f !== e.toneMapping) && (l.material.needsUpdate = !0, u = i, d = i.version, f = e.toneMapping), l.layers.enableAll(), t.unshift(l, l.geometry, l.material, 0, 0, null)) : i && i.isTexture && (c === void 0 && (c = new Mn(new ar(2, 2), new mr({
+		} }), r.update(l)), l.material.uniforms.envMap.value = i, l.material.uniforms.backgroundBlurriness.value = n.backgroundBlurriness, l.material.uniforms.backgroundIntensity.value = n.backgroundIntensity, l.material.uniforms.backgroundRotation.value.setFromMatrix4(di.makeRotationFromEuler(n.backgroundRotation)).transpose(), i.isCubeTexture && i.isRenderTargetTexture === !1 && l.material.uniforms.backgroundRotation.value.premultiply(fi), l.material.toneMapped = K.getTransfer(i.colorSpace) !== M, (u !== i || d !== i.version || f !== e.toneMapping) && (l.material.needsUpdate = !0, u = i, d = i.version, f = e.toneMapping), l.layers.enableAll(), t.unshift(l, l.geometry, l.material, 0, 0, null)) : i && i.isTexture && (c === void 0 && (c = new Mn(new ar(2, 2), new mr({
 			name: "BackgroundMaterial",
 			uniforms: or(li.background.uniforms),
 			vertexShader: li.background.vertexShader,
@@ -5675,7 +5675,7 @@ function pi(e, t, n, r, i, a) {
 			allowOverride: !1
 		})), c.geometry.deleteAttribute("normal"), Object.defineProperty(c.material, "map", { get: function() {
 			return this.uniforms.t2D.value;
-		} }), r.update(c)), c.material.uniforms.t2D.value = i, c.material.uniforms.backgroundIntensity.value = n.backgroundIntensity, c.material.toneMapped = K.getTransfer(i.colorSpace) !== j, i.matrixAutoUpdate === !0 && i.updateMatrix(), c.material.uniforms.uvTransform.value.copy(i.matrix), (u !== i || d !== i.version || f !== e.toneMapping) && (c.material.needsUpdate = !0, u = i, d = i.version, f = e.toneMapping), c.layers.enableAll(), t.unshift(c, c.geometry, c.material, 0, 0, null));
+		} }), r.update(c)), c.material.uniforms.t2D.value = i, c.material.uniforms.backgroundIntensity.value = n.backgroundIntensity, c.material.toneMapped = K.getTransfer(i.colorSpace) !== M, i.matrixAutoUpdate === !0 && i.updateMatrix(), c.material.uniforms.uvTransform.value.copy(i.matrix), (u !== i || d !== i.version || f !== e.toneMapping) && (c.material.needsUpdate = !0, u = i, d = i.version, f = e.toneMapping), c.layers.enableAll(), t.unshift(c, c.geometry, c.material, 0, 0, null));
 	}
 	function g(t, r) {
 		t.getRGB(ui, ur(e)), n.buffers.color.setClear(ui.r, ui.g, ui.b, r, a);
@@ -5941,9 +5941,9 @@ function gi(e, t, n, r) {
 		return t === "mediump" && e.getShaderPrecisionFormat(e.VERTEX_SHADER, e.MEDIUM_FLOAT).precision > 0 && e.getShaderPrecisionFormat(e.FRAGMENT_SHADER, e.MEDIUM_FLOAT).precision > 0 ? "mediump" : "lowp";
 	}
 	let l = n.precision === void 0 ? "highp" : n.precision, u = c(l);
-	u !== l && (F("WebGLRenderer:", l, "not supported, using", u, "instead."), l = u);
+	u !== l && (I("WebGLRenderer:", l, "not supported, using", u, "instead."), l = u);
 	let d = n.logarithmicDepthBuffer === !0, f = n.reversedDepthBuffer === !0 && t.has("EXT_clip_control");
-	n.reversedDepthBuffer === !0 && f === !1 && F("WebGLRenderer: Unable to use reversed depth buffer due to missing EXT_clip_control extension. Fallback to default depth buffer.");
+	n.reversedDepthBuffer === !0 && f === !1 && I("WebGLRenderer: Unable to use reversed depth buffer due to missing EXT_clip_control extension. Fallback to default depth buffer.");
 	let p = e.getParameter(e.MAX_TEXTURE_IMAGE_UNITS), m = e.getParameter(e.MAX_VERTEX_TEXTURE_IMAGE_UNITS), h = e.getParameter(e.MAX_TEXTURE_SIZE), g = e.getParameter(e.MAX_CUBE_MAP_TEXTURE_SIZE), _ = e.getParameter(e.MAX_VERTEX_ATTRIBS), v = e.getParameter(e.MAX_VERTEX_UNIFORM_VECTORS), y = e.getParameter(e.MAX_VARYING_VECTORS), b = e.getParameter(e.MAX_FRAGMENT_UNIFORM_VECTORS), x = e.getParameter(e.MAX_SAMPLES), S = e.getParameter(e.SAMPLES);
 	return {
 		isWebGL2: !0,
@@ -6135,11 +6135,11 @@ var vi = 4, yi = [
 	}
 	_halfBlur(e, t, n, r, i, a, o) {
 		let s = this._renderer, c = this._blurMaterial;
-		a !== "latitudinal" && a !== "longitudinal" && I("blur direction must be either latitudinal or longitudinal!");
+		a !== "latitudinal" && a !== "longitudinal" && L("blur direction must be either latitudinal or longitudinal!");
 		let l = this._lodMeshes[r];
 		l.material = c;
 		let u = c.uniforms, d = this._sizeLods[n] - 1, f = isFinite(i) ? Math.PI / (2 * d) : 2 * Math.PI / (2 * bi - 1), p = i / f, m = isFinite(i) ? 1 + Math.floor(3 * p) : bi;
-		m > bi && F(`sigmaRadians, ${i}, is too large and will clip, as it requested ${m} samples when the maximum is set to ${bi}`);
+		m > bi && I(`sigmaRadians, ${i}, is too large and will clip, as it requested ${m} samples when the maximum is set to ${bi}`);
 		let h = [], g = 0;
 		for (let e = 0; e < bi; ++e) {
 			let t = e / p, n = Math.exp(-t * t / 2);
@@ -6418,7 +6418,7 @@ function Bi(e) {
 		},
 		get: function(e) {
 			let t = n(e);
-			return t === null && L("WebGLRenderer: " + e + " extension not supported."), t;
+			return t === null && R("WebGLRenderer: " + e + " extension not supported."), t;
 		}
 	};
 }
@@ -6529,7 +6529,7 @@ function Ui(e) {
 				n.points += i * t;
 				break;
 			default:
-				I("WebGLInfo: Unknown draw mode:", r);
+				L("WebGLInfo: Unknown draw mode:", r);
 				break;
 		}
 	}
@@ -7096,9 +7096,9 @@ function oo(e) {
 	K._getMatrix(ao, K.workingColorSpace, e);
 	let t = `mat3( ${ao.elements.map((e) => e.toFixed(4))} )`;
 	switch (K.getTransfer(e)) {
-		case ee: return [t, "LinearTransferOETF"];
-		case j: return [t, "sRGBTransferOETF"];
-		default: return F("WebGLProgram: Unsupported color space: ", e), [t, "LinearTransferOETF"];
+		case j: return [t, "LinearTransferOETF"];
+		case M: return [t, "sRGBTransferOETF"];
+		default: return I("WebGLProgram: Unsupported color space: ", e), [t, "LinearTransferOETF"];
 	}
 }
 function so(e, t, n) {
@@ -7129,7 +7129,7 @@ var lo = {
 };
 function uo(e, t) {
 	let n = lo[t];
-	return n === void 0 ? (F("WebGLProgram: Unsupported toneMapping:", t), "vec3 " + e + "( vec3 color ) { return LinearToneMapping( color ); }") : "vec3 " + e + "( vec3 color ) { return " + n + "ToneMapping( color ); }";
+	return n === void 0 ? (I("WebGLProgram: Unsupported toneMapping:", t), "vec3 " + e + "( vec3 color ) { return LinearToneMapping( color ); }") : "vec3 " + e + "( vec3 color ) { return " + n + "ToneMapping( color ); }";
 }
 var fo = /*@__PURE__*/ new W();
 function po() {
@@ -7182,7 +7182,7 @@ function Co(e, t) {
 	let n = Q[t];
 	if (n === void 0) {
 		let e = So.get(t);
-		if (e !== void 0) n = Q[e], F("WebGLRenderer: Shader chunk \"%s\" has been deprecated. Use \"%s\" instead.", t, e);
+		if (e !== void 0) n = Q[e], I("WebGLRenderer: Shader chunk \"%s\" has been deprecated. Use \"%s\" instead.", t, e);
 		else throw Error("THREE.WebGLProgram: Can not resolve #include <" + t + ">");
 	}
 	return xo(n);
@@ -7504,9 +7504,9 @@ function Lo(e, t, n, r) {
 			if (i.getProgramParameter(h, i.LINK_STATUS) === !1) if (l = !1, typeof e.debug.onShaderError == "function") e.debug.onShaderError(i, h, x, S);
 			else {
 				let e = so(i, x, "vertex"), n = so(i, S, "fragment");
-				I("WebGLProgram: Shader Error " + i.getError() + " - VALIDATE_STATUS " + i.getProgramParameter(h, i.VALIDATE_STATUS) + "\n\nMaterial Name: " + t.name + "\nMaterial Type: " + t.type + "\n\nProgram Info Log: " + o + "\n" + e + "\n" + n);
+				L("WebGLProgram: Shader Error " + i.getError() + " - VALIDATE_STATUS " + i.getProgramParameter(h, i.VALIDATE_STATUS) + "\n\nMaterial Name: " + t.name + "\nMaterial Type: " + t.type + "\n\nProgram Info Log: " + o + "\n" + e + "\n" + n);
 			}
-			else o === "" ? (s === "" || c === "") && (u = !1) : F("WebGLProgram: Program Info Log:", o);
+			else o === "" ? (s === "" || c === "") && (u = !1) : I("WebGLProgram: Program Info Log:", o);
 			u && (t.diagnostics = {
 				runnable: l,
 				programLog: o,
@@ -7598,7 +7598,7 @@ function Ho(e, t, n, r, i, a) {
 	}
 	function h(i, o, l, u, h, g) {
 		let _ = u.fog, v = h.geometry, y = i.isMeshStandardMaterial || i.isMeshLambertMaterial || i.isMeshPhongMaterial ? u.environment : null, b = i.isMeshStandardMaterial || i.isMeshLambertMaterial && !i.envMap || i.isMeshPhongMaterial && !i.envMap, x = t.get(i.envMap || y, b), S = x && x.mapping === 306 ? x.image.height : null, C = p[i.type];
-		i.precision !== null && (f = r.getMaxPrecision(i.precision), f !== i.precision && F("WebGLProgram.getParameters:", i.precision, "not supported, using", f, "instead."));
+		i.precision !== null && (f = r.getMaxPrecision(i.precision), f !== i.precision && I("WebGLProgram.getParameters:", i.precision, "not supported, using", f, "instead."));
 		let w = v.morphAttributes.position || v.morphAttributes.normal || v.morphAttributes.color, T = w === void 0 ? 0 : w.length, E = 0;
 		v.morphAttributes.position !== void 0 && (E = 1), v.morphAttributes.normal !== void 0 && (E = 2), v.morphAttributes.color !== void 0 && (E = 3);
 		let D, O, k, A;
@@ -7610,8 +7610,8 @@ function Ho(e, t, n, r, i, a) {
 			let e = s.getVertexShaderStage(i), t = s.getFragmentShaderStage(i);
 			s.update(i, e, t), k = e.id, A = t.id;
 		}
-		let ee = e.getRenderTarget(), j = e.state.buffers.depth.getReversed(), M = h.isInstancedMesh === !0, te = h.isBatchedMesh === !0, ne = !!i.map, N = !!i.matcap, re = !!x, ie = !!i.aoMap, P = !!i.lightMap, ae = !!i.bumpMap && i.wireframe === !1, oe = !!i.normalMap, I = !!i.displacementMap, L = !!i.emissiveMap, se = !!i.metalnessMap, ce = !!i.roughnessMap, R = i.anisotropy > 0, z = i.clearcoat > 0, le = i.dispersion > 0, ue = i.iridescence > 0, B = i.sheen > 0, V = i.transmission > 0, de = R && !!i.anisotropyMap, fe = z && !!i.clearcoatMap, pe = z && !!i.clearcoatNormalMap, H = z && !!i.clearcoatRoughnessMap, U = ue && !!i.iridescenceMap, me = ue && !!i.iridescenceThicknessMap, W = B && !!i.sheenColorMap, he = B && !!i.sheenRoughnessMap, ge = !!i.specularMap, G = !!i.specularColorMap, _e = !!i.specularIntensityMap, ve = V && !!i.transmissionMap, ye = V && !!i.thicknessMap, be = !!i.gradientMap, xe = !!i.alphaMap, Se = i.alphaTest > 0, Ce = !!i.alphaHash, we = !!i.extensions, Te = 0;
-		i.toneMapped && (ee === null || ee.isXRRenderTarget === !0) && (Te = e.toneMapping);
+		let j = e.getRenderTarget(), M = e.state.buffers.depth.getReversed(), N = h.isInstancedMesh === !0, ee = h.isBatchedMesh === !0, te = !!i.map, P = !!i.matcap, ne = !!x, re = !!i.aoMap, F = !!i.lightMap, ie = !!i.bumpMap && i.wireframe === !1, ae = !!i.normalMap, L = !!i.displacementMap, R = !!i.emissiveMap, oe = !!i.metalnessMap, se = !!i.roughnessMap, z = i.anisotropy > 0, ce = i.clearcoat > 0, le = i.dispersion > 0, ue = i.iridescence > 0, B = i.sheen > 0, V = i.transmission > 0, de = z && !!i.anisotropyMap, fe = ce && !!i.clearcoatMap, pe = ce && !!i.clearcoatNormalMap, H = ce && !!i.clearcoatRoughnessMap, U = ue && !!i.iridescenceMap, me = ue && !!i.iridescenceThicknessMap, W = B && !!i.sheenColorMap, he = B && !!i.sheenRoughnessMap, ge = !!i.specularMap, G = !!i.specularColorMap, _e = !!i.specularIntensityMap, ve = V && !!i.transmissionMap, ye = V && !!i.thicknessMap, be = !!i.gradientMap, xe = !!i.alphaMap, Se = i.alphaTest > 0, Ce = !!i.alphaHash, we = !!i.extensions, Te = 0;
+		i.toneMapped && (j === null || j.isXRRenderTarget === !0) && (Te = e.toneMapping);
 		let Ee = {
 			shaderID: C,
 			shaderType: i.type,
@@ -7624,32 +7624,32 @@ function Ho(e, t, n, r, i, a) {
 			isRawShaderMaterial: i.isRawShaderMaterial === !0,
 			glslVersion: i.glslVersion,
 			precision: f,
-			batching: te,
-			batchingColor: te && h._colorsTexture !== null,
-			instancing: M,
-			instancingColor: M && h.instanceColor !== null,
-			instancingMorph: M && h.morphTexture !== null,
-			outputColorSpace: ee === null ? e.outputColorSpace : ee.isXRRenderTarget === !0 ? ee.texture.colorSpace : K.workingColorSpace,
+			batching: ee,
+			batchingColor: ee && h._colorsTexture !== null,
+			instancing: N,
+			instancingColor: N && h.instanceColor !== null,
+			instancingMorph: N && h.morphTexture !== null,
+			outputColorSpace: j === null ? e.outputColorSpace : j.isXRRenderTarget === !0 ? j.texture.colorSpace : K.workingColorSpace,
 			alphaToCoverage: !!i.alphaToCoverage,
-			map: ne,
-			matcap: N,
-			envMap: re,
-			envMapMode: re && x.mapping,
+			map: te,
+			matcap: P,
+			envMap: ne,
+			envMapMode: ne && x.mapping,
 			envMapCubeUVHeight: S,
-			aoMap: ie,
-			lightMap: P,
-			bumpMap: ae,
-			normalMap: oe,
-			displacementMap: I,
-			emissiveMap: L,
-			normalMapObjectSpace: oe && i.normalMapType === 1,
-			normalMapTangentSpace: oe && i.normalMapType === 0,
-			packedNormalMap: oe && i.normalMapType === 0 && Vo(i.normalMap.format),
-			metalnessMap: se,
-			roughnessMap: ce,
-			anisotropy: R,
+			aoMap: re,
+			lightMap: F,
+			bumpMap: ie,
+			normalMap: ae,
+			displacementMap: L,
+			emissiveMap: R,
+			normalMapObjectSpace: ae && i.normalMapType === 1,
+			normalMapTangentSpace: ae && i.normalMapType === 0,
+			packedNormalMap: ae && i.normalMapType === 0 && Vo(i.normalMap.format),
+			metalnessMap: oe,
+			roughnessMap: se,
+			anisotropy: z,
 			anisotropyMap: de,
-			clearcoat: z,
+			clearcoat: ce,
 			clearcoatMap: fe,
 			clearcoatNormalMap: pe,
 			clearcoatRoughnessMap: H,
@@ -7672,15 +7672,15 @@ function Ho(e, t, n, r, i, a) {
 			alphaTest: Se,
 			alphaHash: Ce,
 			combine: i.combine,
-			mapUv: ne && m(i.map.channel),
-			aoMapUv: ie && m(i.aoMap.channel),
-			lightMapUv: P && m(i.lightMap.channel),
-			bumpMapUv: ae && m(i.bumpMap.channel),
-			normalMapUv: oe && m(i.normalMap.channel),
-			displacementMapUv: I && m(i.displacementMap.channel),
-			emissiveMapUv: L && m(i.emissiveMap.channel),
-			metalnessMapUv: se && m(i.metalnessMap.channel),
-			roughnessMapUv: ce && m(i.roughnessMap.channel),
+			mapUv: te && m(i.map.channel),
+			aoMapUv: re && m(i.aoMap.channel),
+			lightMapUv: F && m(i.lightMap.channel),
+			bumpMapUv: ie && m(i.bumpMap.channel),
+			normalMapUv: ae && m(i.normalMap.channel),
+			displacementMapUv: L && m(i.displacementMap.channel),
+			emissiveMapUv: R && m(i.emissiveMap.channel),
+			metalnessMapUv: oe && m(i.metalnessMap.channel),
+			roughnessMapUv: se && m(i.roughnessMap.channel),
 			anisotropyMapUv: de && m(i.anisotropyMap.channel),
 			clearcoatMapUv: fe && m(i.clearcoatMap.channel),
 			clearcoatNormalMapUv: pe && m(i.clearcoatNormalMap.channel),
@@ -7695,18 +7695,18 @@ function Ho(e, t, n, r, i, a) {
 			transmissionMapUv: ve && m(i.transmissionMap.channel),
 			thicknessMapUv: ye && m(i.thicknessMap.channel),
 			alphaMapUv: xe && m(i.alphaMap.channel),
-			vertexTangents: !!v.attributes.tangent && (oe || R),
+			vertexTangents: !!v.attributes.tangent && (ae || z),
 			vertexNormals: !!v.attributes.normal,
 			vertexColors: i.vertexColors,
 			vertexAlphas: i.vertexColors === !0 && !!v.attributes.color && v.attributes.color.itemSize === 4,
-			pointsUvs: h.isPoints === !0 && !!v.attributes.uv && (ne || xe),
+			pointsUvs: h.isPoints === !0 && !!v.attributes.uv && (te || xe),
 			fog: !!_,
 			useFog: i.fog === !0,
 			fogExp2: !!_ && _.isFogExp2,
-			flatShading: i.wireframe === !1 && (i.flatShading === !0 || v.attributes.normal === void 0 && oe === !1 && (i.isMeshLambertMaterial || i.isMeshPhongMaterial || i.isMeshStandardMaterial || i.isMeshPhysicalMaterial)),
+			flatShading: i.wireframe === !1 && (i.flatShading === !0 || v.attributes.normal === void 0 && ae === !1 && (i.isMeshLambertMaterial || i.isMeshPhongMaterial || i.isMeshStandardMaterial || i.isMeshPhysicalMaterial)),
 			sizeAttenuation: i.sizeAttenuation === !0,
 			logarithmicDepthBuffer: d,
-			reversedDepthBuffer: j,
+			reversedDepthBuffer: M,
 			skinning: h.isSkinnedMesh === !0,
 			hasPositionAttribute: v.attributes.position !== void 0,
 			morphTargets: v.morphAttributes.position !== void 0,
@@ -7732,8 +7732,8 @@ function Ho(e, t, n, r, i, a) {
 			shadowMapEnabled: e.shadowMap.enabled && l.length > 0,
 			shadowMapType: e.shadowMap.type,
 			toneMapping: Te,
-			decodeVideoTexture: ne && i.map.isVideoTexture === !0 && K.getTransfer(i.map.colorSpace) === "srgb",
-			decodeVideoTextureEmissive: L && i.emissiveMap.isVideoTexture === !0 && K.getTransfer(i.emissiveMap.colorSpace) === "srgb",
+			decodeVideoTexture: te && i.map.isVideoTexture === !0 && K.getTransfer(i.map.colorSpace) === "srgb",
+			decodeVideoTextureEmissive: R && i.emissiveMap.isVideoTexture === !0 && K.getTransfer(i.emissiveMap.colorSpace) === "srgb",
 			premultipliedAlpha: i.premultipliedAlpha,
 			doubleSided: i.side === 2,
 			flipSided: i.side === 1,
@@ -7741,7 +7741,7 @@ function Ho(e, t, n, r, i, a) {
 			depthPacking: i.depthPacking || 0,
 			index0AttributeName: i.index0AttributeName,
 			extensionClipCullDistance: we && i.extensions.clipCullDistance === !0 && n.has("WEBGL_clip_cull_distance"),
-			extensionMultiDraw: (we && i.extensions.multiDraw === !0 || te) && n.has("WEBGL_multi_draw"),
+			extensionMultiDraw: (we && i.extensions.multiDraw === !0 || ee) && n.has("WEBGL_multi_draw"),
 			rendererExtensionParallelShaderCompile: n.has("KHR_parallel_shader_compile"),
 			customProgramCacheKey: i.customProgramCacheKey()
 		};
@@ -8202,7 +8202,7 @@ function cs(e, t, n) {
 	let w = this.type;
 	this.render = function(t, n, f) {
 		if (C.enabled === !1 || C.autoUpdate === !1 && C.needsUpdate === !1 || t.length === 0) return;
-		this.type === 2 && (F("WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead."), this.type = 1);
+		this.type === 2 && (I("WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead."), this.type = 1);
 		let p = e.getRenderTarget(), m = e.getActiveCubeFace(), _ = e.getActiveMipmapLevel(), v = e.state;
 		v.setBlending(0), v.buffers.depth.getReversed() === !0 ? v.buffers.color.setClear(0, 0, 0, 0) : v.buffers.color.setClear(1, 1, 1, 1), v.buffers.depth.setTest(!0), v.setScissorTest(!1);
 		let b = w !== this.type;
@@ -8212,7 +8212,7 @@ function cs(e, t, n) {
 		for (let p = 0, m = t.length; p < m; p++) {
 			let m = t[p], _ = m.shadow;
 			if (_ === void 0) {
-				F("WebGLShadowMap:", m, "has no shadow.");
+				I("WebGLShadowMap:", m, "has no shadow.");
 				continue;
 			}
 			if (_.autoUpdate === !1 && _.needsUpdate === !1) continue;
@@ -8223,7 +8223,7 @@ function cs(e, t, n) {
 			if (_.camera._reversedDepth = S, _.map === null || b === !0) {
 				if (_.map !== null && (_.map.depthTexture !== null && (_.map.depthTexture.dispose(), _.map.depthTexture = null), _.map.dispose()), this.type === 3) {
 					if (m.isPointLight) {
-						F("WebGLShadowMap: VSM shadow maps are not supported for PointLights. Use PCF or BasicShadowMap instead.");
+						I("WebGLShadowMap: VSM shadow maps are not supported for PointLights. Use PCF or BasicShadowMap instead.");
 						continue;
 					}
 					_.map = new Me(o.x, o.y, {
@@ -8339,13 +8339,13 @@ function ls(e, t) {
 				return r;
 			},
 			setTest: function(t) {
-				t ? se(e.DEPTH_TEST) : R(e.DEPTH_TEST);
+				t ? oe(e.DEPTH_TEST) : z(e.DEPTH_TEST);
 			},
 			setMask: function(t) {
 				i !== t && !n && (e.depthMask(t), i = t);
 			},
 			setFunc: function(t) {
-				if (r && (t = ce[t]), a !== t) {
+				if (r && (t = se[t]), a !== t) {
 					switch (t) {
 						case 0:
 							e.depthFunc(e.NEVER);
@@ -8391,7 +8391,7 @@ function ls(e, t) {
 		let t = !1, n = null, r = null, i = null, a = null, o = null, s = null, c = null, l = null;
 		return {
 			setTest: function(n) {
-				t || (n ? se(e.STENCIL_TEST) : R(e.STENCIL_TEST));
+				t || (n ? oe(e.STENCIL_TEST) : z(e.STENCIL_TEST));
 			},
 			setMask: function(r) {
 				n !== r && !t && (e.stencilMask(r), n = r);
@@ -8413,24 +8413,24 @@ function ls(e, t) {
 			}
 		};
 	}
-	let a = new n(), o = new r(), s = new i(), c = /* @__PURE__ */ new WeakMap(), l = /* @__PURE__ */ new WeakMap(), u = {}, d = {}, f = {}, p = /* @__PURE__ */ new WeakMap(), m = [], h = null, g = !1, _ = null, v = null, y = null, b = null, x = null, S = null, C = null, w = new Z(0, 0, 0), T = 0, E = !1, D = null, O = null, k = null, A = null, ee = null, j = e.getParameter(e.MAX_COMBINED_TEXTURE_IMAGE_UNITS), M = !1, te = 0, ne = e.getParameter(e.VERSION);
-	ne.indexOf("WebGL") === -1 ? ne.indexOf("OpenGL ES") !== -1 && (te = parseFloat(/^OpenGL ES (\d)/.exec(ne)[1]), M = te >= 2) : (te = parseFloat(/^WebGL (\d)/.exec(ne)[1]), M = te >= 1);
-	let N = null, re = {}, ie = e.getParameter(e.SCISSOR_BOX), P = e.getParameter(e.VIEWPORT), ae = new je().fromArray(ie), oe = new je().fromArray(P);
-	function F(t, n, r, i) {
+	let a = new n(), o = new r(), s = new i(), c = /* @__PURE__ */ new WeakMap(), l = /* @__PURE__ */ new WeakMap(), u = {}, d = {}, f = {}, p = /* @__PURE__ */ new WeakMap(), m = [], h = null, g = !1, _ = null, v = null, y = null, b = null, x = null, S = null, C = null, w = new Z(0, 0, 0), T = 0, E = !1, D = null, O = null, k = null, A = null, j = null, M = e.getParameter(e.MAX_COMBINED_TEXTURE_IMAGE_UNITS), N = !1, ee = 0, te = e.getParameter(e.VERSION);
+	te.indexOf("WebGL") === -1 ? te.indexOf("OpenGL ES") !== -1 && (ee = parseFloat(/^OpenGL ES (\d)/.exec(te)[1]), N = ee >= 2) : (ee = parseFloat(/^WebGL (\d)/.exec(te)[1]), N = ee >= 1);
+	let P = null, ne = {}, re = e.getParameter(e.SCISSOR_BOX), F = e.getParameter(e.VIEWPORT), ie = new je().fromArray(re), ae = new je().fromArray(F);
+	function I(t, n, r, i) {
 		let a = /* @__PURE__ */ new Uint8Array(4), o = e.createTexture();
 		e.bindTexture(t, o), e.texParameteri(t, e.TEXTURE_MIN_FILTER, e.NEAREST), e.texParameteri(t, e.TEXTURE_MAG_FILTER, e.NEAREST);
 		for (let o = 0; o < r; o++) t === e.TEXTURE_3D || t === e.TEXTURE_2D_ARRAY ? e.texImage3D(n, 0, e.RGBA, 1, 1, i, 0, e.RGBA, e.UNSIGNED_BYTE, a) : e.texImage2D(n + o, 0, e.RGBA, 1, 1, 0, e.RGBA, e.UNSIGNED_BYTE, a);
 		return o;
 	}
-	let L = {};
-	L[e.TEXTURE_2D] = F(e.TEXTURE_2D, e.TEXTURE_2D, 1), L[e.TEXTURE_CUBE_MAP] = F(e.TEXTURE_CUBE_MAP, e.TEXTURE_CUBE_MAP_POSITIVE_X, 6), L[e.TEXTURE_2D_ARRAY] = F(e.TEXTURE_2D_ARRAY, e.TEXTURE_2D_ARRAY, 1, 1), L[e.TEXTURE_3D] = F(e.TEXTURE_3D, e.TEXTURE_3D, 1, 1), a.setClear(0, 0, 0, 1), o.setClear(1), s.setClear(0), se(e.DEPTH_TEST), o.setFunc(3), pe(!1), H(1), se(e.CULL_FACE), de(0);
-	function se(t) {
+	let R = {};
+	R[e.TEXTURE_2D] = I(e.TEXTURE_2D, e.TEXTURE_2D, 1), R[e.TEXTURE_CUBE_MAP] = I(e.TEXTURE_CUBE_MAP, e.TEXTURE_CUBE_MAP_POSITIVE_X, 6), R[e.TEXTURE_2D_ARRAY] = I(e.TEXTURE_2D_ARRAY, e.TEXTURE_2D_ARRAY, 1, 1), R[e.TEXTURE_3D] = I(e.TEXTURE_3D, e.TEXTURE_3D, 1, 1), a.setClear(0, 0, 0, 1), o.setClear(1), s.setClear(0), oe(e.DEPTH_TEST), o.setFunc(3), pe(!1), H(1), oe(e.CULL_FACE), de(0);
+	function oe(t) {
 		u[t] !== !0 && (e.enable(t), u[t] = !0);
 	}
-	function R(t) {
+	function z(t) {
 		u[t] !== !1 && (e.disable(t), u[t] = !1);
 	}
-	function z(t, n) {
+	function ce(t, n) {
 		return f[t] === n ? !1 : (e.bindFramebuffer(t, n), f[t] = n, t === e.DRAW_FRAMEBUFFER && (f[e.FRAMEBUFFER] = n), t === e.FRAMEBUFFER && (f[e.DRAW_FRAMEBUFFER] = n), !0);
 	}
 	function le(t, n) {
@@ -8473,10 +8473,10 @@ function ls(e, t) {
 	};
 	function de(t, n, r, i, a, o, s, c, l, u) {
 		if (t === 0) {
-			g === !0 && (R(e.BLEND), g = !1);
+			g === !0 && (z(e.BLEND), g = !1);
 			return;
 		}
-		if (g === !1 && (se(e.BLEND), g = !0), t !== 5) {
+		if (g === !1 && (oe(e.BLEND), g = !0), t !== 5) {
 			if (t !== _ || u !== E) {
 				if ((v !== 100 || x !== 100) && (e.blendEquation(e.FUNC_ADD), v = 100, x = 100), u) switch (t) {
 					case 1:
@@ -8492,7 +8492,7 @@ function ls(e, t) {
 						e.blendFuncSeparate(e.DST_COLOR, e.ONE_MINUS_SRC_ALPHA, e.ZERO, e.ONE);
 						break;
 					default:
-						I("WebGLState: Invalid blending: ", t);
+						L("WebGLState: Invalid blending: ", t);
 						break;
 				}
 				else switch (t) {
@@ -8503,13 +8503,13 @@ function ls(e, t) {
 						e.blendFuncSeparate(e.SRC_ALPHA, e.ONE, e.ONE, e.ONE);
 						break;
 					case 3:
-						I("WebGLState: SubtractiveBlending requires material.premultipliedAlpha = true");
+						L("WebGLState: SubtractiveBlending requires material.premultipliedAlpha = true");
 						break;
 					case 4:
-						I("WebGLState: MultiplyBlending requires material.premultipliedAlpha = true");
+						L("WebGLState: MultiplyBlending requires material.premultipliedAlpha = true");
 						break;
 					default:
-						I("WebGLState: Invalid blending: ", t);
+						L("WebGLState: Invalid blending: ", t);
 						break;
 				}
 				y = null, b = null, S = null, C = null, w.set(0, 0, 0), T = 0, _ = t, E = u;
@@ -8519,110 +8519,110 @@ function ls(e, t) {
 		a ||= n, o ||= r, s ||= i, (n !== v || a !== x) && (e.blendEquationSeparate(B[n], B[a]), v = n, x = a), (r !== y || i !== b || o !== S || s !== C) && (e.blendFuncSeparate(V[r], V[i], V[o], V[s]), y = r, b = i, S = o, C = s), (c.equals(w) === !1 || l !== T) && (e.blendColor(c.r, c.g, c.b, l), w.copy(c), T = l), _ = t, E = !1;
 	}
 	function fe(t, n) {
-		t.side === 2 ? R(e.CULL_FACE) : se(e.CULL_FACE);
+		t.side === 2 ? z(e.CULL_FACE) : oe(e.CULL_FACE);
 		let r = t.side === 1;
 		n && (r = !r), pe(r), t.blending === 1 && t.transparent === !1 ? de(0) : de(t.blending, t.blendEquation, t.blendSrc, t.blendDst, t.blendEquationAlpha, t.blendSrcAlpha, t.blendDstAlpha, t.blendColor, t.blendAlpha, t.premultipliedAlpha), o.setFunc(t.depthFunc), o.setTest(t.depthTest), o.setMask(t.depthWrite), a.setMask(t.colorWrite);
 		let i = t.stencilWrite;
-		s.setTest(i), i && (s.setMask(t.stencilWriteMask), s.setFunc(t.stencilFunc, t.stencilRef, t.stencilFuncMask), s.setOp(t.stencilFail, t.stencilZFail, t.stencilZPass)), me(t.polygonOffset, t.polygonOffsetFactor, t.polygonOffsetUnits), t.alphaToCoverage === !0 ? se(e.SAMPLE_ALPHA_TO_COVERAGE) : R(e.SAMPLE_ALPHA_TO_COVERAGE);
+		s.setTest(i), i && (s.setMask(t.stencilWriteMask), s.setFunc(t.stencilFunc, t.stencilRef, t.stencilFuncMask), s.setOp(t.stencilFail, t.stencilZFail, t.stencilZPass)), me(t.polygonOffset, t.polygonOffsetFactor, t.polygonOffsetUnits), t.alphaToCoverage === !0 ? oe(e.SAMPLE_ALPHA_TO_COVERAGE) : z(e.SAMPLE_ALPHA_TO_COVERAGE);
 	}
 	function pe(t) {
 		D !== t && (t ? e.frontFace(e.CW) : e.frontFace(e.CCW), D = t);
 	}
 	function H(t) {
-		t === 0 ? R(e.CULL_FACE) : (se(e.CULL_FACE), t !== O && (t === 1 ? e.cullFace(e.BACK) : t === 2 ? e.cullFace(e.FRONT) : e.cullFace(e.FRONT_AND_BACK))), O = t;
+		t === 0 ? z(e.CULL_FACE) : (oe(e.CULL_FACE), t !== O && (t === 1 ? e.cullFace(e.BACK) : t === 2 ? e.cullFace(e.FRONT) : e.cullFace(e.FRONT_AND_BACK))), O = t;
 	}
 	function U(t) {
-		t !== k && (M && e.lineWidth(t), k = t);
+		t !== k && (N && e.lineWidth(t), k = t);
 	}
 	function me(t, n, r) {
-		t ? (se(e.POLYGON_OFFSET_FILL), (A !== n || ee !== r) && (A = n, ee = r, o.getReversed() && (n = -n), e.polygonOffset(n, r))) : R(e.POLYGON_OFFSET_FILL);
+		t ? (oe(e.POLYGON_OFFSET_FILL), (A !== n || j !== r) && (A = n, j = r, o.getReversed() && (n = -n), e.polygonOffset(n, r))) : z(e.POLYGON_OFFSET_FILL);
 	}
 	function W(t) {
-		t ? se(e.SCISSOR_TEST) : R(e.SCISSOR_TEST);
+		t ? oe(e.SCISSOR_TEST) : z(e.SCISSOR_TEST);
 	}
 	function he(t) {
-		t === void 0 && (t = e.TEXTURE0 + j - 1), N !== t && (e.activeTexture(t), N = t);
+		t === void 0 && (t = e.TEXTURE0 + M - 1), P !== t && (e.activeTexture(t), P = t);
 	}
 	function ge(t, n, r) {
-		r === void 0 && (r = N === null ? e.TEXTURE0 + j - 1 : N);
-		let i = re[r];
+		r === void 0 && (r = P === null ? e.TEXTURE0 + M - 1 : P);
+		let i = ne[r];
 		i === void 0 && (i = {
 			type: void 0,
 			texture: void 0
-		}, re[r] = i), (i.type !== t || i.texture !== n) && (N !== r && (e.activeTexture(r), N = r), e.bindTexture(t, n || L[t]), i.type = t, i.texture = n);
+		}, ne[r] = i), (i.type !== t || i.texture !== n) && (P !== r && (e.activeTexture(r), P = r), e.bindTexture(t, n || R[t]), i.type = t, i.texture = n);
 	}
 	function G() {
-		let t = re[N];
+		let t = ne[P];
 		t !== void 0 && t.type !== void 0 && (e.bindTexture(t.type, null), t.type = void 0, t.texture = void 0);
 	}
 	function _e() {
 		try {
 			e.compressedTexImage2D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function ve() {
 		try {
 			e.compressedTexImage3D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function ye() {
 		try {
 			e.texSubImage2D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function be() {
 		try {
 			e.texSubImage3D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function K() {
 		try {
 			e.compressedTexSubImage2D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function xe() {
 		try {
 			e.compressedTexSubImage3D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function Se() {
 		try {
 			e.texStorage2D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function Ce() {
 		try {
 			e.texStorage3D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function we() {
 		try {
 			e.texImage2D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function Te() {
 		try {
 			e.texImage3D(...arguments);
 		} catch (e) {
-			I("WebGLState:", e);
+			L("WebGLState:", e);
 		}
 	}
 	function Ee(t) {
@@ -8632,10 +8632,10 @@ function ls(e, t) {
 		d[t] !== n && (e.pixelStorei(t, n), d[t] = n);
 	}
 	function Oe(t) {
-		ae.equals(t) === !1 && (e.scissor(t.x, t.y, t.z, t.w), ae.copy(t));
+		ie.equals(t) === !1 && (e.scissor(t.x, t.y, t.z, t.w), ie.copy(t));
 	}
 	function ke(t) {
-		oe.equals(t) === !1 && (e.viewport(t.x, t.y, t.z, t.w), oe.copy(t));
+		ae.equals(t) === !1 && (e.viewport(t.x, t.y, t.z, t.w), ae.copy(t));
 	}
 	function Ae(t, n) {
 		let r = l.get(n);
@@ -8648,7 +8648,7 @@ function ls(e, t) {
 		c.get(n) !== r && (e.uniformBlockBinding(n, r, t.__bindingPointIndex), c.set(n, r));
 	}
 	function Me() {
-		e.disable(e.BLEND), e.disable(e.CULL_FACE), e.disable(e.DEPTH_TEST), e.disable(e.POLYGON_OFFSET_FILL), e.disable(e.SCISSOR_TEST), e.disable(e.STENCIL_TEST), e.disable(e.SAMPLE_ALPHA_TO_COVERAGE), e.blendEquation(e.FUNC_ADD), e.blendFunc(e.ONE, e.ZERO), e.blendFuncSeparate(e.ONE, e.ZERO, e.ONE, e.ZERO), e.blendColor(0, 0, 0, 0), e.colorMask(!0, !0, !0, !0), e.clearColor(0, 0, 0, 0), e.depthMask(!0), e.depthFunc(e.LESS), o.setReversed(!1), e.clearDepth(1), e.stencilMask(4294967295), e.stencilFunc(e.ALWAYS, 0, 4294967295), e.stencilOp(e.KEEP, e.KEEP, e.KEEP), e.clearStencil(0), e.cullFace(e.BACK), e.frontFace(e.CCW), e.polygonOffset(0, 0), e.activeTexture(e.TEXTURE0), e.bindFramebuffer(e.FRAMEBUFFER, null), e.bindFramebuffer(e.DRAW_FRAMEBUFFER, null), e.bindFramebuffer(e.READ_FRAMEBUFFER, null), e.useProgram(null), e.lineWidth(1), e.scissor(0, 0, e.canvas.width, e.canvas.height), e.viewport(0, 0, e.canvas.width, e.canvas.height), e.pixelStorei(e.PACK_ALIGNMENT, 4), e.pixelStorei(e.UNPACK_ALIGNMENT, 4), e.pixelStorei(e.UNPACK_FLIP_Y_WEBGL, !1), e.pixelStorei(e.UNPACK_PREMULTIPLY_ALPHA_WEBGL, !1), e.pixelStorei(e.UNPACK_COLORSPACE_CONVERSION_WEBGL, e.BROWSER_DEFAULT_WEBGL), e.pixelStorei(e.PACK_ROW_LENGTH, 0), e.pixelStorei(e.PACK_SKIP_PIXELS, 0), e.pixelStorei(e.PACK_SKIP_ROWS, 0), e.pixelStorei(e.UNPACK_ROW_LENGTH, 0), e.pixelStorei(e.UNPACK_IMAGE_HEIGHT, 0), e.pixelStorei(e.UNPACK_SKIP_PIXELS, 0), e.pixelStorei(e.UNPACK_SKIP_ROWS, 0), e.pixelStorei(e.UNPACK_SKIP_IMAGES, 0), u = {}, d = {}, N = null, re = {}, f = {}, p = /* @__PURE__ */ new WeakMap(), m = [], h = null, g = !1, _ = null, v = null, y = null, b = null, x = null, S = null, C = null, w = new Z(0, 0, 0), T = 0, E = !1, D = null, O = null, k = null, A = null, ee = null, ae.set(0, 0, e.canvas.width, e.canvas.height), oe.set(0, 0, e.canvas.width, e.canvas.height), a.reset(), o.reset(), s.reset();
+		e.disable(e.BLEND), e.disable(e.CULL_FACE), e.disable(e.DEPTH_TEST), e.disable(e.POLYGON_OFFSET_FILL), e.disable(e.SCISSOR_TEST), e.disable(e.STENCIL_TEST), e.disable(e.SAMPLE_ALPHA_TO_COVERAGE), e.blendEquation(e.FUNC_ADD), e.blendFunc(e.ONE, e.ZERO), e.blendFuncSeparate(e.ONE, e.ZERO, e.ONE, e.ZERO), e.blendColor(0, 0, 0, 0), e.colorMask(!0, !0, !0, !0), e.clearColor(0, 0, 0, 0), e.depthMask(!0), e.depthFunc(e.LESS), o.setReversed(!1), e.clearDepth(1), e.stencilMask(4294967295), e.stencilFunc(e.ALWAYS, 0, 4294967295), e.stencilOp(e.KEEP, e.KEEP, e.KEEP), e.clearStencil(0), e.cullFace(e.BACK), e.frontFace(e.CCW), e.polygonOffset(0, 0), e.activeTexture(e.TEXTURE0), e.bindFramebuffer(e.FRAMEBUFFER, null), e.bindFramebuffer(e.DRAW_FRAMEBUFFER, null), e.bindFramebuffer(e.READ_FRAMEBUFFER, null), e.useProgram(null), e.lineWidth(1), e.scissor(0, 0, e.canvas.width, e.canvas.height), e.viewport(0, 0, e.canvas.width, e.canvas.height), e.pixelStorei(e.PACK_ALIGNMENT, 4), e.pixelStorei(e.UNPACK_ALIGNMENT, 4), e.pixelStorei(e.UNPACK_FLIP_Y_WEBGL, !1), e.pixelStorei(e.UNPACK_PREMULTIPLY_ALPHA_WEBGL, !1), e.pixelStorei(e.UNPACK_COLORSPACE_CONVERSION_WEBGL, e.BROWSER_DEFAULT_WEBGL), e.pixelStorei(e.PACK_ROW_LENGTH, 0), e.pixelStorei(e.PACK_SKIP_PIXELS, 0), e.pixelStorei(e.PACK_SKIP_ROWS, 0), e.pixelStorei(e.UNPACK_ROW_LENGTH, 0), e.pixelStorei(e.UNPACK_IMAGE_HEIGHT, 0), e.pixelStorei(e.UNPACK_SKIP_PIXELS, 0), e.pixelStorei(e.UNPACK_SKIP_ROWS, 0), e.pixelStorei(e.UNPACK_SKIP_IMAGES, 0), u = {}, d = {}, P = null, ne = {}, f = {}, p = /* @__PURE__ */ new WeakMap(), m = [], h = null, g = !1, _ = null, v = null, y = null, b = null, x = null, S = null, C = null, w = new Z(0, 0, 0), T = 0, E = !1, D = null, O = null, k = null, A = null, j = null, ie.set(0, 0, e.canvas.width, e.canvas.height), ae.set(0, 0, e.canvas.width, e.canvas.height), a.reset(), o.reset(), s.reset();
 	}
 	return {
 		buffers: {
@@ -8656,9 +8656,9 @@ function ls(e, t) {
 			depth: o,
 			stencil: s
 		},
-		enable: se,
-		disable: R,
-		bindFramebuffer: z,
+		enable: oe,
+		disable: z,
+		bindFramebuffer: ce,
 		drawBuffers: le,
 		useProgram: ue,
 		setBlending: de,
@@ -8696,7 +8696,7 @@ function us(o, s, c, l, u, d, f) {
 		x = typeof OffscreenCanvas < "u" && new OffscreenCanvas(1, 1).getContext("2d") !== null;
 	} catch {}
 	function S(e, t) {
-		return x ? new OffscreenCanvas(e, t) : re("canvas");
+		return x ? new OffscreenCanvas(e, t) : ne("canvas");
 	}
 	function C(e, t, n) {
 		let r = 1, i = De(e);
@@ -8704,8 +8704,8 @@ function us(o, s, c, l, u, d, f) {
 			let n = Math.floor(r * i.width), a = Math.floor(r * i.height);
 			y === void 0 && (y = S(n, a));
 			let o = t ? S(n, a) : y;
-			return o.width = n, o.height = a, o.getContext("2d").drawImage(e, 0, 0, n, a), F("WebGLRenderer: Texture has been resized from (" + i.width + "x" + i.height + ") to (" + n + "x" + a + ")."), o;
-		} else return "data" in e && F("WebGLRenderer: Image in DataTexture is too big (" + i.width + "x" + i.height + ")."), e;
+			return o.width = n, o.height = a, o.getContext("2d").drawImage(e, 0, 0, n, a), I("WebGLRenderer: Texture has been resized from (" + i.width + "x" + i.height + ") to (" + n + "x" + a + ")."), o;
+		} else return "data" in e && I("WebGLRenderer: Image in DataTexture is too big (" + i.width + "x" + i.height + ")."), e;
 		return e;
 	}
 	function w(e) {
@@ -8720,49 +8720,49 @@ function us(o, s, c, l, u, d, f) {
 	function D(e, t, n, r, i, a = !1) {
 		if (e !== null) {
 			if (o[e] !== void 0) return o[e];
-			F("WebGLRenderer: Attempt to use non-existing WebGL internal format '" + e + "'");
+			I("WebGLRenderer: Attempt to use non-existing WebGL internal format '" + e + "'");
 		}
 		let c;
-		r && (c = s.get("EXT_texture_norm16"), c || F("WebGLRenderer: Unable to use normalized textures without EXT_texture_norm16 extension"));
+		r && (c = s.get("EXT_texture_norm16"), c || I("WebGLRenderer: Unable to use normalized textures without EXT_texture_norm16 extension"));
 		let l = t;
 		if (t === o.RED && (n === o.FLOAT && (l = o.R32F), n === o.HALF_FLOAT && (l = o.R16F), n === o.UNSIGNED_BYTE && (l = o.R8), n === o.UNSIGNED_SHORT && c && (l = c.R16_EXT), n === o.SHORT && c && (l = c.R16_SNORM_EXT)), t === o.RED_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.R8UI), n === o.UNSIGNED_SHORT && (l = o.R16UI), n === o.UNSIGNED_INT && (l = o.R32UI), n === o.BYTE && (l = o.R8I), n === o.SHORT && (l = o.R16I), n === o.INT && (l = o.R32I)), t === o.RG && (n === o.FLOAT && (l = o.RG32F), n === o.HALF_FLOAT && (l = o.RG16F), n === o.UNSIGNED_BYTE && (l = o.RG8), n === o.UNSIGNED_SHORT && c && (l = c.RG16_EXT), n === o.SHORT && c && (l = c.RG16_SNORM_EXT)), t === o.RG_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.RG8UI), n === o.UNSIGNED_SHORT && (l = o.RG16UI), n === o.UNSIGNED_INT && (l = o.RG32UI), n === o.BYTE && (l = o.RG8I), n === o.SHORT && (l = o.RG16I), n === o.INT && (l = o.RG32I)), t === o.RGB_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.RGB8UI), n === o.UNSIGNED_SHORT && (l = o.RGB16UI), n === o.UNSIGNED_INT && (l = o.RGB32UI), n === o.BYTE && (l = o.RGB8I), n === o.SHORT && (l = o.RGB16I), n === o.INT && (l = o.RGB32I)), t === o.RGBA_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.RGBA8UI), n === o.UNSIGNED_SHORT && (l = o.RGBA16UI), n === o.UNSIGNED_INT && (l = o.RGBA32UI), n === o.BYTE && (l = o.RGBA8I), n === o.SHORT && (l = o.RGBA16I), n === o.INT && (l = o.RGBA32I)), t === o.RGB && (n === o.UNSIGNED_SHORT && c && (l = c.RGB16_EXT), n === o.SHORT && c && (l = c.RGB16_SNORM_EXT), n === o.UNSIGNED_INT_5_9_9_9_REV && (l = o.RGB9_E5), n === o.UNSIGNED_INT_10F_11F_11F_REV && (l = o.R11F_G11F_B10F)), t === o.RGBA) {
-			let e = a ? ee : K.getTransfer(i);
+			let e = a ? j : K.getTransfer(i);
 			n === o.FLOAT && (l = o.RGBA32F), n === o.HALF_FLOAT && (l = o.RGBA16F), n === o.UNSIGNED_BYTE && (l = e === "srgb" ? o.SRGB8_ALPHA8 : o.RGBA8), n === o.UNSIGNED_SHORT && c && (l = c.RGBA16_EXT), n === o.SHORT && c && (l = c.RGBA16_SNORM_EXT), n === o.UNSIGNED_SHORT_4_4_4_4 && (l = o.RGBA4), n === o.UNSIGNED_SHORT_5_5_5_1 && (l = o.RGB5_A1);
 		}
 		return (l === o.R16F || l === o.R32F || l === o.RG16F || l === o.RG32F || l === o.RGBA16F || l === o.RGBA32F) && s.get("EXT_color_buffer_float"), l;
 	}
 	function O(e, t) {
 		let n;
-		return e ? t === null || t === 1014 || t === 1020 ? n = o.DEPTH24_STENCIL8 : t === 1015 ? n = o.DEPTH32F_STENCIL8 : t === 1012 && (n = o.DEPTH24_STENCIL8, F("DepthTexture: 16 bit depth attachment is not supported with stencil. Using 24-bit attachment.")) : t === null || t === 1014 || t === 1020 ? n = o.DEPTH_COMPONENT24 : t === 1015 ? n = o.DEPTH_COMPONENT32F : t === 1012 && (n = o.DEPTH_COMPONENT16), n;
+		return e ? t === null || t === 1014 || t === 1020 ? n = o.DEPTH24_STENCIL8 : t === 1015 ? n = o.DEPTH32F_STENCIL8 : t === 1012 && (n = o.DEPTH24_STENCIL8, I("DepthTexture: 16 bit depth attachment is not supported with stencil. Using 24-bit attachment.")) : t === null || t === 1014 || t === 1020 ? n = o.DEPTH_COMPONENT24 : t === 1015 ? n = o.DEPTH_COMPONENT32F : t === 1012 && (n = o.DEPTH_COMPONENT16), n;
 	}
 	function k(e, t) {
 		return w(e) === !0 || e.isFramebufferTexture && e.minFilter !== 1003 && e.minFilter !== 1006 ? Math.log2(Math.max(t.width, t.height)) + 1 : e.mipmaps !== void 0 && e.mipmaps.length > 0 ? e.mipmaps.length : e.isCompressedTexture && Array.isArray(e.image) ? t.mipmaps.length : 1;
 	}
 	function A(e) {
 		let t = e.target;
-		t.removeEventListener("dispose", A), M(t), t.isVideoTexture && _.delete(t), t.isHTMLTexture && v.delete(t);
-	}
-	function j(e) {
-		let t = e.target;
-		t.removeEventListener("dispose", j), ne(t);
+		t.removeEventListener("dispose", A), N(t), t.isVideoTexture && _.delete(t), t.isHTMLTexture && v.delete(t);
 	}
 	function M(e) {
+		let t = e.target;
+		t.removeEventListener("dispose", M), te(t);
+	}
+	function N(e) {
 		let t = l.get(e);
 		if (t.__webglInit === void 0) return;
 		let n = e.source, r = b.get(n);
 		if (r) {
 			let i = r[t.__cacheKey];
-			i.usedTimes--, i.usedTimes === 0 && te(e), Object.keys(r).length === 0 && b.delete(n);
+			i.usedTimes--, i.usedTimes === 0 && ee(e), Object.keys(r).length === 0 && b.delete(n);
 		}
 		l.remove(e);
 	}
-	function te(e) {
+	function ee(e) {
 		let t = l.get(e);
 		o.deleteTexture(t.__webglTexture);
 		let n = e.source, r = b.get(n);
 		delete r[t.__cacheKey], f.memory.textures--;
 	}
-	function ne(e) {
+	function te(e) {
 		let t = l.get(e);
 		if (e.depthTexture && (e.depthTexture.dispose(), l.remove(e.depthTexture)), e.isWebGLCubeRenderTarget) for (let e = 0; e < 6; e++) {
 			if (Array.isArray(t.__webglFramebuffer[e])) for (let n = 0; n < t.__webglFramebuffer[e].length; n++) o.deleteFramebuffer(t.__webglFramebuffer[e][n]);
@@ -8782,30 +8782,30 @@ function us(o, s, c, l, u, d, f) {
 		}
 		l.remove(e);
 	}
-	let N = 0;
-	function ie() {
-		N = 0;
+	let P = 0;
+	function re() {
+		P = 0;
 	}
-	function P() {
-		return N;
+	function F() {
+		return P;
 	}
-	function ae(e) {
-		N = e;
+	function ie(e) {
+		P = e;
 	}
-	function oe() {
-		let e = N;
-		return e >= u.maxTextures && F("WebGLTextures: Trying to use " + e + " texture units while this GPU supports only " + u.maxTextures), N += 1, e;
+	function ae() {
+		let e = P;
+		return e >= u.maxTextures && I("WebGLTextures: Trying to use " + e + " texture units while this GPU supports only " + u.maxTextures), P += 1, e;
 	}
-	function L(e) {
+	function R(e) {
 		let t = [];
 		return t.push(e.wrapS), t.push(e.wrapT), t.push(e.wrapR || 0), t.push(e.magFilter), t.push(e.minFilter), t.push(e.anisotropy), t.push(e.internalFormat), t.push(e.format), t.push(e.type), t.push(e.generateMipmaps), t.push(e.premultiplyAlpha), t.push(e.flipY), t.push(e.unpackAlignment), t.push(e.colorSpace), t.join();
 	}
-	function se(e, t) {
+	function oe(e, t) {
 		let n = l.get(e);
 		if (e.isVideoTexture && Te(e), e.isRenderTargetTexture === !1 && e.isExternalTexture !== !0 && e.version > 0 && n.__version !== e.version) {
 			let r = e.image;
-			if (r === null) F("WebGLRenderer: Texture marked for update but no image data found.");
-			else if (r.complete === !1) F("WebGLRenderer: Texture marked for update but image is incomplete");
+			if (r === null) I("WebGLRenderer: Texture marked for update but no image data found.");
+			else if (r.complete === !1) I("WebGLRenderer: Texture marked for update but image is incomplete");
 			else {
 				H(n, e, t);
 				return;
@@ -8813,7 +8813,7 @@ function us(o, s, c, l, u, d, f) {
 		} else e.isExternalTexture && (n.__webglTexture = e.sourceTexture ? e.sourceTexture : null);
 		c.bindTexture(o.TEXTURE_2D, n.__webglTexture, o.TEXTURE0 + t);
 	}
-	function ce(e, t) {
+	function se(e, t) {
 		let n = l.get(e);
 		if (e.isRenderTargetTexture === !1 && e.version > 0 && n.__version !== e.version) {
 			H(n, e, t);
@@ -8821,7 +8821,7 @@ function us(o, s, c, l, u, d, f) {
 		} else e.isExternalTexture && (n.__webglTexture = e.sourceTexture ? e.sourceTexture : null);
 		c.bindTexture(o.TEXTURE_2D_ARRAY, n.__webglTexture, o.TEXTURE0 + t);
 	}
-	function R(e, t) {
+	function z(e, t) {
 		let n = l.get(e);
 		if (e.isRenderTargetTexture === !1 && e.version > 0 && n.__version !== e.version) {
 			H(n, e, t);
@@ -8829,7 +8829,7 @@ function us(o, s, c, l, u, d, f) {
 		}
 		c.bindTexture(o.TEXTURE_3D, n.__webglTexture, o.TEXTURE0 + t);
 	}
-	function z(e, t) {
+	function ce(e, t) {
 		let n = l.get(e);
 		if (e.isCubeDepthTexture !== !0 && e.version > 0 && n.__version !== e.version) {
 			me(n, e, t);
@@ -8859,7 +8859,7 @@ function us(o, s, c, l, u, d, f) {
 		517: o.NOTEQUAL
 	};
 	function V(e, t) {
-		if (t.type === 1015 && s.has("OES_texture_float_linear") === !1 && (t.magFilter === 1006 || t.magFilter === 1007 || t.magFilter === 1005 || t.magFilter === 1008 || t.minFilter === 1006 || t.minFilter === 1007 || t.minFilter === 1005 || t.minFilter === 1008) && F("WebGLRenderer: Unable to use linear filtering with floating point textures. OES_texture_float_linear not supported on this device."), o.texParameteri(e, o.TEXTURE_WRAP_S, le[t.wrapS]), o.texParameteri(e, o.TEXTURE_WRAP_T, le[t.wrapT]), (e === o.TEXTURE_3D || e === o.TEXTURE_2D_ARRAY) && o.texParameteri(e, o.TEXTURE_WRAP_R, le[t.wrapR]), o.texParameteri(e, o.TEXTURE_MAG_FILTER, ue[t.magFilter]), o.texParameteri(e, o.TEXTURE_MIN_FILTER, ue[t.minFilter]), t.compareFunction && (o.texParameteri(e, o.TEXTURE_COMPARE_MODE, o.COMPARE_REF_TO_TEXTURE), o.texParameteri(e, o.TEXTURE_COMPARE_FUNC, B[t.compareFunction])), s.has("EXT_texture_filter_anisotropic") === !0) {
+		if (t.type === 1015 && s.has("OES_texture_float_linear") === !1 && (t.magFilter === 1006 || t.magFilter === 1007 || t.magFilter === 1005 || t.magFilter === 1008 || t.minFilter === 1006 || t.minFilter === 1007 || t.minFilter === 1005 || t.minFilter === 1008) && I("WebGLRenderer: Unable to use linear filtering with floating point textures. OES_texture_float_linear not supported on this device."), o.texParameteri(e, o.TEXTURE_WRAP_S, le[t.wrapS]), o.texParameteri(e, o.TEXTURE_WRAP_T, le[t.wrapT]), (e === o.TEXTURE_3D || e === o.TEXTURE_2D_ARRAY) && o.texParameteri(e, o.TEXTURE_WRAP_R, le[t.wrapR]), o.texParameteri(e, o.TEXTURE_MAG_FILTER, ue[t.magFilter]), o.texParameteri(e, o.TEXTURE_MIN_FILTER, ue[t.minFilter]), t.compareFunction && (o.texParameteri(e, o.TEXTURE_COMPARE_MODE, o.COMPARE_REF_TO_TEXTURE), o.texParameteri(e, o.TEXTURE_COMPARE_FUNC, B[t.compareFunction])), s.has("EXT_texture_filter_anisotropic") === !0) {
 			if (t.magFilter === 1003 || t.minFilter !== 1005 && t.minFilter !== 1008 || t.type === 1015 && s.has("OES_texture_float_linear") === !1) return;
 			if (t.anisotropy > 1 || l.get(t).__currentAnisotropy) {
 				let n = s.get("EXT_texture_filter_anisotropic");
@@ -8872,14 +8872,14 @@ function us(o, s, c, l, u, d, f) {
 		e.__webglInit === void 0 && (e.__webglInit = !0, t.addEventListener("dispose", A));
 		let r = t.source, i = b.get(r);
 		i === void 0 && (i = {}, b.set(r, i));
-		let a = L(t);
+		let a = R(t);
 		if (a !== e.__cacheKey) {
 			i[a] === void 0 && (i[a] = {
 				texture: o.createTexture(),
 				usedTimes: 0
 			}, f.memory.textures++, n = !0), i[a].usedTimes++;
 			let r = i[e.__cacheKey];
-			r !== void 0 && (i[e.__cacheKey].usedTimes--, r.usedTimes === 0 && te(t)), e.__cacheKey = a, e.__webglTexture = i[a].texture;
+			r !== void 0 && (i[e.__cacheKey].usedTimes--, r.usedTimes === 0 && ee(t)), e.__cacheKey = a, e.__webglTexture = i[a].texture;
 		}
 		return n;
 	}
@@ -8941,11 +8941,11 @@ function us(o, s, c, l, u, d, f) {
 						t.clearLayerUpdates();
 					} else c.compressedTexSubImage3D(o.TEXTURE_2D_ARRAY, n, 0, 0, 0, m.width, m.height, e.depth, l, m.data);
 				} else c.compressedTexImage3D(o.TEXTURE_2D_ARRAY, n, p, m.width, m.height, e.depth, 0, m.data, 0, 0);
-				else F("WebGLRenderer: Attempt to load unsupported compressed texture format in .uploadTexture()");
+				else I("WebGLRenderer: Attempt to load unsupported compressed texture format in .uploadTexture()");
 				else _ ? b && c.texSubImage3D(o.TEXTURE_2D_ARRAY, n, 0, 0, 0, m.width, m.height, e.depth, l, f, m.data) : c.texImage3D(o.TEXTURE_2D_ARRAY, n, p, m.width, m.height, e.depth, 0, l, f, m.data);
 			} else {
 				_ && y && c.texStorage2D(o.TEXTURE_2D, x, p, h[0].width, h[0].height);
-				for (let e = 0, n = h.length; e < n; e++) m = h[e], t.format === 1023 ? _ ? b && c.texSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, f, m.data) : c.texImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, l, f, m.data) : l === null ? F("WebGLRenderer: Attempt to load unsupported compressed texture format in .uploadTexture()") : _ ? b && c.compressedTexSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, m.data) : c.compressedTexImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, m.data);
+				for (let e = 0, n = h.length; e < n; e++) m = h[e], t.format === 1023 ? _ ? b && c.texSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, f, m.data) : c.texImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, l, f, m.data) : l === null ? I("WebGLRenderer: Attempt to load unsupported compressed texture format in .uploadTexture()") : _ ? b && c.compressedTexSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, m.data) : c.compressedTexImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, m.data);
 			}
 			else if (t.isDataArrayTexture) if (_) {
 				if (y && c.texStorage3D(o.TEXTURE_2D_ARRAY, x, p, e.width, e.height, e.depth), b) if (t.layerUpdates.size > 0) {
@@ -9019,7 +9019,7 @@ function us(o, s, c, l, u, d, f) {
 					E = m[e].mipmaps;
 					for (let n = 0; n < E.length; n++) {
 						let r = E[n];
-						t.format === 1023 ? y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, 0, 0, r.width, r.height, g, _, r.data) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, v, r.width, r.height, 0, g, _, r.data) : g === null ? F("WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()") : y ? x && c.compressedTexSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, 0, 0, r.width, r.height, g, r.data) : c.compressedTexImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, v, r.width, r.height, 0, r.data);
+						t.format === 1023 ? y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, 0, 0, r.width, r.height, g, _, r.data) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, v, r.width, r.height, 0, g, _, r.data) : g === null ? I("WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()") : y ? x && c.compressedTexSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, 0, 0, r.width, r.height, g, r.data) : c.compressedTexImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, v, r.width, r.height, 0, r.data);
 					}
 				}
 			} else {
@@ -9078,7 +9078,7 @@ function us(o, s, c, l, u, d, f) {
 				t.depthTexture.format === 1026 ? r = o.DEPTH_COMPONENT24 : t.depthTexture.format === 1027 && (r = o.DEPTH24_STENCIL8);
 				for (let i = 0; i < 6; i++) o.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, r, t.width, t.height, 0, e, n, null);
 			}
-		} else se(t.depthTexture, 0);
+		} else oe(t.depthTexture, 0);
 		let a = i.__webglTexture, s = Ce(t), u = r ? o.TEXTURE_CUBE_MAP_POSITIVE_X + n : o.TEXTURE_2D, f = t.depthTexture.format === 1027 ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT;
 		if (t.depthTexture.format === 1026) we(t) ? p.framebufferTexture2DMultisampleEXT(o.FRAMEBUFFER, f, u, a, 0, s) : o.framebufferTexture2D(o.FRAMEBUFFER, f, u, a, 0);
 		else if (t.depthTexture.format === 1027) we(t) ? p.framebufferTexture2DMultisampleEXT(o.FRAMEBUFFER, f, u, a, 0, s) : o.framebufferTexture2D(o.FRAMEBUFFER, f, u, a, 0);
@@ -9124,7 +9124,7 @@ function us(o, s, c, l, u, d, f) {
 	}
 	function ve(e) {
 		let t = e.texture, n = l.get(e), r = l.get(t);
-		e.addEventListener("dispose", j);
+		e.addEventListener("dispose", M);
 		let i = e.textures, a = e.isWebGLCubeRenderTarget === !0, s = i.length > 1;
 		if (s || (r.__webglTexture === void 0 && (r.__webglTexture = o.createTexture()), r.__version = t.version, f.memory.textures++), a) {
 			n.__webglFramebuffer = [];
@@ -9223,12 +9223,12 @@ function us(o, s, c, l, u, d, f) {
 	}
 	function Ee(e, t) {
 		let n = e.colorSpace, r = e.format, i = e.type;
-		return e.isCompressedTexture === !0 || e.isVideoTexture === !0 || n !== "srgb-linear" && n !== "" && (K.getTransfer(n) === "srgb" ? (r !== 1023 || i !== 1009) && F("WebGLTextures: sRGB encoded textures have to use RGBAFormat and UnsignedByteType.") : I("WebGLTextures: Unsupported texture color space:", n)), t;
+		return e.isCompressedTexture === !0 || e.isVideoTexture === !0 || n !== "srgb-linear" && n !== "" && (K.getTransfer(n) === "srgb" ? (r !== 1023 || i !== 1009) && I("WebGLTextures: sRGB encoded textures have to use RGBAFormat and UnsignedByteType.") : L("WebGLTextures: Unsupported texture color space:", n)), t;
 	}
 	function De(e) {
 		return typeof HTMLImageElement < "u" && e instanceof HTMLImageElement ? (h.width = e.naturalWidth || e.width, h.height = e.naturalHeight || e.height) : typeof VideoFrame < "u" && e instanceof VideoFrame ? (h.width = e.displayWidth, h.height = e.displayHeight) : (h.width = e.width, h.height = e.height), h;
 	}
-	this.allocateTextureUnit = oe, this.resetTextureUnits = ie, this.getTextureUnits = P, this.setTextureUnits = ae, this.setTexture2D = se, this.setTexture2DArray = ce, this.setTexture3D = R, this.setTextureCube = z, this.rebindTextures = _e, this.setupRenderTarget = ve, this.updateRenderTargetMipmap = ye, this.updateMultisampleRenderTarget = Se, this.setupDepthRenderbuffer = G, this.setupFrameBufferTexture = W, this.useMultisampledRTT = we, this.isReversedDepthBuffer = function() {
+	this.allocateTextureUnit = ae, this.resetTextureUnits = re, this.getTextureUnits = F, this.setTextureUnits = ie, this.setTexture2D = oe, this.setTexture2DArray = se, this.setTexture3D = z, this.setTextureCube = ce, this.rebindTextures = _e, this.setupRenderTarget = ve, this.updateRenderTargetMipmap = ye, this.updateMultisampleRenderTarget = Se, this.setupDepthRenderbuffer = G, this.setupFrameBufferTexture = W, this.useMultisampledRTT = we, this.isReversedDepthBuffer = function() {
 		return c.buffers.depth.getReversed();
 	};
 }
@@ -9345,14 +9345,14 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 	getDepthTexture() {
 		return this.texture;
 	}
-}, hs = class extends R {
+}, hs = class extends z {
 	constructor(e, t) {
 		super();
 		let n = this, r = null, i = 1, a = null, s = "local-floor", l = 1, u = null, d = null, f = null, _ = null, v = null, y = null, b = typeof XRWebGLBinding < "u", x = new ms(), S = {}, C = t.getContextAttributes(), w = null, T = null, E = [], D = [], O = new U(), k = null, A = new Vr();
 		A.viewport = new je();
-		let ee = new Vr();
-		ee.viewport = new je();
-		let j = [A, ee], M = new Kr(), te = null, ne = null;
+		let j = new Vr();
+		j.viewport = new je();
+		let M = [A, j], N = new Kr(), ee = null, te = null;
 		this.cameraAutoUpdate = !0, this.enabled = !1, this.isPresenting = !1, this.getController = function(e) {
 			let t = E[e];
 			return t === void 0 && (t = new ct(), E[e] = t), t.getTargetRaySpace();
@@ -9363,7 +9363,7 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 			let t = E[e];
 			return t === void 0 && (t = new ct(), E[e] = t), t.getHandSpace();
 		};
-		function N(e) {
+		function P(e) {
 			let t = D.indexOf(e.inputSource);
 			if (t === -1) return;
 			let n = E[t];
@@ -9372,20 +9372,20 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 				data: e.inputSource
 			}));
 		}
-		function re() {
-			r.removeEventListener("select", N), r.removeEventListener("selectstart", N), r.removeEventListener("selectend", N), r.removeEventListener("squeeze", N), r.removeEventListener("squeezestart", N), r.removeEventListener("squeezeend", N), r.removeEventListener("end", re), r.removeEventListener("inputsourceschange", ie);
+		function ne() {
+			r.removeEventListener("select", P), r.removeEventListener("selectstart", P), r.removeEventListener("selectend", P), r.removeEventListener("squeeze", P), r.removeEventListener("squeezestart", P), r.removeEventListener("squeezeend", P), r.removeEventListener("end", ne), r.removeEventListener("inputsourceschange", re);
 			for (let e = 0; e < E.length; e++) {
 				let t = D[e];
 				t !== null && (D[e] = null, E[e].disconnect(t));
 			}
-			te = null, ne = null, x.reset();
+			ee = null, te = null, x.reset();
 			for (let e in S) delete S[e];
-			e.setRenderTarget(w), v = null, _ = null, f = null, r = null, T = null, R.stop(), n.isPresenting = !1, e.setPixelRatio(k), e.setSize(O.width, O.height, !1), n.dispatchEvent({ type: "sessionend" });
+			e.setRenderTarget(w), v = null, _ = null, f = null, r = null, T = null, z.stop(), n.isPresenting = !1, e.setPixelRatio(k), e.setSize(O.width, O.height, !1), n.dispatchEvent({ type: "sessionend" });
 		}
 		this.setFramebufferScaleFactor = function(e) {
-			i = e, n.isPresenting === !0 && F("WebXRManager: Cannot change framebuffer scale while presenting.");
+			i = e, n.isPresenting === !0 && I("WebXRManager: Cannot change framebuffer scale while presenting.");
 		}, this.setReferenceSpaceType = function(e) {
-			s = e, n.isPresenting === !0 && F("WebXRManager: Cannot change reference space type while presenting.");
+			s = e, n.isPresenting === !0 && I("WebXRManager: Cannot change reference space type while presenting.");
 		}, this.getReferenceSpace = function() {
 			return u || a;
 		}, this.setReferenceSpace = function(e) {
@@ -9400,7 +9400,7 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 			return r;
 		}, this.setSession = async function(d) {
 			if (r = d, r !== null) {
-				if (w = e.getRenderTarget(), r.addEventListener("select", N), r.addEventListener("selectstart", N), r.addEventListener("selectend", N), r.addEventListener("squeeze", N), r.addEventListener("squeezestart", N), r.addEventListener("squeezeend", N), r.addEventListener("end", re), r.addEventListener("inputsourceschange", ie), C.xrCompatible !== !0 && await t.makeXRCompatible(), k = e.getPixelRatio(), e.getSize(O), b && "createProjectionLayer" in XRWebGLBinding.prototype) {
+				if (w = e.getRenderTarget(), r.addEventListener("select", P), r.addEventListener("selectstart", P), r.addEventListener("selectend", P), r.addEventListener("squeeze", P), r.addEventListener("squeezestart", P), r.addEventListener("squeezeend", P), r.addEventListener("end", ne), r.addEventListener("inputsourceschange", re), C.xrCompatible !== !0 && await t.makeXRCompatible(), k = e.getPixelRatio(), e.getSize(O), b && "createProjectionLayer" in XRWebGLBinding.prototype) {
 					let n = null, a = null, s = null;
 					C.depth && (s = C.stencil ? t.DEPTH24_STENCIL8 : t.DEPTH_COMPONENT24, n = C.stencil ? g : h, a = C.stencil ? p : c);
 					let l = {
@@ -9435,14 +9435,14 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 						resolveStencilBuffer: v.ignoreDepthValues === !1
 					});
 				}
-				T.isXRRenderTarget = !0, this.setFoveation(l), u = null, a = await r.requestReferenceSpace(s), R.setContext(r), R.start(), n.isPresenting = !0, n.dispatchEvent({ type: "sessionstart" });
+				T.isXRRenderTarget = !0, this.setFoveation(l), u = null, a = await r.requestReferenceSpace(s), z.setContext(r), z.start(), n.isPresenting = !0, n.dispatchEvent({ type: "sessionstart" });
 			}
 		}, this.getEnvironmentBlendMode = function() {
 			if (r !== null) return r.environmentBlendMode;
 		}, this.getDepthTexture = function() {
 			return x.getDepthTexture();
 		};
-		function ie(e) {
+		function re(e) {
 			for (let t = 0; t < e.removed.length; t++) {
 				let n = e.removed[t], r = D.indexOf(n);
 				r >= 0 && (D[r] = null, E[r].disconnect(n));
@@ -9463,36 +9463,36 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 				i && i.connect(n);
 			}
 		}
-		let P = new W(), ae = new W();
-		function oe(e, t, n) {
-			P.setFromMatrixPosition(t.matrixWorld), ae.setFromMatrixPosition(n.matrixWorld);
-			let r = P.distanceTo(ae), i = t.projectionMatrix.elements, a = n.projectionMatrix.elements, o = i[14] / (i[10] - 1), s = i[14] / (i[10] + 1), c = (i[9] + 1) / i[5], l = (i[9] - 1) / i[5], u = (i[8] - 1) / i[0], d = (a[8] + 1) / a[0], f = o * u, p = o * d, m = r / (-u + d), h = m * -u;
+		let F = new W(), ie = new W();
+		function ae(e, t, n) {
+			F.setFromMatrixPosition(t.matrixWorld), ie.setFromMatrixPosition(n.matrixWorld);
+			let r = F.distanceTo(ie), i = t.projectionMatrix.elements, a = n.projectionMatrix.elements, o = i[14] / (i[10] - 1), s = i[14] / (i[10] + 1), c = (i[9] + 1) / i[5], l = (i[9] - 1) / i[5], u = (i[8] - 1) / i[0], d = (a[8] + 1) / a[0], f = o * u, p = o * d, m = r / (-u + d), h = m * -u;
 			if (t.matrixWorld.decompose(e.position, e.quaternion, e.scale), e.translateX(h), e.translateZ(m), e.matrixWorld.compose(e.position, e.quaternion, e.scale), e.matrixWorldInverse.copy(e.matrixWorld).invert(), i[10] === -1) e.projectionMatrix.copy(t.projectionMatrix), e.projectionMatrixInverse.copy(t.projectionMatrixInverse);
 			else {
 				let t = o + m, n = s + m, i = f - h, a = p + (r - h), u = c * s / n * t, d = l * s / n * t;
 				e.projectionMatrix.makePerspective(i, a, u, d, t, n), e.projectionMatrixInverse.copy(e.projectionMatrix).invert();
 			}
 		}
-		function I(e, t) {
+		function L(e, t) {
 			t === null ? e.matrixWorld.copy(e.matrix) : e.matrixWorld.multiplyMatrices(t.matrixWorld, e.matrix), e.matrixWorldInverse.copy(e.matrixWorld).invert();
 		}
 		this.updateCamera = function(e) {
 			if (r === null) return;
 			let t = e.near, n = e.far;
-			x.texture !== null && (x.depthNear > 0 && (t = x.depthNear), x.depthFar > 0 && (n = x.depthFar)), M.near = ee.near = A.near = t, M.far = ee.far = A.far = n, (te !== M.near || ne !== M.far) && (r.updateRenderState({
-				depthNear: M.near,
-				depthFar: M.far
-			}), te = M.near, ne = M.far), M.layers.mask = e.layers.mask | 6, A.layers.mask = M.layers.mask & -5, ee.layers.mask = M.layers.mask & -3;
-			let i = e.parent, a = M.cameras;
-			I(M, i);
-			for (let e = 0; e < a.length; e++) I(a[e], i);
-			a.length === 2 ? oe(M, A, ee) : M.projectionMatrix.copy(A.projectionMatrix), L(e, M, i);
+			x.texture !== null && (x.depthNear > 0 && (t = x.depthNear), x.depthFar > 0 && (n = x.depthFar)), N.near = j.near = A.near = t, N.far = j.far = A.far = n, (ee !== N.near || te !== N.far) && (r.updateRenderState({
+				depthNear: N.near,
+				depthFar: N.far
+			}), ee = N.near, te = N.far), N.layers.mask = e.layers.mask | 6, A.layers.mask = N.layers.mask & -5, j.layers.mask = N.layers.mask & -3;
+			let i = e.parent, a = N.cameras;
+			L(N, i);
+			for (let e = 0; e < a.length; e++) L(a[e], i);
+			a.length === 2 ? ae(N, A, j) : N.projectionMatrix.copy(A.projectionMatrix), R(e, N, i);
 		};
-		function L(e, t, n) {
+		function R(e, t, n) {
 			n === null ? e.matrix.copy(t.matrixWorld) : (e.matrix.copy(n.matrixWorld), e.matrix.invert(), e.matrix.multiply(t.matrixWorld)), e.matrix.decompose(e.position, e.quaternion, e.scale), e.updateMatrixWorld(!0), e.projectionMatrix.copy(t.projectionMatrix), e.projectionMatrixInverse.copy(t.projectionMatrixInverse), e.isPerspectiveCamera && (e.fov = ue * 2 * Math.atan(1 / e.projectionMatrix.elements[5]), e.zoom = 1);
 		}
 		this.getCamera = function() {
-			return M;
+			return N;
 		}, this.getFoveation = function() {
 			if (!(_ === null && v === null)) return l;
 		}, this.setFoveation = function(e) {
@@ -9500,17 +9500,17 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 		}, this.hasDepthSensing = function() {
 			return x.texture !== null;
 		}, this.getDepthSensingMesh = function() {
-			return x.getMesh(M);
+			return x.getMesh(N);
 		}, this.getCameraTexture = function(e) {
 			return S[e];
 		};
-		let se = null;
-		function ce(t, i) {
+		let oe = null;
+		function se(t, i) {
 			if (d = i.getViewerPose(u || a), y = i, d !== null) {
 				let t = d.views;
 				v !== null && (e.setRenderTargetFramebuffer(T, v.framebuffer), e.setRenderTarget(T));
 				let i = !1;
-				t.length !== M.cameras.length && (M.cameras.length = 0, i = !0);
+				t.length !== N.cameras.length && (N.cameras.length = 0, i = !0);
 				for (let n = 0; n < t.length; n++) {
 					let r = t[n], a = null;
 					if (v !== null) a = v.getViewport(r);
@@ -9518,8 +9518,8 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 						let t = f.getViewSubImage(_, r);
 						a = t.viewport, n === 0 && (e.setRenderTargetTextures(T, t.colorTexture, t.depthStencilTexture), e.setRenderTarget(T));
 					}
-					let o = j[n];
-					o === void 0 && (o = new Vr(), o.layers.enable(n), o.viewport = new je(), j[n] = o), o.matrix.fromArray(r.transform.matrix), o.matrix.decompose(o.position, o.quaternion, o.scale), o.projectionMatrix.fromArray(r.projectionMatrix), o.projectionMatrixInverse.copy(o.projectionMatrix).invert(), o.viewport.set(a.x, a.y, a.width, a.height), n === 0 && (M.matrix.copy(o.matrix), M.matrix.decompose(M.position, M.quaternion, M.scale)), i === !0 && M.cameras.push(o);
+					let o = M[n];
+					o === void 0 && (o = new Vr(), o.layers.enable(n), o.viewport = new je(), M[n] = o), o.matrix.fromArray(r.transform.matrix), o.matrix.decompose(o.position, o.quaternion, o.scale), o.projectionMatrix.fromArray(r.projectionMatrix), o.projectionMatrixInverse.copy(o.projectionMatrix).invert(), o.viewport.set(a.x, a.y, a.width, a.height), n === 0 && (N.matrix.copy(o.matrix), N.matrix.decompose(N.position, N.quaternion, N.scale)), i === !0 && N.cameras.push(o);
 				}
 				let a = r.enabledFeatures;
 				if (a && a.includes("depth-sensing") && r.depthUsage == "gpu-optimized" && b) {
@@ -9544,14 +9544,14 @@ var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "
 				let t = D[e], n = E[e];
 				t !== null && n !== void 0 && n.update(t, i, u || a);
 			}
-			se && se(t, i), i.detectedPlanes && n.dispatchEvent({
+			oe && oe(t, i), i.detectedPlanes && n.dispatchEvent({
 				type: "planesdetected",
 				data: i
 			}), y = null;
 		}
-		let R = new si();
-		R.setAnimationLoop(ce), this.setAnimationLoop = function(e) {
-			se = e;
+		let z = new si();
+		z.setAnimationLoop(se), this.setAnimationLoop = function(e) {
+			oe = e;
 		}, this.dispose = function() {};
 	}
 }, gs = /*@__PURE__*/ new Fe(), _s = /*@__PURE__*/ new G();
@@ -9629,7 +9629,7 @@ function ys(e, t, n, r) {
 	}
 	function d() {
 		for (let e = 0; e < s; e++) if (o.indexOf(e) === -1) return o.push(e), e;
-		return I("WebGLRenderer: Maximum number of simultaneously usable uniforms groups reached."), 0;
+		return L("WebGLRenderer: Maximum number of simultaneously usable uniforms groups reached."), 0;
 	}
 	function f(t) {
 		let n = i[t.id], r = t.uniforms, a = t.__cache;
@@ -9689,7 +9689,7 @@ function ys(e, t, n, r) {
 			boundary: 0,
 			storage: 0
 		};
-		return typeof e == "number" || typeof e == "boolean" ? (t.boundary = 4, t.storage = 4) : e.isVector2 ? (t.boundary = 8, t.storage = 8) : e.isVector3 || e.isColor ? (t.boundary = 16, t.storage = 12) : e.isVector4 ? (t.boundary = 16, t.storage = 16) : e.isMatrix3 ? (t.boundary = 48, t.storage = 48) : e.isMatrix4 ? (t.boundary = 64, t.storage = 64) : e.isTexture ? F("WebGLRenderer: Texture samplers can not be part of an uniforms group.") : ArrayBuffer.isView(e) ? (t.boundary = 16, t.storage = e.byteLength) : F("WebGLRenderer: Unsupported uniform value type.", e), t;
+		return typeof e == "number" || typeof e == "boolean" ? (t.boundary = 4, t.storage = 4) : e.isVector2 ? (t.boundary = 8, t.storage = 8) : e.isVector3 || e.isColor ? (t.boundary = 16, t.storage = 12) : e.isVector4 ? (t.boundary = 16, t.storage = 16) : e.isMatrix3 ? (t.boundary = 48, t.storage = 48) : e.isMatrix4 ? (t.boundary = 64, t.storage = 64) : e.isTexture ? I("WebGLRenderer: Texture samplers can not be part of an uniforms group.") : ArrayBuffer.isView(e) ? (t.boundary = 16, t.storage = e.byteLength) : I("WebGLRenderer: Unsupported uniform value type.", e), t;
 	}
 	function v(t) {
 		let n = t.target;
@@ -10226,7 +10226,7 @@ function Ss() {
 }
 var Cs = class {
 	constructor(e = {}) {
-		let { canvas: t = ie(), context: n = null, depth: r = !0, stencil: i = !1, alpha: l = !1, antialias: m = !1, premultipliedAlpha: h = !0, preserveDrawingBuffer: g = !1, powerPreference: _ = "default", failIfMajorPerformanceCaveat: y = !1, reversedDepthBuffer: S = !1, outputBufferType: C = o } = e;
+		let { canvas: t = re(), context: n = null, depth: r = !0, stencil: i = !1, alpha: l = !1, antialias: m = !1, premultipliedAlpha: h = !0, preserveDrawingBuffer: g = !1, powerPreference: _ = "default", failIfMajorPerformanceCaveat: y = !1, reversedDepthBuffer: S = !1, outputBufferType: C = o } = e;
 		this.isWebGLRenderer = !0;
 		let w;
 		if (n !== null) {
@@ -10244,12 +10244,12 @@ var Cs = class {
 			p,
 			d,
 			f
-		]), O = /* @__PURE__ */ new Uint32Array(4), A = /* @__PURE__ */ new Int32Array(4), ee = new W(), j = null, M = null, ne = [], N = [], re = null;
+		]), O = /* @__PURE__ */ new Uint32Array(4), A = /* @__PURE__ */ new Int32Array(4), j = new W(), M = null, N = null, te = [], P = [], ne = null;
 		this.domElement = t, this.debug = {
 			checkShaderErrors: !0,
 			onShaderError: null
 		}, this.autoClear = !0, this.autoClearColor = !0, this.autoClearDepth = !0, this.autoClearStencil = !0, this.sortObjects = !0, this.clippingPlanes = [], this.localClippingEnabled = !1, this.toneMapping = 0, this.toneMappingExposure = 1, this.transmissionResolutionScale = 1;
-		let P = this, oe = !1, L = null, ce = null, R = null, z = null;
+		let F = this, ae = !1, R = null, se = null, z = null, ce = null;
 		this._outputColorSpace = k;
 		let le = 0, ue = 0, B = null, V = -1, de = null, fe = new je(), pe = new je(), H = null, U = new Z(0), me = 0, he = t.width, ge = t.height, G = 1, _e = null, ve = null, ye = new je(0, 0, he, ge), be = new je(0, 0, he, ge), xe = !1, Se = new Qn(), Ce = !1, we = !1, Te = new Fe(), Ee = new W(), De = new je(), Oe = {
 			background: null,
@@ -10281,14 +10281,14 @@ var Cs = class {
 				if (q = Ne(t, e), q === null) throw Ne(t) ? Error("THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.") : Error("THREE.WebGLRenderer: Error creating WebGL context.");
 			}
 		} catch (e) {
-			throw I("WebGLRenderer: " + e.message), e;
+			throw L("WebGLRenderer: " + e.message), e;
 		}
 		let Pe, Ie, J, Le, Y, X, Re, ze, Be, Ve, He, Ue, We, Ge, Ke, qe, Je, Ye, Xe, Ze, Qe, $e, et;
 		function tt() {
-			Pe = new Bi(q), Pe.init(), Qe = new ds(q, Pe), Ie = new gi(q, Pe, e, Qe), J = new ls(q, Pe), Ie.reversedDepthBuffer && S && J.buffers.depth.setReversed(!0), ce = q.createFramebuffer(), R = q.createFramebuffer(), z = q.createFramebuffer(), Le = new Ui(q), Y = new Uo(), X = new us(q, Pe, J, Y, Ie, Qe, Le), Re = new zi(P), ze = new ci(q), $e = new mi(q, ze), Be = new Vi(q, ze, Le, $e), Ve = new Gi(q, Be, ze, $e, Le), Ye = new Wi(q, Ie, X), Ke = new _i(Y), He = new Ho(P, Re, Pe, Ie, $e, Ke), Ue = new vs(P, Y), We = new qo(), Ge = new es(Pe), Je = new pi(P, Re, J, Ve, w, h), qe = new cs(P, Ve, Ie), et = new ys(q, Le, Ie, J), Xe = new hi(q, Pe, Le), Ze = new Hi(q, Pe, Le), Le.programs = He.programs, P.capabilities = Ie, P.extensions = Pe, P.properties = Y, P.renderLists = We, P.shadowMap = qe, P.state = J, P.info = Le;
+			Pe = new Bi(q), Pe.init(), Qe = new ds(q, Pe), Ie = new gi(q, Pe, e, Qe), J = new ls(q, Pe), Ie.reversedDepthBuffer && S && J.buffers.depth.setReversed(!0), se = q.createFramebuffer(), z = q.createFramebuffer(), ce = q.createFramebuffer(), Le = new Ui(q), Y = new Uo(), X = new us(q, Pe, J, Y, Ie, Qe, Le), Re = new zi(F), ze = new ci(q), $e = new mi(q, ze), Be = new Vi(q, ze, Le, $e), Ve = new Gi(q, Be, ze, $e, Le), Ye = new Wi(q, Ie, X), Ke = new _i(Y), He = new Ho(F, Re, Pe, Ie, $e, Ke), Ue = new vs(F, Y), We = new qo(), Ge = new es(Pe), Je = new pi(F, Re, J, Ve, w, h), qe = new cs(F, Ve, Ie), et = new ys(q, Le, Ie, J), Xe = new hi(q, Pe, Le), Ze = new Hi(q, Pe, Le), Le.programs = He.programs, F.capabilities = Ie, F.extensions = Pe, F.properties = Y, F.renderLists = We, F.shadowMap = qe, F.state = J, F.info = Le;
 		}
-		tt(), T !== 1009 && (re = new qi(T, t.width, t.height, m, r, i));
-		let nt = new hs(P, q);
+		tt(), T !== 1009 && (ne = new qi(T, t.width, t.height, m, r, i));
+		let nt = new hs(F, q);
 		this.xr = nt, this.getContext = function() {
 			return q;
 		}, this.getContextAttributes = function() {
@@ -10307,26 +10307,26 @@ var Cs = class {
 			return e.set(he, ge);
 		}, this.setSize = function(e, n, r = !0) {
 			if (nt.isPresenting) {
-				F("WebGLRenderer: Can't change size while VR device is presenting.");
+				I("WebGLRenderer: Can't change size while VR device is presenting.");
 				return;
 			}
-			he = e, ge = n, t.width = Math.floor(e * G), t.height = Math.floor(n * G), r === !0 && (t.style.width = e + "px", t.style.height = n + "px"), re !== null && re.setSize(t.width, t.height), this.setViewport(0, 0, e, n);
+			he = e, ge = n, t.width = Math.floor(e * G), t.height = Math.floor(n * G), r === !0 && (t.style.width = e + "px", t.style.height = n + "px"), ne !== null && ne.setSize(t.width, t.height), this.setViewport(0, 0, e, n);
 		}, this.getDrawingBufferSize = function(e) {
 			return e.set(he * G, ge * G).floor();
 		}, this.setDrawingBufferSize = function(e, n, r) {
 			he = e, ge = n, G = r, t.width = Math.floor(e * r), t.height = Math.floor(n * r), this.setViewport(0, 0, e, n);
 		}, this.setEffects = function(e) {
 			if (T === 1009) {
-				I("WebGLRenderer: setEffects() requires outputBufferType set to HalfFloatType or FloatType.");
+				L("WebGLRenderer: setEffects() requires outputBufferType set to HalfFloatType or FloatType.");
 				return;
 			}
 			if (e) {
 				for (let t = 0; t < e.length; t++) if (e[t].isOutputPass === !0) {
-					F("WebGLRenderer: OutputPass is not needed in setEffects(). Tone mapping and color space conversion are applied automatically.");
+					I("WebGLRenderer: OutputPass is not needed in setEffects(). Tone mapping and color space conversion are applied automatically.");
 					break;
 				}
 			}
-			re.setEffects(e || []);
+			ne.setEffects(e || []);
 		}, this.getCurrentViewport = function(e) {
 			return e.copy(fe);
 		}, this.getViewport = function(e) {
@@ -10374,20 +10374,20 @@ var Cs = class {
 		}, this.clearStencil = function() {
 			this.clear(!1, !1, !0);
 		}, this.setNodesHandler = function(e) {
-			e.setRenderer(this), L = e;
+			e.setRenderer(this), R = e;
 		}, this.dispose = function() {
 			t.removeEventListener("webglcontextlost", rt, !1), t.removeEventListener("webglcontextrestored", it, !1), t.removeEventListener("webglcontextcreationerror", at, !1), Je.dispose(), We.dispose(), Ge.dispose(), Y.dispose(), Re.dispose(), Ve.dispose(), $e.dispose(), et.dispose(), He.dispose(), nt.dispose(), nt.removeEventListener("sessionstart", ft), nt.removeEventListener("sessionend", pt), mt.stop();
 		};
 		function rt(e) {
-			e.preventDefault(), ae("WebGLRenderer: Context Lost."), oe = !0;
+			e.preventDefault(), ie("WebGLRenderer: Context Lost."), ae = !0;
 		}
 		function it() {
-			ae("WebGLRenderer: Context Restored."), oe = !1;
+			ie("WebGLRenderer: Context Restored."), ae = !1;
 			let e = Le.autoReset, t = qe.enabled, n = qe.autoUpdate, r = qe.needsUpdate, i = qe.type;
 			tt(), Le.autoReset = e, qe.enabled = t, qe.autoUpdate = n, qe.needsUpdate = r, qe.type = i;
 		}
 		function at(e) {
-			I("WebGLRenderer: A WebGL context could not be created. Reason: ", e.statusMessage);
+			L("WebGLRenderer: A WebGL context could not be created. Reason: ", e.statusMessage);
 		}
 		function ot(e) {
 			let t = e.target;
@@ -10437,11 +10437,11 @@ var Cs = class {
 			e.transparent === !0 && e.side === 2 && e.forceSinglePass === !1 ? (e.side = 1, e.needsUpdate = !0, bt(e, t, n), e.side = 0, e.needsUpdate = !0, bt(e, t, n), e.side = 2) : bt(e, t, n);
 		}
 		this.compile = function(e, t, n = null) {
-			n === null && (n = e), M = Ge.get(n), M.init(t), N.push(M), n.traverseVisible(function(e) {
-				e.isLight && e.layers.test(t.layers) && (M.pushLight(e), e.castShadow && M.pushShadow(e));
+			n === null && (n = e), N = Ge.get(n), N.init(t), P.push(N), n.traverseVisible(function(e) {
+				e.isLight && e.layers.test(t.layers) && (N.pushLight(e), e.castShadow && N.pushShadow(e));
 			}), e !== n && e.traverseVisible(function(e) {
-				e.isLight && e.layers.test(t.layers) && (M.pushLight(e), e.castShadow && M.pushShadow(e));
-			}), M.setupLights();
+				e.isLight && e.layers.test(t.layers) && (N.pushLight(e), e.castShadow && N.pushShadow(e));
+			}), N.setupLights();
 			let r = /* @__PURE__ */ new Set();
 			return e.traverse(function(e) {
 				if (!(e.isMesh || e.isPoints || e.isLine || e.isSprite)) return;
@@ -10451,7 +10451,7 @@ var Cs = class {
 					lt(a, n, e), r.add(a);
 				}
 				else lt(t, n, e), r.add(t);
-			}), M = N.pop(), r;
+			}), N = P.pop(), r;
 		}, this.compileAsync = function(e, t, n = null) {
 			let r = this.compile(e, t, n);
 			return new Promise((t) => {
@@ -10482,21 +10482,21 @@ var Cs = class {
 			ut = e, nt.setAnimationLoop(e), e === null ? mt.stop() : mt.start();
 		}, nt.addEventListener("sessionstart", ft), nt.addEventListener("sessionend", pt), this.render = function(e, t) {
 			if (t !== void 0 && t.isCamera !== !0) {
-				I("WebGLRenderer.render: camera is not an instance of THREE.Camera.");
+				L("WebGLRenderer.render: camera is not an instance of THREE.Camera.");
 				return;
 			}
-			if (oe === !0) return;
-			L !== null && L.renderStart(e, t);
-			let n = nt.enabled === !0 && nt.isPresenting === !0, r = re !== null && (B === null || n) && re.begin(P, B);
-			if (e.matrixWorldAutoUpdate === !0 && e.updateMatrixWorld(), t.parent === null && t.matrixWorldAutoUpdate === !0 && t.updateMatrixWorld(), nt.enabled === !0 && nt.isPresenting === !0 && (re === null || re.isCompositing() === !1) && (nt.cameraAutoUpdate === !0 && nt.updateCamera(t), t = nt.getCamera()), e.isScene === !0 && e.onBeforeRender(P, e, t, B), M = Ge.get(e, N.length), M.init(t), M.state.textureUnits = X.getTextureUnits(), N.push(M), Te.multiplyMatrices(t.projectionMatrix, t.matrixWorldInverse), Se.setFromProjectionMatrix(Te, te, t.reversedDepth), we = this.localClippingEnabled, Ce = Ke.init(this.clippingPlanes, we), j = We.get(e, ne.length), j.init(), ne.push(j), nt.enabled === !0 && nt.isPresenting === !0) {
-				let e = P.xr.getDepthSensingMesh();
-				e !== null && ht(e, t, -Infinity, P.sortObjects);
+			if (ae === !0) return;
+			R !== null && R.renderStart(e, t);
+			let n = nt.enabled === !0 && nt.isPresenting === !0, r = ne !== null && (B === null || n) && ne.begin(F, B);
+			if (e.matrixWorldAutoUpdate === !0 && e.updateMatrixWorld(), t.parent === null && t.matrixWorldAutoUpdate === !0 && t.updateMatrixWorld(), nt.enabled === !0 && nt.isPresenting === !0 && (ne === null || ne.isCompositing() === !1) && (nt.cameraAutoUpdate === !0 && nt.updateCamera(t), t = nt.getCamera()), e.isScene === !0 && e.onBeforeRender(F, e, t, B), N = Ge.get(e, P.length), N.init(t), N.state.textureUnits = X.getTextureUnits(), P.push(N), Te.multiplyMatrices(t.projectionMatrix, t.matrixWorldInverse), Se.setFromProjectionMatrix(Te, ee, t.reversedDepth), we = this.localClippingEnabled, Ce = Ke.init(this.clippingPlanes, we), M = We.get(e, te.length), M.init(), te.push(M), nt.enabled === !0 && nt.isPresenting === !0) {
+				let e = F.xr.getDepthSensingMesh();
+				e !== null && ht(e, t, -Infinity, F.sortObjects);
 			}
-			ht(e, t, 0, P.sortObjects), j.finish(), P.sortObjects === !0 && j.sort(_e, ve, t.reversedDepth), ke = nt.enabled === !1 || nt.isPresenting === !1 || nt.hasDepthSensing() === !1, ke && Je.addToRenderList(j, e), this.info.render.frame++, this.info.autoReset === !0 && this.info.reset(), Ce === !0 && Ke.beginShadows();
-			let i = M.state.shadowsArray;
-			if (qe.render(i, e, t), Ce === !0 && Ke.endShadows(), (r && re.hasRenderPass()) === !1) {
-				let n = j.opaque, r = j.transmissive;
-				if (M.setupLights(), t.isArrayCamera) {
+			ht(e, t, 0, F.sortObjects), M.finish(), F.sortObjects === !0 && M.sort(_e, ve, t.reversedDepth), ke = nt.enabled === !1 || nt.isPresenting === !1 || nt.hasDepthSensing() === !1, ke && Je.addToRenderList(M, e), this.info.render.frame++, this.info.autoReset === !0 && this.info.reset(), Ce === !0 && Ke.beginShadows();
+			let i = N.state.shadowsArray;
+			if (qe.render(i, e, t), Ce === !0 && Ke.endShadows(), (r && ne.hasRenderPass()) === !1) {
+				let n = M.opaque, r = M.transmissive;
+				if (N.setupLights(), t.isArrayCamera) {
 					let i = t.cameras;
 					if (r.length > 0) for (let t = 0, a = i.length; t < a; t++) {
 						let a = i[t];
@@ -10505,24 +10505,24 @@ var Cs = class {
 					ke && Je.render(e);
 					for (let t = 0, n = i.length; t < n; t++) {
 						let n = i[t];
-						gt(j, e, n, n.viewport);
+						gt(M, e, n, n.viewport);
 					}
-				} else r.length > 0 && _t(n, r, e, t), ke && Je.render(e), gt(j, e, t);
+				} else r.length > 0 && _t(n, r, e, t), ke && Je.render(e), gt(M, e, t);
 			}
-			B !== null && ue === 0 && (X.updateMultisampleRenderTarget(B), X.updateRenderTargetMipmap(B)), r && re.end(P), e.isScene === !0 && e.onAfterRender(P, e, t), $e.resetDefaultState(), V = -1, de = null, N.pop(), N.length > 0 ? (M = N[N.length - 1], X.setTextureUnits(M.state.textureUnits), Ce === !0 && Ke.setGlobalState(P.clippingPlanes, M.state.camera)) : M = null, ne.pop(), j = ne.length > 0 ? ne[ne.length - 1] : null, L !== null && L.renderEnd();
+			B !== null && ue === 0 && (X.updateMultisampleRenderTarget(B), X.updateRenderTargetMipmap(B)), r && ne.end(F), e.isScene === !0 && e.onAfterRender(F, e, t), $e.resetDefaultState(), V = -1, de = null, P.pop(), P.length > 0 ? (N = P[P.length - 1], X.setTextureUnits(N.state.textureUnits), Ce === !0 && Ke.setGlobalState(F.clippingPlanes, N.state.camera)) : N = null, te.pop(), M = te.length > 0 ? te[te.length - 1] : null, R !== null && R.renderEnd();
 		};
 		function ht(e, t, n, r) {
 			if (e.visible === !1) return;
 			if (e.layers.test(t.layers)) {
 				if (e.isGroup) n = e.renderOrder;
 				else if (e.isLOD) e.autoUpdate === !0 && e.update(t);
-				else if (e.isLightProbeGrid) M.pushLightProbeGrid(e);
-				else if (e.isLight) M.pushLight(e), e.castShadow && M.pushShadow(e);
+				else if (e.isLightProbeGrid) N.pushLightProbeGrid(e);
+				else if (e.isLight) N.pushLight(e), e.castShadow && N.pushShadow(e);
 				else if (e.isSprite) {
 					if (!e.frustumCulled || Se.intersectsSprite(e)) {
 						r && De.setFromMatrixPosition(e.matrixWorld).applyMatrix4(Te);
 						let t = Ve.update(e), i = e.material;
-						i.visible && j.push(e, t, i, n, De.z, null);
+						i.visible && M.push(e, t, i, n, De.z, null);
 					}
 				} else if ((e.isMesh || e.isLine || e.isPoints) && (!e.frustumCulled || Se.intersectsObject(e))) {
 					let t = Ve.update(e), i = e.material;
@@ -10530,9 +10530,9 @@ var Cs = class {
 						let r = t.groups;
 						for (let a = 0, o = r.length; a < o; a++) {
 							let o = r[a], s = i[o.materialIndex];
-							s && s.visible && j.push(e, t, s, n, De.z, o);
+							s && s.visible && M.push(e, t, s, n, De.z, o);
 						}
-					} else i.visible && j.push(e, t, i, n, De.z, null);
+					} else i.visible && M.push(e, t, i, n, De.z, null);
 				}
 			}
 			let i = e.children;
@@ -10540,13 +10540,13 @@ var Cs = class {
 		}
 		function gt(e, t, n, r) {
 			let { opaque: i, transmissive: a, transparent: o } = e;
-			M.setupLightsView(n), Ce === !0 && Ke.setGlobalState(P.clippingPlanes, n), r && J.viewport(fe.copy(r)), i.length > 0 && vt(i, t, n), a.length > 0 && vt(a, t, n), o.length > 0 && vt(o, t, n), J.buffers.depth.setTest(!0), J.buffers.depth.setMask(!0), J.buffers.color.setMask(!0), J.setPolygonOffset(!1);
+			N.setupLightsView(n), Ce === !0 && Ke.setGlobalState(F.clippingPlanes, n), r && J.viewport(fe.copy(r)), i.length > 0 && vt(i, t, n), a.length > 0 && vt(a, t, n), o.length > 0 && vt(o, t, n), J.buffers.depth.setTest(!0), J.buffers.depth.setMask(!0), J.buffers.color.setMask(!0), J.setPolygonOffset(!1);
 		}
 		function _t(e, t, n, r) {
 			if ((n.isScene === !0 ? n.overrideMaterial : null) !== null) return;
-			if (M.state.transmissionRenderTarget[r.id] === void 0) {
+			if (N.state.transmissionRenderTarget[r.id] === void 0) {
 				let e = Pe.has("EXT_color_buffer_half_float") || Pe.has("EXT_color_buffer_float");
-				M.state.transmissionRenderTarget[r.id] = new Me(1, 1, {
+				N.state.transmissionRenderTarget[r.id] = new Me(1, 1, {
 					generateMipmaps: !0,
 					type: e ? u : o,
 					minFilter: a,
@@ -10557,14 +10557,14 @@ var Cs = class {
 					colorSpace: K.workingColorSpace
 				});
 			}
-			let s = M.state.transmissionRenderTarget[r.id], c = r.viewport || fe;
-			s.setSize(c.z * P.transmissionResolutionScale, c.w * P.transmissionResolutionScale);
-			let l = P.getRenderTarget(), d = P.getActiveCubeFace(), f = P.getActiveMipmapLevel();
-			P.setRenderTarget(s), P.getClearColor(U), me = P.getClearAlpha(), me < 1 && P.setClearColor(16777215, .5), P.clear(), ke && Je.render(n);
-			let p = P.toneMapping;
-			P.toneMapping = 0;
+			let s = N.state.transmissionRenderTarget[r.id], c = r.viewport || fe;
+			s.setSize(c.z * F.transmissionResolutionScale, c.w * F.transmissionResolutionScale);
+			let l = F.getRenderTarget(), d = F.getActiveCubeFace(), f = F.getActiveMipmapLevel();
+			F.setRenderTarget(s), F.getClearColor(U), me = F.getClearAlpha(), me < 1 && F.setClearColor(16777215, .5), F.clear(), ke && Je.render(n);
+			let p = F.toneMapping;
+			F.toneMapping = 0;
 			let m = r.viewport;
-			if (r.viewport !== void 0 && (r.viewport = void 0), M.setupLightsView(r), Ce === !0 && Ke.setGlobalState(P.clippingPlanes, r), vt(e, n, r), X.updateMultisampleRenderTarget(s), X.updateRenderTargetMipmap(s), Pe.has("WEBGL_multisampled_render_to_texture") === !1) {
+			if (r.viewport !== void 0 && (r.viewport = void 0), N.setupLightsView(r), Ce === !0 && Ke.setGlobalState(F.clippingPlanes, r), vt(e, n, r), X.updateMultisampleRenderTarget(s), X.updateRenderTargetMipmap(s), Pe.has("WEBGL_multisampled_render_to_texture") === !1) {
 				let e = !1;
 				for (let i = 0, a = t.length; i < a; i++) {
 					let { object: a, geometry: o, material: s, group: c } = t[i];
@@ -10575,7 +10575,7 @@ var Cs = class {
 				}
 				e === !0 && (X.updateMultisampleRenderTarget(s), X.updateRenderTargetMipmap(s));
 			}
-			P.setRenderTarget(l, d, f), P.setClearColor(U, me), m !== void 0 && (r.viewport = m), P.toneMapping = p;
+			F.setRenderTarget(l, d, f), F.setClearColor(U, me), m !== void 0 && (r.viewport = m), F.toneMapping = p;
 		}
 		function vt(e, t, n) {
 			let r = t.isScene === !0 ? t.overrideMaterial : null;
@@ -10585,20 +10585,20 @@ var Cs = class {
 			}
 		}
 		function yt(e, t, n, r, i, a) {
-			e.onBeforeRender(P, t, n, r, i, a), e.modelViewMatrix.multiplyMatrices(n.matrixWorldInverse, e.matrixWorld), e.normalMatrix.getNormalMatrix(e.modelViewMatrix), i.onBeforeRender(P, t, n, r, e, a), i.transparent === !0 && i.side === 2 && i.forceSinglePass === !1 ? (i.side = 1, i.needsUpdate = !0, P.renderBufferDirect(n, t, r, i, e, a), i.side = 0, i.needsUpdate = !0, P.renderBufferDirect(n, t, r, i, e, a), i.side = 2) : P.renderBufferDirect(n, t, r, i, e, a), e.onAfterRender(P, t, n, r, i, a);
+			e.onBeforeRender(F, t, n, r, i, a), e.modelViewMatrix.multiplyMatrices(n.matrixWorldInverse, e.matrixWorld), e.normalMatrix.getNormalMatrix(e.modelViewMatrix), i.onBeforeRender(F, t, n, r, e, a), i.transparent === !0 && i.side === 2 && i.forceSinglePass === !1 ? (i.side = 1, i.needsUpdate = !0, F.renderBufferDirect(n, t, r, i, e, a), i.side = 0, i.needsUpdate = !0, F.renderBufferDirect(n, t, r, i, e, a), i.side = 2) : F.renderBufferDirect(n, t, r, i, e, a), e.onAfterRender(F, t, n, r, i, a);
 		}
 		function bt(e, t, n) {
 			t.isScene !== !0 && (t = Oe);
-			let r = Y.get(e), i = M.state.lights, a = M.state.shadowsArray, o = i.state.version, s = He.getParameters(e, i.state, a, t, n, M.state.lightProbeGridArray), c = He.getProgramCacheKey(s), l = r.programs;
+			let r = Y.get(e), i = N.state.lights, a = N.state.shadowsArray, o = i.state.version, s = He.getParameters(e, i.state, a, t, n, N.state.lightProbeGridArray), c = He.getProgramCacheKey(s), l = r.programs;
 			r.environment = e.isMeshStandardMaterial || e.isMeshLambertMaterial || e.isMeshPhongMaterial ? t.environment : null, r.fog = t.fog;
 			let u = e.isMeshStandardMaterial || e.isMeshLambertMaterial && !e.envMap || e.isMeshPhongMaterial && !e.envMap;
 			r.envMap = Re.get(e.envMap || r.environment, u), r.envMapRotation = r.environment !== null && e.envMap === null ? t.environmentRotation : e.envMapRotation, l === void 0 && (e.addEventListener("dispose", ot), l = /* @__PURE__ */ new Map(), r.programs = l);
 			let d = l.get(c);
 			if (d !== void 0) {
 				if (r.currentProgram === d && r.lightsStateVersion === o) return St(e, s), d;
-			} else s.uniforms = He.getUniforms(e), L !== null && e.isNodeMaterial && L.build(e, n, s), e.onBeforeCompile(s, P), d = He.acquireProgram(s, c), l.set(c, d), r.uniforms = s.uniforms;
+			} else s.uniforms = He.getUniforms(e), R !== null && e.isNodeMaterial && R.build(e, n, s), e.onBeforeCompile(s, F), d = He.acquireProgram(s, c), l.set(c, d), r.uniforms = s.uniforms;
 			let f = r.uniforms;
-			return (!e.isShaderMaterial && !e.isRawShaderMaterial || e.clipping === !0) && (f.clippingPlanes = Ke.uniform), St(e, s), r.needsLights = Et(e), r.lightsStateVersion = o, r.needsLights && (f.ambientLightColor.value = i.state.ambient, f.lightProbe.value = i.state.probe, f.directionalLights.value = i.state.directional, f.directionalLightShadows.value = i.state.directionalShadow, f.spotLights.value = i.state.spot, f.spotLightShadows.value = i.state.spotShadow, f.rectAreaLights.value = i.state.rectArea, f.ltc_1.value = i.state.rectAreaLTC1, f.ltc_2.value = i.state.rectAreaLTC2, f.pointLights.value = i.state.point, f.pointLightShadows.value = i.state.pointShadow, f.hemisphereLights.value = i.state.hemi, f.directionalShadowMatrix.value = i.state.directionalShadowMatrix, f.spotLightMatrix.value = i.state.spotLightMatrix, f.spotLightMap.value = i.state.spotLightMap, f.pointShadowMatrix.value = i.state.pointShadowMatrix), r.lightProbeGrid = M.state.lightProbeGridArray.length > 0, r.currentProgram = d, r.uniformsList = null, d;
+			return (!e.isShaderMaterial && !e.isRawShaderMaterial || e.clipping === !0) && (f.clippingPlanes = Ke.uniform), St(e, s), r.needsLights = Et(e), r.lightsStateVersion = o, r.needsLights && (f.ambientLightColor.value = i.state.ambient, f.lightProbe.value = i.state.probe, f.directionalLights.value = i.state.directional, f.directionalLightShadows.value = i.state.directionalShadow, f.spotLights.value = i.state.spot, f.spotLightShadows.value = i.state.spotShadow, f.rectAreaLights.value = i.state.rectArea, f.ltc_1.value = i.state.rectAreaLTC1, f.ltc_2.value = i.state.rectAreaLTC2, f.pointLights.value = i.state.point, f.pointLightShadows.value = i.state.pointShadow, f.hemisphereLights.value = i.state.hemi, f.directionalShadowMatrix.value = i.state.directionalShadowMatrix, f.spotLightMatrix.value = i.state.spotLightMatrix, f.spotLightMap.value = i.state.spotLightMap, f.pointShadowMatrix.value = i.state.pointShadowMatrix), r.lightProbeGrid = N.state.lightProbeGridArray.length > 0, r.currentProgram = d, r.uniformsList = null, d;
 		}
 		function xt(e) {
 			if (e.uniformsList === null) {
@@ -10614,29 +10614,29 @@ var Cs = class {
 		function Ct(e, t) {
 			if (e.length === 0) return null;
 			if (e.length === 1) return e[0].texture === null ? null : e[0];
-			ee.setFromMatrixPosition(t.matrixWorld);
+			j.setFromMatrixPosition(t.matrixWorld);
 			for (let t = 0, n = e.length; t < n; t++) {
 				let n = e[t];
-				if (n.texture !== null && n.boundingBox.containsPoint(ee)) return n;
+				if (n.texture !== null && n.boundingBox.containsPoint(j)) return n;
 			}
 			return null;
 		}
 		function wt(e, t, n, r, i) {
 			t.isScene !== !0 && (t = Oe), X.resetTextureUnits();
-			let a = t.fog, o = r.isMeshStandardMaterial || r.isMeshLambertMaterial || r.isMeshPhongMaterial ? t.environment : null, s = B === null ? P.outputColorSpace : B.isXRRenderTarget === !0 ? B.texture.colorSpace : K.workingColorSpace, c = r.isMeshStandardMaterial || r.isMeshLambertMaterial && !r.envMap || r.isMeshPhongMaterial && !r.envMap, l = Re.get(r.envMap || o, c), u = r.vertexColors === !0 && !!n.attributes.color && n.attributes.color.itemSize === 4, d = !!n.attributes.tangent && (!!r.normalMap || r.anisotropy > 0), f = !!n.morphAttributes.position, p = !!n.morphAttributes.normal, m = !!n.morphAttributes.color, h = 0;
-			r.toneMapped && (B === null || B.isXRRenderTarget === !0) && (h = P.toneMapping);
-			let g = n.morphAttributes.position || n.morphAttributes.normal || n.morphAttributes.color, _ = g === void 0 ? 0 : g.length, v = Y.get(r), y = M.state.lights;
+			let a = t.fog, o = r.isMeshStandardMaterial || r.isMeshLambertMaterial || r.isMeshPhongMaterial ? t.environment : null, s = B === null ? F.outputColorSpace : B.isXRRenderTarget === !0 ? B.texture.colorSpace : K.workingColorSpace, c = r.isMeshStandardMaterial || r.isMeshLambertMaterial && !r.envMap || r.isMeshPhongMaterial && !r.envMap, l = Re.get(r.envMap || o, c), u = r.vertexColors === !0 && !!n.attributes.color && n.attributes.color.itemSize === 4, d = !!n.attributes.tangent && (!!r.normalMap || r.anisotropy > 0), f = !!n.morphAttributes.position, p = !!n.morphAttributes.normal, m = !!n.morphAttributes.color, h = 0;
+			r.toneMapped && (B === null || B.isXRRenderTarget === !0) && (h = F.toneMapping);
+			let g = n.morphAttributes.position || n.morphAttributes.normal || n.morphAttributes.color, _ = g === void 0 ? 0 : g.length, v = Y.get(r), y = N.state.lights;
 			if (Ce === !0 && (we === !0 || e !== de)) {
 				let t = e === de && r.id === V;
 				Ke.setState(r, e, t);
 			}
 			let b = !1;
-			r.version === v.__version ? v.needsLights && v.lightsStateVersion !== y.state.version ? b = !0 : v.outputColorSpace === s ? i.isBatchedMesh && v.batching === !1 || !i.isBatchedMesh && v.batching === !0 || i.isBatchedMesh && v.batchingColor === !0 && i.colorTexture === null || i.isBatchedMesh && v.batchingColor === !1 && i.colorTexture !== null || i.isInstancedMesh && v.instancing === !1 || !i.isInstancedMesh && v.instancing === !0 || i.isSkinnedMesh && v.skinning === !1 || !i.isSkinnedMesh && v.skinning === !0 || i.isInstancedMesh && v.instancingColor === !0 && i.instanceColor === null || i.isInstancedMesh && v.instancingColor === !1 && i.instanceColor !== null || i.isInstancedMesh && v.instancingMorph === !0 && i.morphTexture === null || i.isInstancedMesh && v.instancingMorph === !1 && i.morphTexture !== null ? b = !0 : v.envMap === l ? r.fog === !0 && v.fog !== a || v.numClippingPlanes !== void 0 && (v.numClippingPlanes !== Ke.numPlanes || v.numIntersection !== Ke.numIntersection) ? b = !0 : v.vertexAlphas === u && v.vertexTangents === d && v.morphTargets === f && v.morphNormals === p && v.morphColors === m && v.toneMapping === h && v.morphTargetsCount === _ ? !!v.lightProbeGrid != M.state.lightProbeGridArray.length > 0 && (b = !0) : b = !0 : b = !0 : b = !0 : (b = !0, v.__version = r.version);
+			r.version === v.__version ? v.needsLights && v.lightsStateVersion !== y.state.version ? b = !0 : v.outputColorSpace === s ? i.isBatchedMesh && v.batching === !1 || !i.isBatchedMesh && v.batching === !0 || i.isBatchedMesh && v.batchingColor === !0 && i.colorTexture === null || i.isBatchedMesh && v.batchingColor === !1 && i.colorTexture !== null || i.isInstancedMesh && v.instancing === !1 || !i.isInstancedMesh && v.instancing === !0 || i.isSkinnedMesh && v.skinning === !1 || !i.isSkinnedMesh && v.skinning === !0 || i.isInstancedMesh && v.instancingColor === !0 && i.instanceColor === null || i.isInstancedMesh && v.instancingColor === !1 && i.instanceColor !== null || i.isInstancedMesh && v.instancingMorph === !0 && i.morphTexture === null || i.isInstancedMesh && v.instancingMorph === !1 && i.morphTexture !== null ? b = !0 : v.envMap === l ? r.fog === !0 && v.fog !== a || v.numClippingPlanes !== void 0 && (v.numClippingPlanes !== Ke.numPlanes || v.numIntersection !== Ke.numIntersection) ? b = !0 : v.vertexAlphas === u && v.vertexTangents === d && v.morphTargets === f && v.morphNormals === p && v.morphColors === m && v.toneMapping === h && v.morphTargetsCount === _ ? !!v.lightProbeGrid != N.state.lightProbeGridArray.length > 0 && (b = !0) : b = !0 : b = !0 : b = !0 : (b = !0, v.__version = r.version);
 			let x = v.currentProgram;
-			b === !0 && (x = bt(r, t, i), L && r.isNodeMaterial && L.onUpdateProgram(r, x, v));
+			b === !0 && (x = bt(r, t, i), R && r.isNodeMaterial && R.onUpdateProgram(r, x, v));
 			let S = !1, C = !1, w = !1, T = x.getUniforms(), E = v.uniforms;
 			if (J.useProgram(x.program) && (S = !0, C = !0, w = !0), r.id !== V && (V = r.id, C = !0), v.needsLights) {
-				let e = Ct(M.state.lightProbeGridArray, i);
+				let e = Ct(N.state.lightProbeGridArray, i);
 				v.lightProbeGrid !== e && (v.lightProbeGrid = e, C = !0);
 			}
 			if (S || de !== e) {
@@ -10652,7 +10652,7 @@ var Cs = class {
 			i.isBatchedMesh && (T.setOptional(q, i, "batchingTexture"), T.setValue(q, "batchingTexture", i._matricesTexture, X), T.setOptional(q, i, "batchingIdTexture"), T.setValue(q, "batchingIdTexture", i._indirectTexture, X), T.setOptional(q, i, "batchingColorTexture"), i._colorsTexture !== null && T.setValue(q, "batchingColorTexture", i._colorsTexture, X));
 			let D = n.morphAttributes;
 			if ((D.position !== void 0 || D.normal !== void 0 || D.color !== void 0) && Ye.update(i, n, x), (C || v.receiveShadow !== i.receiveShadow) && (v.receiveShadow = i.receiveShadow, T.setValue(q, "receiveShadow", i.receiveShadow)), (r.isMeshStandardMaterial || r.isMeshLambertMaterial || r.isMeshPhongMaterial) && r.envMap === null && t.environment !== null && (E.envMapIntensity.value = t.environmentIntensity), E.dfgLUT !== void 0 && (E.dfgLUT.value = Ss()), C) {
-				if (T.setValue(q, "toneMappingExposure", P.toneMappingExposure), v.needsLights && Tt(E, w), a && r.fog === !0 && Ue.refreshFogUniforms(E, a), Ue.refreshMaterialUniforms(E, r, G, ge, M.state.transmissionRenderTarget[e.id]), v.needsLights && v.lightProbeGrid) {
+				if (T.setValue(q, "toneMappingExposure", F.toneMappingExposure), v.needsLights && Tt(E, w), a && r.fog === !0 && Ue.refreshFogUniforms(E, a), Ue.refreshMaterialUniforms(E, r, G, ge, N.state.transmissionRenderTarget[e.id]), v.needsLights && v.lightProbeGrid) {
 					let e = v.lightProbeGrid;
 					E.probesSH.value = e.texture, E.probesMin.value.copy(e.boundingBox.min), E.probesMax.value.copy(e.boundingBox.max), E.probesResolution.value.copy(e.resolution);
 				}
@@ -10707,7 +10707,7 @@ var Cs = class {
 				let c = Y.get(e).__webglFramebuffer;
 				e.isWebGLCubeRenderTarget ? (r = Array.isArray(c[t]) ? c[t][n] : c[t], i = !0) : r = e.samples > 0 && X.useMultisampledRTT(e) === !1 ? Y.get(e).__webglMultisampledFramebuffer : Array.isArray(c) ? c[n] : c, fe.copy(e.viewport), pe.copy(e.scissor), H = e.scissorTest;
 			} else fe.copy(ye).multiplyScalar(G).floor(), pe.copy(be).multiplyScalar(G).floor(), H = xe;
-			if (n !== 0 && (r = ce), J.bindFramebuffer(q.FRAMEBUFFER, r) && J.drawBuffers(e, r), J.viewport(fe), J.scissor(pe), J.setScissorTest(H), i) {
+			if (n !== 0 && (r = se), J.bindFramebuffer(q.FRAMEBUFFER, r) && J.drawBuffers(e, r), J.viewport(fe), J.scissor(pe), J.setScissorTest(H), i) {
 				let r = Y.get(e.texture);
 				q.framebufferTexture2D(q.FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_CUBE_MAP_POSITIVE_X + t, r.__webglTexture, n);
 			} else if (a) {
@@ -10723,7 +10723,7 @@ var Cs = class {
 			V = -1;
 		}, this.readRenderTargetPixels = function(e, t, n, r, i, a, o, s = 0) {
 			if (!(e && e.isWebGLRenderTarget)) {
-				I("WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.");
+				L("WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.");
 				return;
 			}
 			let c = Y.get(e).__webglFramebuffer;
@@ -10732,11 +10732,11 @@ var Cs = class {
 				try {
 					let o = e.textures[s], c = o.format, l = o.type;
 					if (e.textures.length > 1 && q.readBuffer(q.COLOR_ATTACHMENT0 + s), !Ie.textureFormatReadable(c)) {
-						I("WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.");
+						L("WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.");
 						return;
 					}
 					if (!Ie.textureTypeReadable(l)) {
-						I("WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.");
+						L("WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.");
 						return;
 					}
 					t >= 0 && t <= e.width - r && n >= 0 && n <= e.height - i && q.readPixels(t, n, r, i, Qe.convert(c), Qe.convert(l), a);
@@ -10758,7 +10758,7 @@ var Cs = class {
 				let f = B === null ? null : Y.get(B).__webglFramebuffer;
 				J.bindFramebuffer(q.FRAMEBUFFER, f);
 				let p = q.fenceSync(q.SYNC_GPU_COMMANDS_COMPLETE, 0);
-				return q.flush(), await se(q, p, 4), q.bindBuffer(q.PIXEL_PACK_BUFFER, d), q.getBufferSubData(q.PIXEL_PACK_BUFFER, 0, a), q.deleteBuffer(d), q.deleteSync(p), a;
+				return q.flush(), await oe(q, p, 4), q.bindBuffer(q.PIXEL_PACK_BUFFER, d), q.getBufferSubData(q.PIXEL_PACK_BUFFER, 0, a), q.deleteBuffer(d), q.deleteSync(p), a;
 			} else throw Error("THREE.WebGLRenderer.readRenderTargetPixelsAsync: requested read bounds are out of range.");
 		}, this.copyFramebufferToTexture = function(e, t = null, n = 0) {
 			let r = 2 ** -n, i = Math.floor(e.image.width * r), a = Math.floor(e.image.height * r), o = t === null ? 0 : t.x, s = t === null ? 0 : t.y;
@@ -10783,7 +10783,7 @@ var Cs = class {
 				J.bindFramebuffer(q.READ_FRAMEBUFFER, null), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, null);
 			} else if (i !== 0 || e.isRenderTargetTexture || Y.has(e)) {
 				let n = Y.get(e), r = Y.get(t);
-				J.bindFramebuffer(q.READ_FRAMEBUFFER, R), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, z);
+				J.bindFramebuffer(q.READ_FRAMEBUFFER, z), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, ce);
 				for (let e = 0; e < c; e++) w ? q.framebufferTextureLayer(q.READ_FRAMEBUFFER, q.COLOR_ATTACHMENT0, n.__webglTexture, i, d + e) : q.framebufferTexture2D(q.READ_FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_2D, n.__webglTexture, i), T ? q.framebufferTextureLayer(q.DRAW_FRAMEBUFFER, q.COLOR_ATTACHMENT0, r.__webglTexture, a, m + e) : q.framebufferTexture2D(q.DRAW_FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_2D, r.__webglTexture, a), i === 0 ? T ? q.copyTexSubImage3D(v, a, f, p, m + e, l, u, o, s) : q.copyTexSubImage2D(v, a, f, p, l, u, o, s) : q.blitFramebuffer(l, u, o, s, f, p, o, s, q.COLOR_BUFFER_BIT, q.NEAREST);
 				J.bindFramebuffer(q.READ_FRAMEBUFFER, null), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, null);
 			} else T ? e.isDataTexture || e.isData3DTexture ? q.texSubImage3D(v, a, f, p, m, o, s, c, g, _, h.data) : t.isCompressedArrayTexture ? q.compressedTexSubImage3D(v, a, f, p, m, o, s, c, g, h.data) : q.texSubImage3D(v, a, f, p, m, o, s, c, g, _, h) : e.isDataTexture ? q.texSubImage2D(q.TEXTURE_2D, a, f, p, o, s, g, _, h.data) : e.isCompressedTexture ? q.compressedTexSubImage2D(q.TEXTURE_2D, a, f, p, h.width, h.height, g, h.data) : q.texSubImage2D(q.TEXTURE_2D, a, f, p, o, s, g, _, h);
@@ -10797,7 +10797,7 @@ var Cs = class {
 		}, typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("observe", { detail: this }));
 	}
 	get coordinateSystem() {
-		return te;
+		return ee;
 	}
 	get outputColorSpace() {
 		return this._outputColorSpace;
@@ -10807,37 +10807,410 @@ var Cs = class {
 		let t = this.getContext();
 		t.drawingBufferColorSpace = K._getDrawingBufferColorSpace(e), t.unpackColorSpace = K._getUnpackColorSpace();
 	}
-}, ws = "\nattribute vec3 color;\nattribute float along;\nattribute float flow;\nvarying vec3 vColor;\nvarying float vAlong;\nvarying float vFlow;\nvoid main() {\n  vColor = color;\n  vAlong = along;\n  vFlow = flow;\n  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);\n}\n", Ts = "\nprecision highp float;\nuniform float time;\nuniform float opacity;\nvarying vec3 vColor;\nvarying float vAlong;\nvarying float vFlow;\nvoid main() {\n  float moving = fract(vAlong * 7.0 - time * vFlow);\n  float pulse = smoothstep(0.02, 0.20, moving) *\n                (1.0 - smoothstep(0.30, 0.52, moving));\n  vec3 color = vColor * (0.64 + 0.72 * pulse);\n  gl_FragColor = vec4(color, opacity);\n}\n";
-function Es(e) {
+}, ws = 1e-9, Ts = [
+	"shared:anchor",
+	"shared:direction",
+	"shared:level",
+	"shared:pressure",
+	"shared:hydration",
+	"shared:ion_load",
+	"shared:local_evidence",
+	"shared:path_mean"
+], Es = [
+	"membership",
+	"pressure",
+	"hydration",
+	"ion_load",
+	"forward_commitment",
+	"backward_commitment"
+];
+function Ds(e) {
+	let t = Number(e);
+	return Number.isFinite(t) ? t : 0;
+}
+function Os(e) {
+	return e.data.network_root == null ? "main" : `net:${e.data.network_root}`;
+}
+function ks(e) {
+	let t = 2166136261;
+	for (let n = 0; n < e.length; n += 1) t ^= e.charCodeAt(n), t = Math.imul(t, 16777619);
+	return t >>> 0;
+}
+function As(e) {
+	let t = e || 2654435769;
+	return () => (t ^= t << 13, t ^= t >>> 17, t ^= t << 5, (t >>> 0) / 4294967295 * 2 - 1);
+}
+function js(e, t) {
+	let n = 0;
+	for (let r = 0; r < e.length; r += 1) n += e[r] * t[r];
+	return n;
+}
+function Ms(e) {
+	let t = Math.sqrt(js(e, e));
+	if (t <= ws) {
+		let t = Array(e.length).fill(0);
+		return t[0] = 1, t;
+	}
+	return e.map((e) => e / t);
+}
+function Ns(e) {
+	let t = Array(e.length + 1).fill(0), n = 1;
+	for (let r = 0; r < e.length; r += 1) {
+		let i = Ds(e[r]);
+		t[r] = n * Math.cos(i), n *= Math.sin(i);
+	}
+	return t[e.length] = n, t;
+}
+function Ps(e) {
+	return Array.isArray(e.data.latent_coordinates) ? e.data.latent_coordinates.map(Ds) : Array.isArray(e.data.hyperspherical_angles) ? Ns(e.data.hyperspherical_angles) : [];
+}
+function Fs(e, t) {
+	let n = [
+		[],
+		[],
+		[]
+	];
+	for (let r of e) {
+		let e = As(ks(`${t}|${r}`)), i = Ms([
+			e(),
+			e(),
+			e()
+		]);
+		n[0].push(i[0]), n[1].push(i[1]), n[2].push(i[2]);
+	}
+	return n;
+}
+function Is(e) {
+	let t = {}, n = Math.PI * (3 - Math.sqrt(5));
+	return e.forEach((r, i) => {
+		if (e.length === 1) {
+			t[r] = [
+				0,
+				0,
+				1
+			];
+			return;
+		}
+		let a = 1 - 2 * (i + .5) / e.length, o = Math.sqrt(Math.max(0, 1 - a * a)), s = i * n;
+		t[r] = [
+			Math.cos(s) * o,
+			a,
+			Math.sin(s) * o
+		];
+	}), t;
+}
+function Ls(e, t, n) {
+	let r = Math.max(-1, Math.min(1, js(e, t))), i = Math.acos(r);
+	if (i <= ws) return [...t];
+	let a = Ms(e.map((e, n) => e - r * t[n])), o = n * i / Math.PI;
+	return [
+		Math.cos(o) * t[0] + Math.sin(o) * a[0],
+		Math.cos(o) * t[1] + Math.sin(o) * a[1],
+		Math.cos(o) * t[2] + Math.sin(o) * a[2]
+	];
+}
+function Rs(e) {
+	let t = Math.max(ws, Ds(e.data.volume)), n = Math.max(0, Ds(e.data.solvent)), r = Object.values(e.data.solubles ?? {}).reduce((e, t) => e + Math.max(0, Ds(t)), 0);
+	return {
+		pressure: Math.tanh(Math.log1p(Math.max(0, Ds(e.data.pressure)))),
+		hydration: Math.tanh(n / t),
+		ionLoad: Math.tanh(r / t),
+		forwardCommitment: Math.tanh(Math.max(0, Ds(e.data.forward_growth_interest)) / 3),
+		backwardCommitment: Math.tanh(Math.max(0, Ds(e.data.backward_growth_interest)) / 3)
+	};
+}
+var zs = class {
+	seed;
+	constructor(e = "flux-radar-observation-v1") {
+		this.seed = e;
+	}
+	observe(e, t, n, r = []) {
+		let i = Array.from(new Set(e.map(Os))).sort(), a = e.reduce((e, t) => Math.max(e, Ps(t).length), 0), o = a > 0, s = Array.from({ length: a }, (e, t) => r[t] ?? `intrinsic:${t}`), c = o ? s : [...Ts, ...i.flatMap((e) => Es.map((t) => `${e}:${t}`))], l = Fs(c, this.seed), u = Is(i), d = i.length <= 1 ? Math.PI * .92 : Math.max(.24, Math.min(.68, 1.12 / Math.sqrt(i.length))), f = Math.max(40, Math.min(t, n) * .39), p = t / 2, m = n / 2;
+		return {
+			version: 1,
+			dimensions: c,
+			projection: l,
+			networkCaps: u,
+			shellRadius: f,
+			nodes: e.map((e) => {
+				let t = Os(e), n = Rs(e), r = Array(c.length).fill(0);
+				if (o) Ps(e).forEach((e, t) => {
+					r[t] = e;
+				});
+				else {
+					r[0] = e.data.is_anchor || e.data.is_center ? 1 : 0, r[1] = e.data.direction === "backward" ? -1 : +(e.data.direction === "forward"), r[2] = Math.tanh(Ds(e.data.level ?? e.data.depth) / 4), r[3] = n.pressure, r[4] = n.hydration, r[5] = n.ionLoad, r[6] = Math.tanh(Ds(e.data.local_evidence)), r[7] = Math.tanh(Ds(e.data.path_mean));
+					let a = Ts.length + i.indexOf(t) * Es.length;
+					r[a] = 1, r[a + 1] = n.pressure, r[a + 2] = n.hydration, r[a + 3] = n.ionLoad, r[a + 4] = n.forwardCommitment, r[a + 5] = n.backwardCommitment;
+				}
+				let a = Math.sqrt(js(r, r)), s = Ms(r), h = l.map((e) => js(e, s)), g = a <= ws ? 0 : Math.sqrt(js(h, h)), _ = u[t] ?? [
+					0,
+					0,
+					1
+				], v = g <= ws ? [..._] : Ls(Ms(h), _, d), y = .78 + .22 * ((v[2] + 1) / 2);
+				return {
+					id: e.id,
+					network: t,
+					latent: r,
+					unit: s,
+					projected: h,
+					shell: v,
+					confidence: Math.min(1, g),
+					screen: {
+						x: p + v[0] * f * y,
+						y: m - v[1] * f * y,
+						depth: v[2],
+						scale: y
+					}
+				};
+			})
+		};
+	}
+}, Bs = 1e-7;
+function Vs(e) {
+	let t = Number(e);
+	return Number.isFinite(t) ? t : 0;
+}
+function Hs(e) {
+	return typeof e == "number" ? e : e.id;
+}
+function Us(e) {
+	return e.data.network_root == null ? "main" : `net:${e.data.network_root}`;
+}
+function Ws(e, t) {
+	let n = Math.imul((e ^ t) >>> 0, 73244475);
+	return n = Math.imul((n ^ n >>> 16) >>> 0, 73244475), n ^= n >>> 16, (n >>> 0) / 4294967295;
+}
+function Gs(e) {
+	let t = [[]];
+	for (let n = 0; n < e; n += 1) t = t.flatMap((e) => [
+		-1,
+		0,
+		1
+	].map((t) => [...e, t]));
+	return t;
+}
+var Ks = class {
+	sharedDimensions;
+	localDimensions;
+	networks = [];
+	dimensionLabels = [];
+	nodes = [];
+	nodeIndex = /* @__PURE__ */ new Map();
+	networkIndices = /* @__PURE__ */ new Int32Array();
+	fixed = /* @__PURE__ */ new Uint8Array();
+	levels = /* @__PURE__ */ new Float32Array();
+	pressures = /* @__PURE__ */ new Float32Array();
+	radii = /* @__PURE__ */ new Float32Array();
+	positions = /* @__PURE__ */ new Float32Array();
+	velocities = /* @__PURE__ */ new Float32Array();
+	sources = /* @__PURE__ */ new Int32Array();
+	targets = /* @__PURE__ */ new Int32Array();
+	lastProof = null;
+	collisionOffsets;
+	pipeStiffness = .72;
+	pipeRestLength = 1.05;
+	pressureExpansion = .06;
+	constructor(e = 2, t = 4) {
+		this.sharedDimensions = Math.max(0, Math.floor(e)), this.localDimensions = Math.max(2, Math.floor(t)), this.collisionOffsets = Gs(this.localDimensions);
+	}
+	configure(e) {
+		e.pipeStiffness != null && (this.pipeStiffness = Math.max(0, Vs(e.pipeStiffness))), e.pipeRestLength != null && (this.pipeRestLength = Math.max(Bs, Vs(e.pipeRestLength))), e.pressureExpansion != null && (this.pressureExpansion = Math.max(0, Vs(e.pressureExpansion)));
+	}
+	rebuildDimensionLabels() {
+		this.dimensionLabels = [...Array.from({ length: this.sharedDimensions }, (e, t) => `world:${t}`), ...this.networks.flatMap((e) => Array.from({ length: this.localDimensions }, (t, n) => `${e}:space:${n}`))];
+	}
+	localOffset(e) {
+		return this.sharedDimensions + e * this.localDimensions;
+	}
+	sync(e, t) {
+		let n = this.dimensionLabels, r = this.positions, i = this.velocities, a = this.nodeIndex, o = n.length;
+		for (let t of e) {
+			let e = Us(t);
+			this.networks.includes(e) || this.networks.push(e);
+		}
+		this.rebuildDimensionLabels();
+		let s = this.dimensionLabels.length, c = this.dimensionLabels.map((e) => n.indexOf(e));
+		this.nodes = [...e], this.nodeIndex = new Map(e.map((e, t) => [e.id, t])), this.networkIndices = new Int32Array(e.length), this.fixed = new Uint8Array(e.length), this.levels = new Float32Array(e.length), this.pressures = new Float32Array(e.length), this.radii = new Float32Array(e.length), this.positions = new Float32Array(e.length * s), this.velocities = new Float32Array(e.length * s), e.forEach((e, t) => {
+			let n = this.networks.indexOf(Us(e));
+			this.networkIndices[t] = n, this.fixed[t] = e.data.is_anchor || e.data.is_center ? 1 : 0, this.levels[t] = Vs(e.data.level ?? e.data.depth), this.pressures[t] = Math.max(0, Vs(e.data.pressure)), this.radii[t] = .16 + .08 * Math.sqrt(Math.max(0, Vs(e.data.volume)));
+			let l = a.get(e.id);
+			if (l != null && o > 0) {
+				for (let e = 0; e < s; e += 1) {
+					let n = c[e];
+					n < 0 || (this.positions[t * s + e] = r[l * o + n], this.velocities[t * s + e] = i[l * o + n]);
+				}
+				return;
+			}
+			if (this.fixed[t]) return;
+			let u = this.localOffset(n), d = Math.max(.7, Math.abs(this.levels[t]) * 1.05), f = 0;
+			for (let n = 0; n < this.localDimensions; n += 1) {
+				let r = Ws(e.id, 40503 + n * 34283) * 2 - 1;
+				this.positions[t * s + u + n] = r, f += r * r;
+			}
+			let p = d / Math.sqrt(Math.max(Bs, f));
+			for (let e = 0; e < this.localDimensions; e += 1) this.positions[t * s + u + e] *= p;
+			this.sharedDimensions > 0 && (this.positions[t * s] = (Ws(e.id, 10196) * 2 - 1) * .08);
+		});
+		let l = t.flatMap((e) => {
+			let t = this.nodeIndex.get(Hs(e.source)), n = this.nodeIndex.get(Hs(e.target));
+			return t == null || n == null ? [] : [[t, n]];
+		});
+		this.sources = new Int32Array(l.map(([e]) => e)), this.targets = new Int32Array(l.map(([, e]) => e));
+	}
+	addPipeForces(e) {
+		let t = this.dimensionLabels.length, n = 0;
+		for (let r = 0; r < this.sources.length; r += 1) {
+			let i = this.sources[r], a = this.targets[r], o = this.networkIndices[i], s = this.networkIndices[a], c = Array.from({ length: this.sharedDimensions }, (e, t) => t);
+			if (s === o) for (let e = 0; e < this.localDimensions; e += 1) c.push(this.localOffset(o) + e);
+			let l = 0;
+			for (let e of c) {
+				let n = this.positions[a * t + e] - this.positions[i * t + e];
+				l += n * n;
+			}
+			let u = Math.sqrt(Math.max(Bs, l)), d = this.pressureExpansion * Math.log1p((this.pressures[i] + this.pressures[a]) * .5), f = u - (this.pipeRestLength + d), p = this.pipeStiffness, m = p * f / u;
+			n += .5 * p * f * f;
+			for (let n of c) {
+				let r = m * (this.positions[a * t + n] - this.positions[i * t + n]);
+				e[i * t + n] += r, e[a * t + n] -= r;
+			}
+		}
+		return n;
+	}
+	addLocalShellForces(e) {
+		let t = this.dimensionLabels.length, n = 0;
+		for (let r = 0; r < this.nodes.length; r += 1) {
+			if (this.fixed[r]) continue;
+			let i = this.localOffset(this.networkIndices[r]), a = 0;
+			for (let e = 0; e < this.localDimensions; e += 1) {
+				let n = this.positions[r * t + i + e];
+				a += n * n;
+			}
+			let o = Math.sqrt(Math.max(Bs, a)), s = o - Math.max(.7, Math.abs(this.levels[r]) * 1.05), c = .24;
+			n += .5 * c * s * s;
+			for (let n = 0; n < this.localDimensions; n += 1) {
+				let a = r * t + i + n;
+				e[a] -= c * s * this.positions[a] / o;
+			}
+			for (let n = 0; n < this.sharedDimensions; n += 1) {
+				let i = r * t + n;
+				e[i] -= .025 * this.positions[i];
+			}
+		}
+		return n;
+	}
+	addCollisionForces(e) {
+		let t = this.dimensionLabels.length, n = this.networks.map(() => /* @__PURE__ */ new Map()), r = 0;
+		for (let i = 0; i < this.nodes.length; i += 1) {
+			let a = this.networkIndices[i], o = this.localOffset(a), s = Array.from({ length: this.localDimensions }, (e, n) => Math.floor(this.positions[i * t + o + n] / .48)), c = n[a];
+			for (let n of this.collisionOffsets) {
+				let a = s.map((e, t) => e + n[t]).join(",");
+				for (let n of c.get(a) ?? []) {
+					let a = 0;
+					for (let e = 0; e < this.localDimensions; e += 1) {
+						let r = o + e, s = this.positions[i * t + r] - this.positions[n * t + r];
+						a += s * s;
+					}
+					let s = Math.sqrt(Math.max(Bs, a)), c = this.radii[i] + this.radii[n] + .08;
+					if (s >= c) continue;
+					let l = c - s, u = .9;
+					r += .5 * u * l * l;
+					for (let r = 0; r < this.localDimensions; r += 1) {
+						let a = o + r, c = this.positions[i * t + a] - this.positions[n * t + a], d = u * l * c / s;
+						e[i * t + a] += d, e[n * t + a] -= d;
+					}
+				}
+			}
+			let l = s.join(","), u = c.get(l) ?? [];
+			u.push(i), c.set(l, u);
+		}
+		return r;
+	}
+	relax(e = 32, t = .035) {
+		let n = this.dimensionLabels.length, r = new Float32Array(this.positions.length), i = 0, a = 0;
+		for (let o = 0; o < e; o += 1) {
+			r.fill(0), i = this.addPipeForces(r) + this.addLocalShellForces(r) + this.addCollisionForces(r);
+			let e = 0, o = Math.exp(-3.8 * t);
+			for (let i = 0; i < this.nodes.length; i += 1) for (let a = 0; a < n; a += 1) {
+				let s = i * n + a;
+				if (this.fixed[i]) {
+					this.positions[s] = 0, this.velocities[s] = 0;
+					continue;
+				}
+				e += r[s] * r[s], this.velocities[s] = (this.velocities[s] + r[s] * t) * o, this.velocities[s] = Math.max(-5, Math.min(5, this.velocities[s])), this.positions[s] += this.velocities[s] * t;
+			}
+			a = Math.sqrt(e / Math.max(1, this.nodes.length * n));
+		}
+		let o = 0;
+		for (let e of this.velocities) o += .5 * e * e;
+		return this.lastProof = {
+			dimensions: n,
+			nodes: this.nodes.length,
+			edges: this.sources.length,
+			substeps: e,
+			residual: a,
+			kineticEnergy: o,
+			potentialEnergy: i
+		}, this.lastProof;
+	}
+	coordinates(e) {
+		let t = this.nodeIndex.get(e);
+		if (t == null) return [];
+		let n = this.dimensionLabels.length;
+		return Array.from(this.positions.subarray(t * n, (t + 1) * n));
+	}
+	habitatProximity() {
+		let e = this.dimensionLabels.length, t = {};
+		for (let n = 0; n < this.nodes.length; n += 1) {
+			if (this.fixed[n]) continue;
+			let r = this.localOffset(this.networkIndices[n]), i = 0;
+			for (let t = 0; t < this.localDimensions; t += 1) {
+				let a = this.positions[n * e + r + t];
+				i += a * a;
+			}
+			let a = Math.sqrt(i), o = Math.max(.7, Math.abs(this.levels[n]) * 1.05);
+			t[String(this.nodes[n].id)] = Math.max(0, 1 - Math.abs(a - o) / 1.05);
+		}
+		return t;
+	}
+	snapshot() {
+		return {
+			dimensions: [...this.dimensionLabels],
+			networks: [...this.networks],
+			positions: Object.fromEntries(this.nodes.map((e) => [String(e.id), this.coordinates(e.id)])),
+			proof: this.lastProof
+		};
+	}
+}, qs = "\nattribute vec3 color;\nattribute float along;\nattribute float flow;\nvarying vec3 vColor;\nvarying float vAlong;\nvarying float vFlow;\nvoid main() {\n  vColor = color;\n  vAlong = along;\n  vFlow = flow;\n  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);\n}\n", Js = "\nprecision highp float;\nuniform float time;\nuniform float opacity;\nvarying vec3 vColor;\nvarying float vAlong;\nvarying float vFlow;\nvoid main() {\n  float moving = fract(vAlong * 7.0 - time * vFlow);\n  float pulse = smoothstep(0.02, 0.20, moving) *\n                (1.0 - smoothstep(0.30, 0.52, moving));\n  vec3 color = vColor * (0.64 + 0.72 * pulse);\n  gl_FragColor = vec4(color, opacity);\n}\n";
+function Ys(e) {
 	return new Z(e);
 }
-function Ds(e) {
+function Xs(e) {
 	let t = 2166136261;
 	for (let n = 0; n < e.length; n += 1) t ^= e.charCodeAt(n), t = Math.imul(t, 16777619);
 	return Math.abs(t) % 360;
 }
-function Os(e, t) {
+function Zs(e, t) {
 	let n = "", r = 0;
 	for (let [e, i] of Object.entries(t)) i > r && (n = e, r = i);
-	return Es(!n || e >= r ? "hsl(200, 85%, 64%)" : `hsl(${Ds(n)}, 86%, 61%)`);
+	return Ys(!n || e >= r ? "hsl(200, 85%, 64%)" : `hsl(${Xs(n)}, 86%, 61%)`);
 }
-function ks(e) {
-	return e.data.is_anchor || e.data.is_center ? Es("#f0cf65") : e.data.network_root == null ? e.data.direction === "backward" ? Es("#d883d9") : Es("#66d6a1") : Es(`hsl(${e.data.network_root * 67 % 360}, 66%, 58%)`);
+function Qs(e) {
+	return e.data.is_anchor || e.data.is_center ? Ys("#f0cf65") : e.data.network_root == null ? e.data.direction === "backward" ? Ys("#d883d9") : Ys("#66d6a1") : Ys(`hsl(${e.data.network_root * 67 % 360}, 66%, 58%)`);
 }
-function As(e, t) {
+function $s(e, t) {
 	return typeof e == "number" ? t.get(e) : e;
 }
-function js(e, t, n, r, i, a, o, s, c, l) {
+function ec(e, t, n, r, i, a, o, s, c, l) {
 	let u = r - t, d = i - n, f = Math.max(1e-6, Math.hypot(u, d)), p = -d / f, m = u / f, h = p * o, g = m * o, _ = p * a, v = m * a, y = e.positions.length / 3;
 	e.positions.push(t + h - _, n + g - v, l, t + h + _, n + g + v, l, r + h + _, i + g + v, l, r + h - _, i + g - v, l);
 	for (let t = 0; t < 4; t += 1) e.colors.push(s.r, s.g, s.b), e.flow.push(c);
 	e.along.push(0, 0, 1, 1), e.indices.push(y, y + 1, y + 2, y, y + 2, y + 3);
 }
-function Ms(e) {
+function tc(e) {
 	let t = new ln();
 	return t.setAttribute("position", new Xt(e.positions, 3)), t.setAttribute("color", new Xt(e.colors, 3)), t.setAttribute("along", new Xt(e.along, 1)), t.setAttribute("flow", new Xt(e.flow, 1)), t.setIndex(e.indices), t.computeBoundingSphere(), t;
 }
-function Ns() {
+function nc() {
 	return {
 		positions: [],
 		colors: [],
@@ -10846,7 +11219,7 @@ function Ns() {
 		indices: []
 	};
 }
-var Ps = class {
+var rc = class {
 	renderer;
 	scene = new mt();
 	camera;
@@ -10875,8 +11248,8 @@ var Ps = class {
 			antialias: !0,
 			powerPreference: "high-performance"
 		}), this.renderer.setClearColor(0, 0), this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2)), this.camera = new Hr(0, 900, 0, 560, .1, 100), this.camera.position.z = 20, this.camera.lookAt(0, 0, 0), this.hullMaterial = new mr({
-			vertexShader: ws,
-			fragmentShader: Ts,
+			vertexShader: qs,
+			fragmentShader: Js,
 			uniforms: {
 				time: { value: 0 },
 				opacity: { value: .44 }
@@ -10910,16 +11283,16 @@ var Ps = class {
 		let r = e?.geometry.getAttribute("position");
 		if (e && r && r.count === t.positions.length / 3) return r.array.set(t.positions), e.geometry.getAttribute("color").array.set(t.colors), e.geometry.getAttribute("along").array.set(t.along), e.geometry.getAttribute("flow").array.set(t.flow), r.needsUpdate = !0, e.geometry.getAttribute("color").needsUpdate = !0, e.geometry.getAttribute("along").needsUpdate = !0, e.geometry.getAttribute("flow").needsUpdate = !0, e.geometry.computeBoundingSphere(), e;
 		e && (this.scene.remove(e), e.geometry.dispose());
-		let i = new Mn(Ms(t), n);
+		let i = new Mn(tc(t), n);
 		return i.frustumCulled = !1, this.scene.add(i), i;
 	}
 	rebuildHulls(e) {
-		let t = new Map(e.nodes.map((e) => [e.id, e])), n = Ns();
+		let t = new Map(e.nodes.map((e) => [e.id, e])), n = nc();
 		for (let r of e.links) {
-			let e = As(r.source, t), i = As(r.target, t);
+			let e = $s(r.source, t), i = $s(r.target, t);
 			if (!e || !i) continue;
 			let a = r.influence ?? {}, o = Math.max(1, Number(a.count) || 1), s = Math.max(0, Math.min(1, Number(a.maturity) || 0)), c = Math.max(0, Math.min(1, Number(a.avg) || 0)), l = 2.6 + Math.sqrt(o) * 1.6 + s * 2.4, u = new Z().setHSL(c * .32, .72, .42);
-			js(n, e.x, e.y, i.x, i.y, l, 0, u, Number(a.flow) || 0, 0);
+			ec(n, e.x, e.y, i.x, i.y, l, 0, u, Number(a.flow) || 0, 0);
 		}
 		this.hullMesh = this.updateQuadMesh(this.hullMesh, n, this.hullMaterial);
 	}
@@ -10933,14 +11306,14 @@ var Ps = class {
 				edge: e
 			}), n.set(i, a);
 		});
-		let r = Ns();
+		let r = nc();
 		for (let e of n.values()) {
 			let n = Math.min(1.7, 12 / Math.max(1, e.length - 1));
 			e.forEach(({ tube: i, segment: a, edge: o }, s) => {
 				let c = t.get(o[0]), l = t.get(o[1]);
 				if (!c || !l) return;
 				let u = (s - (e.length - 1) / 2) * n, d = Number(i.solvent[a]) || 0, f = i.solubles[a] ?? {}, p = Number(i.pressures[a]) || 0, m = d + Object.values(f).reduce((e, t) => e + Number(t || 0), 0), h = (i.direction === "forward" ? 1 : -1) * (.25 + Math.min(4, p + m));
-				js(r, c.x, c.y, l.x, l.y, Math.min(.58 + Math.min(1.4, Math.sqrt(Math.max(0, m)) * .32), Math.max(.12, n * .38)), u, Os(d, f), h, 2);
+				ec(r, c.x, c.y, l.x, l.y, Math.min(.58 + Math.min(1.4, Math.sqrt(Math.max(0, m)) * .32), Math.max(.12, n * .38)), u, Zs(d, f), h, 2);
 			});
 		}
 		this.lumenMesh = this.updateQuadMesh(this.lumenMesh, r, this.lumenMaterial);
@@ -10956,9 +11329,9 @@ var Ps = class {
 		if (!r || !i) return;
 		let a = new Fe();
 		e.nodes.forEach((e, t) => {
-			a.makeTranslation(e.x, e.y, 4), a.scale(new W(e.r, e.r, 1)), r.setMatrixAt(t, a), r.setColorAt(t, ks(e));
+			a.makeTranslation(e.x, e.y, 4), a.scale(new W(e.r, e.r, 1)), r.setMatrixAt(t, a), r.setColorAt(t, Qs(e));
 			let o = Math.max(0, Number(e.data.volume) || 0), s = e.r * Math.min(.9, Math.sqrt(o / n));
-			a.makeTranslation(e.x, e.y, 5), a.scale(new W(s, s, 1)), i.setMatrixAt(t, a), i.setColorAt(t, Os(Number(e.data.solvent) || 0, e.data.solubles ?? {}));
+			a.makeTranslation(e.x, e.y, 5), a.scale(new W(s, s, 1)), i.setMatrixAt(t, a), i.setColorAt(t, Zs(Number(e.data.solvent) || 0, e.data.solubles ?? {}));
 		}), r.instanceMatrix.needsUpdate = !0, i.instanceMatrix.needsUpdate = !0, r.instanceColor && (r.instanceColor.needsUpdate = !0), i.instanceColor && (i.instanceColor.needsUpdate = !0);
 	}
 	animate = () => {
@@ -10971,4 +11344,4 @@ var Ps = class {
 	}
 };
 //#endregion
-export { Ps as FluxWebGLRenderer };
+export { rc as FluxWebGLRenderer, zs as HypersphereProjector, Ks as NDForceAssembly, Ns as hypersphericalToCartesian };

--- a/speaktome/flux_radar/webgl/webgl_renderer.js
+++ b/speaktome/flux_radar/webgl/webgl_renderer.js
@@ -1,0 +1,10974 @@
+var e = 1e3, t = 1001, n = 1002, r = 1003, i = 1006, a = 1008, o = 1009, s = 1012, c = 1014, l = 1015, u = 1016, d = 1017, f = 1018, p = 1020, m = 1023, h = 1026, g = 1027, _ = 1028, v = 1029, y = 1030, b = 1031, x = 1033, S = 2300, C = 2301, w = 2302, T = 2303, E = 2400, D = 2401, O = 2402, k = "srgb", A = "srgb-linear", ee = "linear", j = "srgb", M = 7680, te = 2e3;
+function ne(e) {
+	for (let t = e.length - 1; t >= 0; --t) if (e[t] >= 65535) return !0;
+	return !1;
+}
+function N(e) {
+	return ArrayBuffer.isView(e) && !(e instanceof DataView);
+}
+function re(e) {
+	return document.createElementNS("http://www.w3.org/1999/xhtml", e);
+}
+function ie() {
+	let e = re("canvas");
+	return e.style.display = "block", e;
+}
+var P = {};
+function ae(...e) {
+	let t = "THREE." + e.shift();
+	console.log(t, ...e);
+}
+function oe(e) {
+	let t = e[0];
+	if (typeof t == "string" && t.startsWith("TSL:")) {
+		let t = e[1];
+		t && t.isStackTrace ? e[0] += " " + t.getLocation() : e[1] = "Stack trace not available. Enable \"THREE.Node.captureStackTrace\" to capture stack traces.";
+	}
+	return e;
+}
+function F(...e) {
+	e = oe(e);
+	let t = "THREE." + e.shift();
+	{
+		let n = e[0];
+		n && n.isStackTrace ? console.warn(n.getError(t)) : console.warn(t, ...e);
+	}
+}
+function I(...e) {
+	e = oe(e);
+	let t = "THREE." + e.shift();
+	{
+		let n = e[0];
+		n && n.isStackTrace ? console.error(n.getError(t)) : console.error(t, ...e);
+	}
+}
+function L(...e) {
+	let t = e.join(" ");
+	t in P || (P[t] = !0, F(...e));
+}
+function se(e, t, n) {
+	return new Promise(function(r, i) {
+		function a() {
+			switch (e.clientWaitSync(t, e.SYNC_FLUSH_COMMANDS_BIT, 0)) {
+				case e.WAIT_FAILED:
+					i();
+					break;
+				case e.TIMEOUT_EXPIRED:
+					setTimeout(a, n);
+					break;
+				default: r();
+			}
+		}
+		setTimeout(a, n);
+	});
+}
+var ce = {
+	0: 1,
+	2: 6,
+	4: 7,
+	3: 5,
+	1: 0,
+	6: 2,
+	7: 4,
+	5: 3
+}, R = class {
+	addEventListener(e, t) {
+		this._listeners === void 0 && (this._listeners = {});
+		let n = this._listeners;
+		n[e] === void 0 && (n[e] = []), n[e].indexOf(t) === -1 && n[e].push(t);
+	}
+	hasEventListener(e, t) {
+		let n = this._listeners;
+		return n !== void 0 && n[e] !== void 0 && n[e].indexOf(t) !== -1;
+	}
+	removeEventListener(e, t) {
+		let n = this._listeners;
+		if (n === void 0) return;
+		let r = n[e];
+		if (r !== void 0) {
+			let e = r.indexOf(t);
+			e !== -1 && r.splice(e, 1);
+		}
+	}
+	dispatchEvent(e) {
+		let t = this._listeners;
+		if (t === void 0) return;
+		let n = t[e.type];
+		if (n !== void 0) {
+			e.target = this;
+			let t = n.slice(0);
+			for (let n = 0, r = t.length; n < r; n++) t[n].call(this, e);
+			e.target = null;
+		}
+	}
+}, z = /* @__PURE__ */ "00.01.02.03.04.05.06.07.08.09.0a.0b.0c.0d.0e.0f.10.11.12.13.14.15.16.17.18.19.1a.1b.1c.1d.1e.1f.20.21.22.23.24.25.26.27.28.29.2a.2b.2c.2d.2e.2f.30.31.32.33.34.35.36.37.38.39.3a.3b.3c.3d.3e.3f.40.41.42.43.44.45.46.47.48.49.4a.4b.4c.4d.4e.4f.50.51.52.53.54.55.56.57.58.59.5a.5b.5c.5d.5e.5f.60.61.62.63.64.65.66.67.68.69.6a.6b.6c.6d.6e.6f.70.71.72.73.74.75.76.77.78.79.7a.7b.7c.7d.7e.7f.80.81.82.83.84.85.86.87.88.89.8a.8b.8c.8d.8e.8f.90.91.92.93.94.95.96.97.98.99.9a.9b.9c.9d.9e.9f.a0.a1.a2.a3.a4.a5.a6.a7.a8.a9.aa.ab.ac.ad.ae.af.b0.b1.b2.b3.b4.b5.b6.b7.b8.b9.ba.bb.bc.bd.be.bf.c0.c1.c2.c3.c4.c5.c6.c7.c8.c9.ca.cb.cc.cd.ce.cf.d0.d1.d2.d3.d4.d5.d6.d7.d8.d9.da.db.dc.dd.de.df.e0.e1.e2.e3.e4.e5.e6.e7.e8.e9.ea.eb.ec.ed.ee.ef.f0.f1.f2.f3.f4.f5.f6.f7.f8.f9.fa.fb.fc.fd.fe.ff".split("."), le = Math.PI / 180, ue = 180 / Math.PI;
+function B() {
+	let e = Math.random() * 4294967295 | 0, t = Math.random() * 4294967295 | 0, n = Math.random() * 4294967295 | 0, r = Math.random() * 4294967295 | 0;
+	return (z[e & 255] + z[e >> 8 & 255] + z[e >> 16 & 255] + z[e >> 24 & 255] + "-" + z[t & 255] + z[t >> 8 & 255] + "-" + z[t >> 16 & 15 | 64] + z[t >> 24 & 255] + "-" + z[n & 63 | 128] + z[n >> 8 & 255] + "-" + z[n >> 16 & 255] + z[n >> 24 & 255] + z[r & 255] + z[r >> 8 & 255] + z[r >> 16 & 255] + z[r >> 24 & 255]).toLowerCase();
+}
+function V(e, t, n) {
+	return Math.max(t, Math.min(n, e));
+}
+function de(e, t) {
+	return (e % t + t) % t;
+}
+function fe(e, t, n) {
+	return (1 - n) * e + n * t;
+}
+function pe(e, t) {
+	switch (t.constructor) {
+		case Float32Array: return e;
+		case Uint32Array: return e / 4294967295;
+		case Uint16Array: return e / 65535;
+		case Uint8Array: return e / 255;
+		case Int32Array: return Math.max(e / 2147483647, -1);
+		case Int16Array: return Math.max(e / 32767, -1);
+		case Int8Array: return Math.max(e / 127, -1);
+		default: throw Error("THREE.MathUtils: Invalid component type.");
+	}
+}
+function H(e, t) {
+	switch (t.constructor) {
+		case Float32Array: return e;
+		case Uint32Array: return Math.round(e * 4294967295);
+		case Uint16Array: return Math.round(e * 65535);
+		case Uint8Array: return Math.round(e * 255);
+		case Int32Array: return Math.round(e * 2147483647);
+		case Int16Array: return Math.round(e * 32767);
+		case Int8Array: return Math.round(e * 127);
+		default: throw Error("THREE.MathUtils: Invalid component type.");
+	}
+}
+var U = class e {
+	static {
+		e.prototype.isVector2 = !0;
+	}
+	constructor(e = 0, t = 0) {
+		this.x = e, this.y = t;
+	}
+	get width() {
+		return this.x;
+	}
+	set width(e) {
+		this.x = e;
+	}
+	get height() {
+		return this.y;
+	}
+	set height(e) {
+		this.y = e;
+	}
+	set(e, t) {
+		return this.x = e, this.y = t, this;
+	}
+	setScalar(e) {
+		return this.x = e, this.y = e, this;
+	}
+	setX(e) {
+		return this.x = e, this;
+	}
+	setY(e) {
+		return this.y = e, this;
+	}
+	setComponent(e, t) {
+		switch (e) {
+			case 0:
+				this.x = t;
+				break;
+			case 1:
+				this.y = t;
+				break;
+			default: throw Error("THREE.Vector2: index is out of range: " + e);
+		}
+		return this;
+	}
+	getComponent(e) {
+		switch (e) {
+			case 0: return this.x;
+			case 1: return this.y;
+			default: throw Error("THREE.Vector2: index is out of range: " + e);
+		}
+	}
+	clone() {
+		return new this.constructor(this.x, this.y);
+	}
+	copy(e) {
+		return this.x = e.x, this.y = e.y, this;
+	}
+	add(e) {
+		return this.x += e.x, this.y += e.y, this;
+	}
+	addScalar(e) {
+		return this.x += e, this.y += e, this;
+	}
+	addVectors(e, t) {
+		return this.x = e.x + t.x, this.y = e.y + t.y, this;
+	}
+	addScaledVector(e, t) {
+		return this.x += e.x * t, this.y += e.y * t, this;
+	}
+	sub(e) {
+		return this.x -= e.x, this.y -= e.y, this;
+	}
+	subScalar(e) {
+		return this.x -= e, this.y -= e, this;
+	}
+	subVectors(e, t) {
+		return this.x = e.x - t.x, this.y = e.y - t.y, this;
+	}
+	multiply(e) {
+		return this.x *= e.x, this.y *= e.y, this;
+	}
+	multiplyScalar(e) {
+		return this.x *= e, this.y *= e, this;
+	}
+	divide(e) {
+		return this.x /= e.x, this.y /= e.y, this;
+	}
+	divideScalar(e) {
+		return this.multiplyScalar(1 / e);
+	}
+	applyMatrix3(e) {
+		let t = this.x, n = this.y, r = e.elements;
+		return this.x = r[0] * t + r[3] * n + r[6], this.y = r[1] * t + r[4] * n + r[7], this;
+	}
+	min(e) {
+		return this.x = Math.min(this.x, e.x), this.y = Math.min(this.y, e.y), this;
+	}
+	max(e) {
+		return this.x = Math.max(this.x, e.x), this.y = Math.max(this.y, e.y), this;
+	}
+	clamp(e, t) {
+		return this.x = V(this.x, e.x, t.x), this.y = V(this.y, e.y, t.y), this;
+	}
+	clampScalar(e, t) {
+		return this.x = V(this.x, e, t), this.y = V(this.y, e, t), this;
+	}
+	clampLength(e, t) {
+		let n = this.length();
+		return this.divideScalar(n || 1).multiplyScalar(V(n, e, t));
+	}
+	floor() {
+		return this.x = Math.floor(this.x), this.y = Math.floor(this.y), this;
+	}
+	ceil() {
+		return this.x = Math.ceil(this.x), this.y = Math.ceil(this.y), this;
+	}
+	round() {
+		return this.x = Math.round(this.x), this.y = Math.round(this.y), this;
+	}
+	roundToZero() {
+		return this.x = Math.trunc(this.x), this.y = Math.trunc(this.y), this;
+	}
+	negate() {
+		return this.x = -this.x, this.y = -this.y, this;
+	}
+	dot(e) {
+		return this.x * e.x + this.y * e.y;
+	}
+	cross(e) {
+		return this.x * e.y - this.y * e.x;
+	}
+	lengthSq() {
+		return this.x * this.x + this.y * this.y;
+	}
+	length() {
+		return Math.sqrt(this.x * this.x + this.y * this.y);
+	}
+	manhattanLength() {
+		return Math.abs(this.x) + Math.abs(this.y);
+	}
+	normalize() {
+		return this.divideScalar(this.length() || 1);
+	}
+	angle() {
+		return Math.atan2(-this.y, -this.x) + Math.PI;
+	}
+	angleTo(e) {
+		let t = Math.sqrt(this.lengthSq() * e.lengthSq());
+		if (t === 0) return Math.PI / 2;
+		let n = this.dot(e) / t;
+		return Math.acos(V(n, -1, 1));
+	}
+	distanceTo(e) {
+		return Math.sqrt(this.distanceToSquared(e));
+	}
+	distanceToSquared(e) {
+		let t = this.x - e.x, n = this.y - e.y;
+		return t * t + n * n;
+	}
+	manhattanDistanceTo(e) {
+		return Math.abs(this.x - e.x) + Math.abs(this.y - e.y);
+	}
+	setLength(e) {
+		return this.normalize().multiplyScalar(e);
+	}
+	lerp(e, t) {
+		return this.x += (e.x - this.x) * t, this.y += (e.y - this.y) * t, this;
+	}
+	lerpVectors(e, t, n) {
+		return this.x = e.x + (t.x - e.x) * n, this.y = e.y + (t.y - e.y) * n, this;
+	}
+	equals(e) {
+		return e.x === this.x && e.y === this.y;
+	}
+	fromArray(e, t = 0) {
+		return this.x = e[t], this.y = e[t + 1], this;
+	}
+	toArray(e = [], t = 0) {
+		return e[t] = this.x, e[t + 1] = this.y, e;
+	}
+	fromBufferAttribute(e, t) {
+		return this.x = e.getX(t), this.y = e.getY(t), this;
+	}
+	rotateAround(e, t) {
+		let n = Math.cos(t), r = Math.sin(t), i = this.x - e.x, a = this.y - e.y;
+		return this.x = i * n - a * r + e.x, this.y = i * r + a * n + e.y, this;
+	}
+	random() {
+		return this.x = Math.random(), this.y = Math.random(), this;
+	}
+	*[Symbol.iterator]() {
+		yield this.x, yield this.y;
+	}
+}, me = class {
+	constructor(e = 0, t = 0, n = 0, r = 1) {
+		this.isQuaternion = !0, this._x = e, this._y = t, this._z = n, this._w = r;
+	}
+	static slerpFlat(e, t, n, r, i, a, o) {
+		let s = n[r + 0], c = n[r + 1], l = n[r + 2], u = n[r + 3], d = i[a + 0], f = i[a + 1], p = i[a + 2], m = i[a + 3];
+		if (u !== m || s !== d || c !== f || l !== p) {
+			let e = s * d + c * f + l * p + u * m;
+			e < 0 && (d = -d, f = -f, p = -p, m = -m, e = -e);
+			let t = 1 - o;
+			if (e < .9995) {
+				let n = Math.acos(e), r = Math.sin(n);
+				t = Math.sin(t * n) / r, o = Math.sin(o * n) / r, s = s * t + d * o, c = c * t + f * o, l = l * t + p * o, u = u * t + m * o;
+			} else {
+				s = s * t + d * o, c = c * t + f * o, l = l * t + p * o, u = u * t + m * o;
+				let e = 1 / Math.sqrt(s * s + c * c + l * l + u * u);
+				s *= e, c *= e, l *= e, u *= e;
+			}
+		}
+		e[t] = s, e[t + 1] = c, e[t + 2] = l, e[t + 3] = u;
+	}
+	static multiplyQuaternionsFlat(e, t, n, r, i, a) {
+		let o = n[r], s = n[r + 1], c = n[r + 2], l = n[r + 3], u = i[a], d = i[a + 1], f = i[a + 2], p = i[a + 3];
+		return e[t] = o * p + l * u + s * f - c * d, e[t + 1] = s * p + l * d + c * u - o * f, e[t + 2] = c * p + l * f + o * d - s * u, e[t + 3] = l * p - o * u - s * d - c * f, e;
+	}
+	get x() {
+		return this._x;
+	}
+	set x(e) {
+		this._x = e, this._onChangeCallback();
+	}
+	get y() {
+		return this._y;
+	}
+	set y(e) {
+		this._y = e, this._onChangeCallback();
+	}
+	get z() {
+		return this._z;
+	}
+	set z(e) {
+		this._z = e, this._onChangeCallback();
+	}
+	get w() {
+		return this._w;
+	}
+	set w(e) {
+		this._w = e, this._onChangeCallback();
+	}
+	set(e, t, n, r) {
+		return this._x = e, this._y = t, this._z = n, this._w = r, this._onChangeCallback(), this;
+	}
+	clone() {
+		return new this.constructor(this._x, this._y, this._z, this._w);
+	}
+	copy(e) {
+		return this._x = e.x, this._y = e.y, this._z = e.z, this._w = e.w, this._onChangeCallback(), this;
+	}
+	setFromEuler(e, t = !0) {
+		let n = e._x, r = e._y, i = e._z, a = e._order, o = Math.cos, s = Math.sin, c = o(n / 2), l = o(r / 2), u = o(i / 2), d = s(n / 2), f = s(r / 2), p = s(i / 2);
+		switch (a) {
+			case "XYZ":
+				this._x = d * l * u + c * f * p, this._y = c * f * u - d * l * p, this._z = c * l * p + d * f * u, this._w = c * l * u - d * f * p;
+				break;
+			case "YXZ":
+				this._x = d * l * u + c * f * p, this._y = c * f * u - d * l * p, this._z = c * l * p - d * f * u, this._w = c * l * u + d * f * p;
+				break;
+			case "ZXY":
+				this._x = d * l * u - c * f * p, this._y = c * f * u + d * l * p, this._z = c * l * p + d * f * u, this._w = c * l * u - d * f * p;
+				break;
+			case "ZYX":
+				this._x = d * l * u - c * f * p, this._y = c * f * u + d * l * p, this._z = c * l * p - d * f * u, this._w = c * l * u + d * f * p;
+				break;
+			case "YZX":
+				this._x = d * l * u + c * f * p, this._y = c * f * u + d * l * p, this._z = c * l * p - d * f * u, this._w = c * l * u - d * f * p;
+				break;
+			case "XZY":
+				this._x = d * l * u - c * f * p, this._y = c * f * u - d * l * p, this._z = c * l * p + d * f * u, this._w = c * l * u + d * f * p;
+				break;
+			default: F("Quaternion: .setFromEuler() encountered an unknown order: " + a);
+		}
+		return t === !0 && this._onChangeCallback(), this;
+	}
+	setFromAxisAngle(e, t) {
+		let n = t / 2, r = Math.sin(n);
+		return this._x = e.x * r, this._y = e.y * r, this._z = e.z * r, this._w = Math.cos(n), this._onChangeCallback(), this;
+	}
+	setFromRotationMatrix(e) {
+		let t = e.elements, n = t[0], r = t[4], i = t[8], a = t[1], o = t[5], s = t[9], c = t[2], l = t[6], u = t[10], d = n + o + u;
+		if (d > 0) {
+			let e = .5 / Math.sqrt(d + 1);
+			this._w = .25 / e, this._x = (l - s) * e, this._y = (i - c) * e, this._z = (a - r) * e;
+		} else if (n > o && n > u) {
+			let e = 2 * Math.sqrt(1 + n - o - u);
+			this._w = (l - s) / e, this._x = .25 * e, this._y = (r + a) / e, this._z = (i + c) / e;
+		} else if (o > u) {
+			let e = 2 * Math.sqrt(1 + o - n - u);
+			this._w = (i - c) / e, this._x = (r + a) / e, this._y = .25 * e, this._z = (s + l) / e;
+		} else {
+			let e = 2 * Math.sqrt(1 + u - n - o);
+			this._w = (a - r) / e, this._x = (i + c) / e, this._y = (s + l) / e, this._z = .25 * e;
+		}
+		return this._onChangeCallback(), this;
+	}
+	setFromUnitVectors(e, t) {
+		let n = e.dot(t) + 1;
+		return n < 1e-8 ? (n = 0, Math.abs(e.x) > Math.abs(e.z) ? (this._x = -e.y, this._y = e.x, this._z = 0, this._w = n) : (this._x = 0, this._y = -e.z, this._z = e.y, this._w = n)) : (this._x = e.y * t.z - e.z * t.y, this._y = e.z * t.x - e.x * t.z, this._z = e.x * t.y - e.y * t.x, this._w = n), this.normalize();
+	}
+	angleTo(e) {
+		return 2 * Math.acos(Math.abs(V(this.dot(e), -1, 1)));
+	}
+	rotateTowards(e, t) {
+		let n = this.angleTo(e);
+		if (n === 0) return this;
+		let r = Math.min(1, t / n);
+		return this.slerp(e, r), this;
+	}
+	identity() {
+		return this.set(0, 0, 0, 1);
+	}
+	invert() {
+		return this.conjugate();
+	}
+	conjugate() {
+		return this._x *= -1, this._y *= -1, this._z *= -1, this._onChangeCallback(), this;
+	}
+	dot(e) {
+		return this._x * e._x + this._y * e._y + this._z * e._z + this._w * e._w;
+	}
+	lengthSq() {
+		return this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w;
+	}
+	length() {
+		return Math.sqrt(this._x * this._x + this._y * this._y + this._z * this._z + this._w * this._w);
+	}
+	normalize() {
+		let e = this.length();
+		return e === 0 ? (this._x = 0, this._y = 0, this._z = 0, this._w = 1) : (e = 1 / e, this._x *= e, this._y *= e, this._z *= e, this._w *= e), this._onChangeCallback(), this;
+	}
+	multiply(e) {
+		return this.multiplyQuaternions(this, e);
+	}
+	premultiply(e) {
+		return this.multiplyQuaternions(e, this);
+	}
+	multiplyQuaternions(e, t) {
+		let n = e._x, r = e._y, i = e._z, a = e._w, o = t._x, s = t._y, c = t._z, l = t._w;
+		return this._x = n * l + a * o + r * c - i * s, this._y = r * l + a * s + i * o - n * c, this._z = i * l + a * c + n * s - r * o, this._w = a * l - n * o - r * s - i * c, this._onChangeCallback(), this;
+	}
+	slerp(e, t) {
+		let n = e._x, r = e._y, i = e._z, a = e._w, o = this.dot(e);
+		o < 0 && (n = -n, r = -r, i = -i, a = -a, o = -o);
+		let s = 1 - t;
+		if (o < .9995) {
+			let e = Math.acos(o), c = Math.sin(e);
+			s = Math.sin(s * e) / c, t = Math.sin(t * e) / c, this._x = this._x * s + n * t, this._y = this._y * s + r * t, this._z = this._z * s + i * t, this._w = this._w * s + a * t, this._onChangeCallback();
+		} else this._x = this._x * s + n * t, this._y = this._y * s + r * t, this._z = this._z * s + i * t, this._w = this._w * s + a * t, this.normalize();
+		return this;
+	}
+	slerpQuaternions(e, t, n) {
+		return this.copy(e).slerp(t, n);
+	}
+	random() {
+		let e = 2 * Math.PI * Math.random(), t = 2 * Math.PI * Math.random(), n = Math.random(), r = Math.sqrt(1 - n), i = Math.sqrt(n);
+		return this.set(r * Math.sin(e), r * Math.cos(e), i * Math.sin(t), i * Math.cos(t));
+	}
+	equals(e) {
+		return e._x === this._x && e._y === this._y && e._z === this._z && e._w === this._w;
+	}
+	fromArray(e, t = 0) {
+		return this._x = e[t], this._y = e[t + 1], this._z = e[t + 2], this._w = e[t + 3], this._onChangeCallback(), this;
+	}
+	toArray(e = [], t = 0) {
+		return e[t] = this._x, e[t + 1] = this._y, e[t + 2] = this._z, e[t + 3] = this._w, e;
+	}
+	fromBufferAttribute(e, t) {
+		return this._x = e.getX(t), this._y = e.getY(t), this._z = e.getZ(t), this._w = e.getW(t), this._onChangeCallback(), this;
+	}
+	toJSON() {
+		return this.toArray();
+	}
+	_onChange(e) {
+		return this._onChangeCallback = e, this;
+	}
+	_onChangeCallback() {}
+	*[Symbol.iterator]() {
+		yield this._x, yield this._y, yield this._z, yield this._w;
+	}
+}, W = class e {
+	static {
+		e.prototype.isVector3 = !0;
+	}
+	constructor(e = 0, t = 0, n = 0) {
+		this.x = e, this.y = t, this.z = n;
+	}
+	set(e, t, n) {
+		return n === void 0 && (n = this.z), this.x = e, this.y = t, this.z = n, this;
+	}
+	setScalar(e) {
+		return this.x = e, this.y = e, this.z = e, this;
+	}
+	setX(e) {
+		return this.x = e, this;
+	}
+	setY(e) {
+		return this.y = e, this;
+	}
+	setZ(e) {
+		return this.z = e, this;
+	}
+	setComponent(e, t) {
+		switch (e) {
+			case 0:
+				this.x = t;
+				break;
+			case 1:
+				this.y = t;
+				break;
+			case 2:
+				this.z = t;
+				break;
+			default: throw Error("THREE.Vector3: index is out of range: " + e);
+		}
+		return this;
+	}
+	getComponent(e) {
+		switch (e) {
+			case 0: return this.x;
+			case 1: return this.y;
+			case 2: return this.z;
+			default: throw Error("THREE.Vector3: index is out of range: " + e);
+		}
+	}
+	clone() {
+		return new this.constructor(this.x, this.y, this.z);
+	}
+	copy(e) {
+		return this.x = e.x, this.y = e.y, this.z = e.z, this;
+	}
+	add(e) {
+		return this.x += e.x, this.y += e.y, this.z += e.z, this;
+	}
+	addScalar(e) {
+		return this.x += e, this.y += e, this.z += e, this;
+	}
+	addVectors(e, t) {
+		return this.x = e.x + t.x, this.y = e.y + t.y, this.z = e.z + t.z, this;
+	}
+	addScaledVector(e, t) {
+		return this.x += e.x * t, this.y += e.y * t, this.z += e.z * t, this;
+	}
+	sub(e) {
+		return this.x -= e.x, this.y -= e.y, this.z -= e.z, this;
+	}
+	subScalar(e) {
+		return this.x -= e, this.y -= e, this.z -= e, this;
+	}
+	subVectors(e, t) {
+		return this.x = e.x - t.x, this.y = e.y - t.y, this.z = e.z - t.z, this;
+	}
+	multiply(e) {
+		return this.x *= e.x, this.y *= e.y, this.z *= e.z, this;
+	}
+	multiplyScalar(e) {
+		return this.x *= e, this.y *= e, this.z *= e, this;
+	}
+	multiplyVectors(e, t) {
+		return this.x = e.x * t.x, this.y = e.y * t.y, this.z = e.z * t.z, this;
+	}
+	applyEuler(e) {
+		return this.applyQuaternion(ge.setFromEuler(e));
+	}
+	applyAxisAngle(e, t) {
+		return this.applyQuaternion(ge.setFromAxisAngle(e, t));
+	}
+	applyMatrix3(e) {
+		let t = this.x, n = this.y, r = this.z, i = e.elements;
+		return this.x = i[0] * t + i[3] * n + i[6] * r, this.y = i[1] * t + i[4] * n + i[7] * r, this.z = i[2] * t + i[5] * n + i[8] * r, this;
+	}
+	applyNormalMatrix(e) {
+		return this.applyMatrix3(e).normalize();
+	}
+	applyMatrix4(e) {
+		let t = this.x, n = this.y, r = this.z, i = e.elements, a = 1 / (i[3] * t + i[7] * n + i[11] * r + i[15]);
+		return this.x = (i[0] * t + i[4] * n + i[8] * r + i[12]) * a, this.y = (i[1] * t + i[5] * n + i[9] * r + i[13]) * a, this.z = (i[2] * t + i[6] * n + i[10] * r + i[14]) * a, this;
+	}
+	applyQuaternion(e) {
+		let t = this.x, n = this.y, r = this.z, i = e.x, a = e.y, o = e.z, s = e.w, c = 2 * (a * r - o * n), l = 2 * (o * t - i * r), u = 2 * (i * n - a * t);
+		return this.x = t + s * c + a * u - o * l, this.y = n + s * l + o * c - i * u, this.z = r + s * u + i * l - a * c, this;
+	}
+	project(e) {
+		return this.applyMatrix4(e.matrixWorldInverse).applyMatrix4(e.projectionMatrix);
+	}
+	unproject(e) {
+		return this.applyMatrix4(e.projectionMatrixInverse).applyMatrix4(e.matrixWorld);
+	}
+	transformDirection(e) {
+		let t = this.x, n = this.y, r = this.z, i = e.elements;
+		return this.x = i[0] * t + i[4] * n + i[8] * r, this.y = i[1] * t + i[5] * n + i[9] * r, this.z = i[2] * t + i[6] * n + i[10] * r, this.normalize();
+	}
+	divide(e) {
+		return this.x /= e.x, this.y /= e.y, this.z /= e.z, this;
+	}
+	divideScalar(e) {
+		return this.multiplyScalar(1 / e);
+	}
+	min(e) {
+		return this.x = Math.min(this.x, e.x), this.y = Math.min(this.y, e.y), this.z = Math.min(this.z, e.z), this;
+	}
+	max(e) {
+		return this.x = Math.max(this.x, e.x), this.y = Math.max(this.y, e.y), this.z = Math.max(this.z, e.z), this;
+	}
+	clamp(e, t) {
+		return this.x = V(this.x, e.x, t.x), this.y = V(this.y, e.y, t.y), this.z = V(this.z, e.z, t.z), this;
+	}
+	clampScalar(e, t) {
+		return this.x = V(this.x, e, t), this.y = V(this.y, e, t), this.z = V(this.z, e, t), this;
+	}
+	clampLength(e, t) {
+		let n = this.length();
+		return this.divideScalar(n || 1).multiplyScalar(V(n, e, t));
+	}
+	floor() {
+		return this.x = Math.floor(this.x), this.y = Math.floor(this.y), this.z = Math.floor(this.z), this;
+	}
+	ceil() {
+		return this.x = Math.ceil(this.x), this.y = Math.ceil(this.y), this.z = Math.ceil(this.z), this;
+	}
+	round() {
+		return this.x = Math.round(this.x), this.y = Math.round(this.y), this.z = Math.round(this.z), this;
+	}
+	roundToZero() {
+		return this.x = Math.trunc(this.x), this.y = Math.trunc(this.y), this.z = Math.trunc(this.z), this;
+	}
+	negate() {
+		return this.x = -this.x, this.y = -this.y, this.z = -this.z, this;
+	}
+	dot(e) {
+		return this.x * e.x + this.y * e.y + this.z * e.z;
+	}
+	lengthSq() {
+		return this.x * this.x + this.y * this.y + this.z * this.z;
+	}
+	length() {
+		return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z);
+	}
+	manhattanLength() {
+		return Math.abs(this.x) + Math.abs(this.y) + Math.abs(this.z);
+	}
+	normalize() {
+		return this.divideScalar(this.length() || 1);
+	}
+	setLength(e) {
+		return this.normalize().multiplyScalar(e);
+	}
+	lerp(e, t) {
+		return this.x += (e.x - this.x) * t, this.y += (e.y - this.y) * t, this.z += (e.z - this.z) * t, this;
+	}
+	lerpVectors(e, t, n) {
+		return this.x = e.x + (t.x - e.x) * n, this.y = e.y + (t.y - e.y) * n, this.z = e.z + (t.z - e.z) * n, this;
+	}
+	cross(e) {
+		return this.crossVectors(this, e);
+	}
+	crossVectors(e, t) {
+		let n = e.x, r = e.y, i = e.z, a = t.x, o = t.y, s = t.z;
+		return this.x = r * s - i * o, this.y = i * a - n * s, this.z = n * o - r * a, this;
+	}
+	projectOnVector(e) {
+		let t = e.lengthSq();
+		if (t === 0) return this.set(0, 0, 0);
+		let n = e.dot(this) / t;
+		return this.copy(e).multiplyScalar(n);
+	}
+	projectOnPlane(e) {
+		return he.copy(this).projectOnVector(e), this.sub(he);
+	}
+	reflect(e) {
+		return this.sub(he.copy(e).multiplyScalar(2 * this.dot(e)));
+	}
+	angleTo(e) {
+		let t = Math.sqrt(this.lengthSq() * e.lengthSq());
+		if (t === 0) return Math.PI / 2;
+		let n = this.dot(e) / t;
+		return Math.acos(V(n, -1, 1));
+	}
+	distanceTo(e) {
+		return Math.sqrt(this.distanceToSquared(e));
+	}
+	distanceToSquared(e) {
+		let t = this.x - e.x, n = this.y - e.y, r = this.z - e.z;
+		return t * t + n * n + r * r;
+	}
+	manhattanDistanceTo(e) {
+		return Math.abs(this.x - e.x) + Math.abs(this.y - e.y) + Math.abs(this.z - e.z);
+	}
+	setFromSpherical(e) {
+		return this.setFromSphericalCoords(e.radius, e.phi, e.theta);
+	}
+	setFromSphericalCoords(e, t, n) {
+		let r = Math.sin(t) * e;
+		return this.x = r * Math.sin(n), this.y = Math.cos(t) * e, this.z = r * Math.cos(n), this;
+	}
+	setFromCylindrical(e) {
+		return this.setFromCylindricalCoords(e.radius, e.theta, e.y);
+	}
+	setFromCylindricalCoords(e, t, n) {
+		return this.x = e * Math.sin(t), this.y = n, this.z = e * Math.cos(t), this;
+	}
+	setFromMatrixPosition(e) {
+		let t = e.elements;
+		return this.x = t[12], this.y = t[13], this.z = t[14], this;
+	}
+	setFromMatrixScale(e) {
+		let t = this.setFromMatrixColumn(e, 0).length(), n = this.setFromMatrixColumn(e, 1).length(), r = this.setFromMatrixColumn(e, 2).length();
+		return this.x = t, this.y = n, this.z = r, this;
+	}
+	setFromMatrixColumn(e, t) {
+		return this.fromArray(e.elements, t * 4);
+	}
+	setFromMatrix3Column(e, t) {
+		return this.fromArray(e.elements, t * 3);
+	}
+	setFromEuler(e) {
+		return this.x = e._x, this.y = e._y, this.z = e._z, this;
+	}
+	setFromColor(e) {
+		return this.x = e.r, this.y = e.g, this.z = e.b, this;
+	}
+	equals(e) {
+		return e.x === this.x && e.y === this.y && e.z === this.z;
+	}
+	fromArray(e, t = 0) {
+		return this.x = e[t], this.y = e[t + 1], this.z = e[t + 2], this;
+	}
+	toArray(e = [], t = 0) {
+		return e[t] = this.x, e[t + 1] = this.y, e[t + 2] = this.z, e;
+	}
+	fromBufferAttribute(e, t) {
+		return this.x = e.getX(t), this.y = e.getY(t), this.z = e.getZ(t), this;
+	}
+	random() {
+		return this.x = Math.random(), this.y = Math.random(), this.z = Math.random(), this;
+	}
+	randomDirection() {
+		let e = Math.random() * Math.PI * 2, t = Math.random() * 2 - 1, n = Math.sqrt(1 - t * t);
+		return this.x = n * Math.cos(e), this.y = t, this.z = n * Math.sin(e), this;
+	}
+	*[Symbol.iterator]() {
+		yield this.x, yield this.y, yield this.z;
+	}
+}, he = /*@__PURE__*/ new W(), ge = /*@__PURE__*/ new me(), G = class e {
+	static {
+		e.prototype.isMatrix3 = !0;
+	}
+	constructor(e, t, n, r, i, a, o, s, c) {
+		this.elements = [
+			1,
+			0,
+			0,
+			0,
+			1,
+			0,
+			0,
+			0,
+			1
+		], e !== void 0 && this.set(e, t, n, r, i, a, o, s, c);
+	}
+	set(e, t, n, r, i, a, o, s, c) {
+		let l = this.elements;
+		return l[0] = e, l[1] = r, l[2] = o, l[3] = t, l[4] = i, l[5] = s, l[6] = n, l[7] = a, l[8] = c, this;
+	}
+	identity() {
+		return this.set(1, 0, 0, 0, 1, 0, 0, 0, 1), this;
+	}
+	copy(e) {
+		let t = this.elements, n = e.elements;
+		return t[0] = n[0], t[1] = n[1], t[2] = n[2], t[3] = n[3], t[4] = n[4], t[5] = n[5], t[6] = n[6], t[7] = n[7], t[8] = n[8], this;
+	}
+	extractBasis(e, t, n) {
+		return e.setFromMatrix3Column(this, 0), t.setFromMatrix3Column(this, 1), n.setFromMatrix3Column(this, 2), this;
+	}
+	setFromMatrix4(e) {
+		let t = e.elements;
+		return this.set(t[0], t[4], t[8], t[1], t[5], t[9], t[2], t[6], t[10]), this;
+	}
+	multiply(e) {
+		return this.multiplyMatrices(this, e);
+	}
+	premultiply(e) {
+		return this.multiplyMatrices(e, this);
+	}
+	multiplyMatrices(e, t) {
+		let n = e.elements, r = t.elements, i = this.elements, a = n[0], o = n[3], s = n[6], c = n[1], l = n[4], u = n[7], d = n[2], f = n[5], p = n[8], m = r[0], h = r[3], g = r[6], _ = r[1], v = r[4], y = r[7], b = r[2], x = r[5], S = r[8];
+		return i[0] = a * m + o * _ + s * b, i[3] = a * h + o * v + s * x, i[6] = a * g + o * y + s * S, i[1] = c * m + l * _ + u * b, i[4] = c * h + l * v + u * x, i[7] = c * g + l * y + u * S, i[2] = d * m + f * _ + p * b, i[5] = d * h + f * v + p * x, i[8] = d * g + f * y + p * S, this;
+	}
+	multiplyScalar(e) {
+		let t = this.elements;
+		return t[0] *= e, t[3] *= e, t[6] *= e, t[1] *= e, t[4] *= e, t[7] *= e, t[2] *= e, t[5] *= e, t[8] *= e, this;
+	}
+	determinant() {
+		let e = this.elements, t = e[0], n = e[1], r = e[2], i = e[3], a = e[4], o = e[5], s = e[6], c = e[7], l = e[8];
+		return t * a * l - t * o * c - n * i * l + n * o * s + r * i * c - r * a * s;
+	}
+	invert() {
+		let e = this.elements, t = e[0], n = e[1], r = e[2], i = e[3], a = e[4], o = e[5], s = e[6], c = e[7], l = e[8], u = l * a - o * c, d = o * s - l * i, f = c * i - a * s, p = t * u + n * d + r * f;
+		if (p === 0) return this.set(0, 0, 0, 0, 0, 0, 0, 0, 0);
+		let m = 1 / p;
+		return e[0] = u * m, e[1] = (r * c - l * n) * m, e[2] = (o * n - r * a) * m, e[3] = d * m, e[4] = (l * t - r * s) * m, e[5] = (r * i - o * t) * m, e[6] = f * m, e[7] = (n * s - c * t) * m, e[8] = (a * t - n * i) * m, this;
+	}
+	transpose() {
+		let e, t = this.elements;
+		return e = t[1], t[1] = t[3], t[3] = e, e = t[2], t[2] = t[6], t[6] = e, e = t[5], t[5] = t[7], t[7] = e, this;
+	}
+	getNormalMatrix(e) {
+		return this.setFromMatrix4(e).invert().transpose();
+	}
+	transposeIntoArray(e) {
+		let t = this.elements;
+		return e[0] = t[0], e[1] = t[3], e[2] = t[6], e[3] = t[1], e[4] = t[4], e[5] = t[7], e[6] = t[2], e[7] = t[5], e[8] = t[8], this;
+	}
+	setUvTransform(e, t, n, r, i, a, o) {
+		let s = Math.cos(i), c = Math.sin(i);
+		return this.set(n * s, n * c, -n * (s * a + c * o) + a + e, -r * c, r * s, -r * (-c * a + s * o) + o + t, 0, 0, 1), this;
+	}
+	scale(e, t) {
+		return L("Matrix3: .scale() is deprecated. Use .makeScale() instead."), this.premultiply(_e.makeScale(e, t)), this;
+	}
+	rotate(e) {
+		return L("Matrix3: .rotate() is deprecated. Use .makeRotation() instead."), this.premultiply(_e.makeRotation(-e)), this;
+	}
+	translate(e, t) {
+		return L("Matrix3: .translate() is deprecated. Use .makeTranslation() instead."), this.premultiply(_e.makeTranslation(e, t)), this;
+	}
+	makeTranslation(e, t) {
+		return e.isVector2 ? this.set(1, 0, e.x, 0, 1, e.y, 0, 0, 1) : this.set(1, 0, e, 0, 1, t, 0, 0, 1), this;
+	}
+	makeRotation(e) {
+		let t = Math.cos(e), n = Math.sin(e);
+		return this.set(t, -n, 0, n, t, 0, 0, 0, 1), this;
+	}
+	makeScale(e, t) {
+		return this.set(e, 0, 0, 0, t, 0, 0, 0, 1), this;
+	}
+	equals(e) {
+		let t = this.elements, n = e.elements;
+		for (let e = 0; e < 9; e++) if (t[e] !== n[e]) return !1;
+		return !0;
+	}
+	fromArray(e, t = 0) {
+		for (let n = 0; n < 9; n++) this.elements[n] = e[n + t];
+		return this;
+	}
+	toArray(e = [], t = 0) {
+		let n = this.elements;
+		return e[t] = n[0], e[t + 1] = n[1], e[t + 2] = n[2], e[t + 3] = n[3], e[t + 4] = n[4], e[t + 5] = n[5], e[t + 6] = n[6], e[t + 7] = n[7], e[t + 8] = n[8], e;
+	}
+	clone() {
+		return new this.constructor().fromArray(this.elements);
+	}
+}, _e = /*@__PURE__*/ new G(), ve = /*@__PURE__*/ new G().set(.4123908, .3575843, .1804808, .212639, .7151687, .0721923, .0193308, .1191948, .9505322), ye = /*@__PURE__*/ new G().set(3.2409699, -1.5373832, -.4986108, -.9692436, 1.8759675, .0415551, .0556301, -.203977, 1.0569715);
+function be() {
+	let e = {
+		enabled: !0,
+		workingColorSpace: A,
+		spaces: {},
+		convert: function(e, t, n) {
+			return this.enabled === !1 || t === n || !t || !n ? e : (this.spaces[t].transfer === "srgb" && (e.r = xe(e.r), e.g = xe(e.g), e.b = xe(e.b)), this.spaces[t].primaries !== this.spaces[n].primaries && (e.applyMatrix3(this.spaces[t].toXYZ), e.applyMatrix3(this.spaces[n].fromXYZ)), this.spaces[n].transfer === "srgb" && (e.r = Se(e.r), e.g = Se(e.g), e.b = Se(e.b)), e);
+		},
+		workingToColorSpace: function(e, t) {
+			return this.convert(e, this.workingColorSpace, t);
+		},
+		colorSpaceToWorking: function(e, t) {
+			return this.convert(e, t, this.workingColorSpace);
+		},
+		getPrimaries: function(e) {
+			return this.spaces[e].primaries;
+		},
+		getTransfer: function(e) {
+			return e === "" ? ee : this.spaces[e].transfer;
+		},
+		getToneMappingMode: function(e) {
+			return this.spaces[e].outputColorSpaceConfig.toneMappingMode || "standard";
+		},
+		getLuminanceCoefficients: function(e, t = this.workingColorSpace) {
+			return e.fromArray(this.spaces[t].luminanceCoefficients);
+		},
+		define: function(e) {
+			Object.assign(this.spaces, e);
+		},
+		_getMatrix: function(e, t, n) {
+			return e.copy(this.spaces[t].toXYZ).multiply(this.spaces[n].fromXYZ);
+		},
+		_getDrawingBufferColorSpace: function(e) {
+			return this.spaces[e].outputColorSpaceConfig.drawingBufferColorSpace;
+		},
+		_getUnpackColorSpace: function(e = this.workingColorSpace) {
+			return this.spaces[e].workingColorSpaceConfig.unpackColorSpace;
+		},
+		fromWorkingColorSpace: function(t, n) {
+			return L("ColorManagement: .fromWorkingColorSpace() has been renamed to .workingToColorSpace()."), e.workingToColorSpace(t, n);
+		},
+		toWorkingColorSpace: function(t, n) {
+			return L("ColorManagement: .toWorkingColorSpace() has been renamed to .colorSpaceToWorking()."), e.colorSpaceToWorking(t, n);
+		}
+	}, t = [
+		.64,
+		.33,
+		.3,
+		.6,
+		.15,
+		.06
+	], n = [
+		.2126,
+		.7152,
+		.0722
+	], r = [.3127, .329];
+	return e.define({
+		[A]: {
+			primaries: t,
+			whitePoint: r,
+			transfer: ee,
+			toXYZ: ve,
+			fromXYZ: ye,
+			luminanceCoefficients: n,
+			workingColorSpaceConfig: { unpackColorSpace: k },
+			outputColorSpaceConfig: { drawingBufferColorSpace: k }
+		},
+		[k]: {
+			primaries: t,
+			whitePoint: r,
+			transfer: j,
+			toXYZ: ve,
+			fromXYZ: ye,
+			luminanceCoefficients: n,
+			outputColorSpaceConfig: { drawingBufferColorSpace: k }
+		}
+	}), e;
+}
+var K = /*@__PURE__*/ be();
+function xe(e) {
+	return e < .04045 ? e * .0773993808 : (e * .9478672986 + .0521327014) ** 2.4;
+}
+function Se(e) {
+	return e < .0031308 ? e * 12.92 : 1.055 * e ** .41666 - .055;
+}
+var Ce, we = class {
+	static getDataURL(e, t = "image/png") {
+		if (/^data:/i.test(e.src) || typeof HTMLCanvasElement > "u") return e.src;
+		let n;
+		if (e instanceof HTMLCanvasElement) n = e;
+		else {
+			Ce === void 0 && (Ce = re("canvas")), Ce.width = e.width, Ce.height = e.height;
+			let t = Ce.getContext("2d");
+			e instanceof ImageData ? t.putImageData(e, 0, 0) : t.drawImage(e, 0, 0, e.width, e.height), n = Ce;
+		}
+		return n.toDataURL(t);
+	}
+	static sRGBToLinear(e) {
+		if (typeof HTMLImageElement < "u" && e instanceof HTMLImageElement || typeof HTMLCanvasElement < "u" && e instanceof HTMLCanvasElement || typeof ImageBitmap < "u" && e instanceof ImageBitmap) {
+			let t = re("canvas");
+			t.width = e.width, t.height = e.height;
+			let n = t.getContext("2d");
+			n.drawImage(e, 0, 0, e.width, e.height);
+			let r = n.getImageData(0, 0, e.width, e.height), i = r.data;
+			for (let e = 0; e < i.length; e++) i[e] = xe(i[e] / 255) * 255;
+			return n.putImageData(r, 0, 0), t;
+		} else if (e.data) {
+			let t = e.data.slice(0);
+			for (let e = 0; e < t.length; e++) t instanceof Uint8Array || t instanceof Uint8ClampedArray ? t[e] = Math.floor(xe(t[e] / 255) * 255) : t[e] = xe(t[e]);
+			return {
+				data: t,
+				width: e.width,
+				height: e.height
+			};
+		} else return F("ImageUtils.sRGBToLinear(): Unsupported image type. No color space conversion applied."), e;
+	}
+}, Te = 0, Ee = class {
+	constructor(e = null) {
+		this.isSource = !0, Object.defineProperty(this, "id", { value: Te++ }), this.uuid = B(), this.data = e, this.dataReady = !0, this.version = 0;
+	}
+	getSize(e) {
+		let t = this.data;
+		return typeof HTMLVideoElement < "u" && t instanceof HTMLVideoElement ? e.set(t.videoWidth, t.videoHeight, 0) : typeof VideoFrame < "u" && t instanceof VideoFrame ? e.set(t.displayWidth, t.displayHeight, 0) : t === null ? e.set(0, 0, 0) : e.set(t.width, t.height, t.depth || 0), e;
+	}
+	set needsUpdate(e) {
+		e === !0 && this.version++;
+	}
+	toJSON(e) {
+		let t = e === void 0 || typeof e == "string";
+		if (!t && e.images[this.uuid] !== void 0) return e.images[this.uuid];
+		let n = {
+			uuid: this.uuid,
+			url: ""
+		}, r = this.data;
+		if (r !== null) {
+			let e;
+			if (Array.isArray(r)) {
+				e = [];
+				for (let t = 0, n = r.length; t < n; t++) r[t].isDataTexture ? e.push(De(r[t].image)) : e.push(De(r[t]));
+			} else e = De(r);
+			n.url = e;
+		}
+		return t || (e.images[this.uuid] = n), n;
+	}
+};
+function De(e) {
+	return typeof HTMLImageElement < "u" && e instanceof HTMLImageElement || typeof HTMLCanvasElement < "u" && e instanceof HTMLCanvasElement || typeof ImageBitmap < "u" && e instanceof ImageBitmap ? we.getDataURL(e) : e.data ? {
+		data: Array.from(e.data),
+		width: e.width,
+		height: e.height,
+		type: e.data.constructor.name
+	} : (F("Texture: Unable to serialize Texture."), {});
+}
+var Oe = 0, ke = /*@__PURE__*/ new W(), Ae = class r extends R {
+	constructor(e = r.DEFAULT_IMAGE, n = r.DEFAULT_MAPPING, s = t, c = t, l = i, u = a, d = m, f = o, p = r.DEFAULT_ANISOTROPY, h = "") {
+		super(), this.isTexture = !0, Object.defineProperty(this, "id", { value: Oe++ }), this.uuid = B(), this.name = "", this.source = new Ee(e), this.mipmaps = [], this.mapping = n, this.channel = 0, this.wrapS = s, this.wrapT = c, this.magFilter = l, this.minFilter = u, this.anisotropy = p, this.format = d, this.internalFormat = null, this.type = f, this.offset = new U(0, 0), this.repeat = new U(1, 1), this.center = new U(0, 0), this.rotation = 0, this.matrixAutoUpdate = !0, this.matrix = new G(), this.generateMipmaps = !0, this.premultiplyAlpha = !1, this.flipY = !0, this.unpackAlignment = 4, this.colorSpace = h, this.userData = {}, this.updateRanges = [], this.version = 0, this.onUpdate = null, this.renderTarget = null, this.isRenderTargetTexture = !1, this.isArrayTexture = !!(e && e.depth && e.depth > 1), this.pmremVersion = 0, this.normalized = !1;
+	}
+	get width() {
+		return this.source.getSize(ke).x;
+	}
+	get height() {
+		return this.source.getSize(ke).y;
+	}
+	get depth() {
+		return this.source.getSize(ke).z;
+	}
+	get image() {
+		return this.source.data;
+	}
+	set image(e) {
+		this.source.data = e;
+	}
+	updateMatrix() {
+		this.matrix.setUvTransform(this.offset.x, this.offset.y, this.repeat.x, this.repeat.y, this.rotation, this.center.x, this.center.y);
+	}
+	addUpdateRange(e, t) {
+		this.updateRanges.push({
+			start: e,
+			count: t
+		});
+	}
+	clearUpdateRanges() {
+		this.updateRanges.length = 0;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	copy(e) {
+		return this.name = e.name, this.source = e.source, this.mipmaps = e.mipmaps.slice(0), this.mapping = e.mapping, this.channel = e.channel, this.wrapS = e.wrapS, this.wrapT = e.wrapT, this.magFilter = e.magFilter, this.minFilter = e.minFilter, this.anisotropy = e.anisotropy, this.format = e.format, this.internalFormat = e.internalFormat, this.type = e.type, this.normalized = e.normalized, this.offset.copy(e.offset), this.repeat.copy(e.repeat), this.center.copy(e.center), this.rotation = e.rotation, this.matrixAutoUpdate = e.matrixAutoUpdate, this.matrix.copy(e.matrix), this.generateMipmaps = e.generateMipmaps, this.premultiplyAlpha = e.premultiplyAlpha, this.flipY = e.flipY, this.unpackAlignment = e.unpackAlignment, this.colorSpace = e.colorSpace, this.renderTarget = e.renderTarget, this.isRenderTargetTexture = e.isRenderTargetTexture, this.isArrayTexture = e.isArrayTexture, this.userData = JSON.parse(JSON.stringify(e.userData)), this.needsUpdate = !0, this;
+	}
+	setValues(e) {
+		for (let t in e) {
+			let n = e[t];
+			if (n === void 0) {
+				F(`Texture.setValues(): parameter '${t}' has value of undefined.`);
+				continue;
+			}
+			let r = this[t];
+			if (r === void 0) {
+				F(`Texture.setValues(): property '${t}' does not exist.`);
+				continue;
+			}
+			r && n && r.isVector2 && n.isVector2 || r && n && r.isVector3 && n.isVector3 || r && n && r.isMatrix3 && n.isMatrix3 ? r.copy(n) : this[t] = n;
+		}
+	}
+	toJSON(e) {
+		let t = e === void 0 || typeof e == "string";
+		if (!t && e.textures[this.uuid] !== void 0) return e.textures[this.uuid];
+		let n = {
+			metadata: {
+				version: 4.7,
+				type: "Texture",
+				generator: "Texture.toJSON"
+			},
+			uuid: this.uuid,
+			name: this.name,
+			image: this.source.toJSON(e).uuid,
+			mapping: this.mapping,
+			channel: this.channel,
+			repeat: [this.repeat.x, this.repeat.y],
+			offset: [this.offset.x, this.offset.y],
+			center: [this.center.x, this.center.y],
+			rotation: this.rotation,
+			wrap: [this.wrapS, this.wrapT],
+			format: this.format,
+			internalFormat: this.internalFormat,
+			type: this.type,
+			normalized: this.normalized,
+			colorSpace: this.colorSpace,
+			minFilter: this.minFilter,
+			magFilter: this.magFilter,
+			anisotropy: this.anisotropy,
+			flipY: this.flipY,
+			generateMipmaps: this.generateMipmaps,
+			premultiplyAlpha: this.premultiplyAlpha,
+			unpackAlignment: this.unpackAlignment
+		};
+		return Object.keys(this.userData).length > 0 && (n.userData = this.userData), t || (e.textures[this.uuid] = n), n;
+	}
+	dispose() {
+		this.dispatchEvent({ type: "dispose" });
+	}
+	transformUv(r) {
+		if (this.mapping !== 300) return r;
+		if (r.applyMatrix3(this.matrix), r.x < 0 || r.x > 1) switch (this.wrapS) {
+			case e:
+				r.x -= Math.floor(r.x);
+				break;
+			case t:
+				r.x = r.x < 0 ? 0 : 1;
+				break;
+			case n:
+				Math.abs(Math.floor(r.x) % 2) === 1 ? r.x = Math.ceil(r.x) - r.x : r.x -= Math.floor(r.x);
+				break;
+		}
+		if (r.y < 0 || r.y > 1) switch (this.wrapT) {
+			case e:
+				r.y -= Math.floor(r.y);
+				break;
+			case t:
+				r.y = r.y < 0 ? 0 : 1;
+				break;
+			case n:
+				Math.abs(Math.floor(r.y) % 2) === 1 ? r.y = Math.ceil(r.y) - r.y : r.y -= Math.floor(r.y);
+				break;
+		}
+		return this.flipY && (r.y = 1 - r.y), r;
+	}
+	set needsUpdate(e) {
+		e === !0 && (this.version++, this.source.needsUpdate = !0);
+	}
+	set needsPMREMUpdate(e) {
+		e === !0 && this.pmremVersion++;
+	}
+};
+Ae.DEFAULT_IMAGE = null, Ae.DEFAULT_MAPPING = 300, Ae.DEFAULT_ANISOTROPY = 1;
+var je = class e {
+	static {
+		e.prototype.isVector4 = !0;
+	}
+	constructor(e = 0, t = 0, n = 0, r = 1) {
+		this.x = e, this.y = t, this.z = n, this.w = r;
+	}
+	get width() {
+		return this.z;
+	}
+	set width(e) {
+		this.z = e;
+	}
+	get height() {
+		return this.w;
+	}
+	set height(e) {
+		this.w = e;
+	}
+	set(e, t, n, r) {
+		return this.x = e, this.y = t, this.z = n, this.w = r, this;
+	}
+	setScalar(e) {
+		return this.x = e, this.y = e, this.z = e, this.w = e, this;
+	}
+	setX(e) {
+		return this.x = e, this;
+	}
+	setY(e) {
+		return this.y = e, this;
+	}
+	setZ(e) {
+		return this.z = e, this;
+	}
+	setW(e) {
+		return this.w = e, this;
+	}
+	setComponent(e, t) {
+		switch (e) {
+			case 0:
+				this.x = t;
+				break;
+			case 1:
+				this.y = t;
+				break;
+			case 2:
+				this.z = t;
+				break;
+			case 3:
+				this.w = t;
+				break;
+			default: throw Error("THREE.Vector4: index is out of range: " + e);
+		}
+		return this;
+	}
+	getComponent(e) {
+		switch (e) {
+			case 0: return this.x;
+			case 1: return this.y;
+			case 2: return this.z;
+			case 3: return this.w;
+			default: throw Error("THREE.Vector4: index is out of range: " + e);
+		}
+	}
+	clone() {
+		return new this.constructor(this.x, this.y, this.z, this.w);
+	}
+	copy(e) {
+		return this.x = e.x, this.y = e.y, this.z = e.z, this.w = e.w === void 0 ? 1 : e.w, this;
+	}
+	add(e) {
+		return this.x += e.x, this.y += e.y, this.z += e.z, this.w += e.w, this;
+	}
+	addScalar(e) {
+		return this.x += e, this.y += e, this.z += e, this.w += e, this;
+	}
+	addVectors(e, t) {
+		return this.x = e.x + t.x, this.y = e.y + t.y, this.z = e.z + t.z, this.w = e.w + t.w, this;
+	}
+	addScaledVector(e, t) {
+		return this.x += e.x * t, this.y += e.y * t, this.z += e.z * t, this.w += e.w * t, this;
+	}
+	sub(e) {
+		return this.x -= e.x, this.y -= e.y, this.z -= e.z, this.w -= e.w, this;
+	}
+	subScalar(e) {
+		return this.x -= e, this.y -= e, this.z -= e, this.w -= e, this;
+	}
+	subVectors(e, t) {
+		return this.x = e.x - t.x, this.y = e.y - t.y, this.z = e.z - t.z, this.w = e.w - t.w, this;
+	}
+	multiply(e) {
+		return this.x *= e.x, this.y *= e.y, this.z *= e.z, this.w *= e.w, this;
+	}
+	multiplyScalar(e) {
+		return this.x *= e, this.y *= e, this.z *= e, this.w *= e, this;
+	}
+	applyMatrix4(e) {
+		let t = this.x, n = this.y, r = this.z, i = this.w, a = e.elements;
+		return this.x = a[0] * t + a[4] * n + a[8] * r + a[12] * i, this.y = a[1] * t + a[5] * n + a[9] * r + a[13] * i, this.z = a[2] * t + a[6] * n + a[10] * r + a[14] * i, this.w = a[3] * t + a[7] * n + a[11] * r + a[15] * i, this;
+	}
+	divide(e) {
+		return this.x /= e.x, this.y /= e.y, this.z /= e.z, this.w /= e.w, this;
+	}
+	divideScalar(e) {
+		return this.multiplyScalar(1 / e);
+	}
+	setAxisAngleFromQuaternion(e) {
+		this.w = 2 * Math.acos(e.w);
+		let t = Math.sqrt(1 - e.w * e.w);
+		return t < 1e-4 ? (this.x = 1, this.y = 0, this.z = 0) : (this.x = e.x / t, this.y = e.y / t, this.z = e.z / t), this;
+	}
+	setAxisAngleFromRotationMatrix(e) {
+		let t, n, r, i, a = .01, o = .1, s = e.elements, c = s[0], l = s[4], u = s[8], d = s[1], f = s[5], p = s[9], m = s[2], h = s[6], g = s[10];
+		if (Math.abs(l - d) < a && Math.abs(u - m) < a && Math.abs(p - h) < a) {
+			if (Math.abs(l + d) < o && Math.abs(u + m) < o && Math.abs(p + h) < o && Math.abs(c + f + g - 3) < o) return this.set(1, 0, 0, 0), this;
+			t = Math.PI;
+			let e = (c + 1) / 2, s = (f + 1) / 2, _ = (g + 1) / 2, v = (l + d) / 4, y = (u + m) / 4, b = (p + h) / 4;
+			return e > s && e > _ ? e < a ? (n = 0, r = .707106781, i = .707106781) : (n = Math.sqrt(e), r = v / n, i = y / n) : s > _ ? s < a ? (n = .707106781, r = 0, i = .707106781) : (r = Math.sqrt(s), n = v / r, i = b / r) : _ < a ? (n = .707106781, r = .707106781, i = 0) : (i = Math.sqrt(_), n = y / i, r = b / i), this.set(n, r, i, t), this;
+		}
+		let _ = Math.sqrt((h - p) * (h - p) + (u - m) * (u - m) + (d - l) * (d - l));
+		return Math.abs(_) < .001 && (_ = 1), this.x = (h - p) / _, this.y = (u - m) / _, this.z = (d - l) / _, this.w = Math.acos((c + f + g - 1) / 2), this;
+	}
+	setFromMatrixPosition(e) {
+		let t = e.elements;
+		return this.x = t[12], this.y = t[13], this.z = t[14], this.w = t[15], this;
+	}
+	min(e) {
+		return this.x = Math.min(this.x, e.x), this.y = Math.min(this.y, e.y), this.z = Math.min(this.z, e.z), this.w = Math.min(this.w, e.w), this;
+	}
+	max(e) {
+		return this.x = Math.max(this.x, e.x), this.y = Math.max(this.y, e.y), this.z = Math.max(this.z, e.z), this.w = Math.max(this.w, e.w), this;
+	}
+	clamp(e, t) {
+		return this.x = V(this.x, e.x, t.x), this.y = V(this.y, e.y, t.y), this.z = V(this.z, e.z, t.z), this.w = V(this.w, e.w, t.w), this;
+	}
+	clampScalar(e, t) {
+		return this.x = V(this.x, e, t), this.y = V(this.y, e, t), this.z = V(this.z, e, t), this.w = V(this.w, e, t), this;
+	}
+	clampLength(e, t) {
+		let n = this.length();
+		return this.divideScalar(n || 1).multiplyScalar(V(n, e, t));
+	}
+	floor() {
+		return this.x = Math.floor(this.x), this.y = Math.floor(this.y), this.z = Math.floor(this.z), this.w = Math.floor(this.w), this;
+	}
+	ceil() {
+		return this.x = Math.ceil(this.x), this.y = Math.ceil(this.y), this.z = Math.ceil(this.z), this.w = Math.ceil(this.w), this;
+	}
+	round() {
+		return this.x = Math.round(this.x), this.y = Math.round(this.y), this.z = Math.round(this.z), this.w = Math.round(this.w), this;
+	}
+	roundToZero() {
+		return this.x = Math.trunc(this.x), this.y = Math.trunc(this.y), this.z = Math.trunc(this.z), this.w = Math.trunc(this.w), this;
+	}
+	negate() {
+		return this.x = -this.x, this.y = -this.y, this.z = -this.z, this.w = -this.w, this;
+	}
+	dot(e) {
+		return this.x * e.x + this.y * e.y + this.z * e.z + this.w * e.w;
+	}
+	lengthSq() {
+		return this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w;
+	}
+	length() {
+		return Math.sqrt(this.x * this.x + this.y * this.y + this.z * this.z + this.w * this.w);
+	}
+	manhattanLength() {
+		return Math.abs(this.x) + Math.abs(this.y) + Math.abs(this.z) + Math.abs(this.w);
+	}
+	normalize() {
+		return this.divideScalar(this.length() || 1);
+	}
+	setLength(e) {
+		return this.normalize().multiplyScalar(e);
+	}
+	lerp(e, t) {
+		return this.x += (e.x - this.x) * t, this.y += (e.y - this.y) * t, this.z += (e.z - this.z) * t, this.w += (e.w - this.w) * t, this;
+	}
+	lerpVectors(e, t, n) {
+		return this.x = e.x + (t.x - e.x) * n, this.y = e.y + (t.y - e.y) * n, this.z = e.z + (t.z - e.z) * n, this.w = e.w + (t.w - e.w) * n, this;
+	}
+	equals(e) {
+		return e.x === this.x && e.y === this.y && e.z === this.z && e.w === this.w;
+	}
+	fromArray(e, t = 0) {
+		return this.x = e[t], this.y = e[t + 1], this.z = e[t + 2], this.w = e[t + 3], this;
+	}
+	toArray(e = [], t = 0) {
+		return e[t] = this.x, e[t + 1] = this.y, e[t + 2] = this.z, e[t + 3] = this.w, e;
+	}
+	fromBufferAttribute(e, t) {
+		return this.x = e.getX(t), this.y = e.getY(t), this.z = e.getZ(t), this.w = e.getW(t), this;
+	}
+	random() {
+		return this.x = Math.random(), this.y = Math.random(), this.z = Math.random(), this.w = Math.random(), this;
+	}
+	*[Symbol.iterator]() {
+		yield this.x, yield this.y, yield this.z, yield this.w;
+	}
+}, q = class extends R {
+	constructor(e = 1, t = 1, n = {}) {
+		super(), n = Object.assign({
+			generateMipmaps: !1,
+			internalFormat: null,
+			minFilter: i,
+			depthBuffer: !0,
+			stencilBuffer: !1,
+			resolveDepthBuffer: !0,
+			resolveStencilBuffer: !0,
+			depthTexture: null,
+			samples: 0,
+			count: 1,
+			depth: 1,
+			multiview: !1,
+			useArrayDepthTexture: !1
+		}, n), this.isRenderTarget = !0, this.width = e, this.height = t, this.depth = n.depth, this.scissor = new je(0, 0, e, t), this.scissorTest = !1, this.viewport = new je(0, 0, e, t), this.textures = [];
+		let r = new Ae({
+			width: e,
+			height: t,
+			depth: n.depth
+		}), a = n.count;
+		for (let e = 0; e < a; e++) this.textures[e] = r.clone(), this.textures[e].isRenderTargetTexture = !0, this.textures[e].renderTarget = this;
+		this._setTextureOptions(n), this.depthBuffer = n.depthBuffer, this.stencilBuffer = n.stencilBuffer, this.resolveDepthBuffer = n.resolveDepthBuffer, this.resolveStencilBuffer = n.resolveStencilBuffer, this._depthTexture = null, this.depthTexture = n.depthTexture, this.samples = n.samples, this.multiview = n.multiview, this.useArrayDepthTexture = n.useArrayDepthTexture;
+	}
+	_setTextureOptions(e = {}) {
+		let t = {
+			minFilter: i,
+			generateMipmaps: !1,
+			flipY: !1,
+			internalFormat: null
+		};
+		e.mapping !== void 0 && (t.mapping = e.mapping), e.wrapS !== void 0 && (t.wrapS = e.wrapS), e.wrapT !== void 0 && (t.wrapT = e.wrapT), e.wrapR !== void 0 && (t.wrapR = e.wrapR), e.magFilter !== void 0 && (t.magFilter = e.magFilter), e.minFilter !== void 0 && (t.minFilter = e.minFilter), e.format !== void 0 && (t.format = e.format), e.type !== void 0 && (t.type = e.type), e.anisotropy !== void 0 && (t.anisotropy = e.anisotropy), e.colorSpace !== void 0 && (t.colorSpace = e.colorSpace), e.flipY !== void 0 && (t.flipY = e.flipY), e.generateMipmaps !== void 0 && (t.generateMipmaps = e.generateMipmaps), e.internalFormat !== void 0 && (t.internalFormat = e.internalFormat);
+		for (let e = 0; e < this.textures.length; e++) this.textures[e].setValues(t);
+	}
+	get texture() {
+		return this.textures[0];
+	}
+	set texture(e) {
+		this.textures[0] = e;
+	}
+	set depthTexture(e) {
+		this._depthTexture !== null && (this._depthTexture.renderTarget = null), e !== null && (e.renderTarget = this), this._depthTexture = e;
+	}
+	get depthTexture() {
+		return this._depthTexture;
+	}
+	setSize(e, t, n = 1) {
+		if (this.width !== e || this.height !== t || this.depth !== n) {
+			this.width = e, this.height = t, this.depth = n;
+			for (let r = 0, i = this.textures.length; r < i; r++) this.textures[r].image.width = e, this.textures[r].image.height = t, this.textures[r].image.depth = n, this.textures[r].isData3DTexture !== !0 && (this.textures[r].isArrayTexture = this.textures[r].image.depth > 1);
+			this.dispose();
+		}
+		this.viewport.set(0, 0, e, t), this.scissor.set(0, 0, e, t);
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	copy(e) {
+		this.width = e.width, this.height = e.height, this.depth = e.depth, this.scissor.copy(e.scissor), this.scissorTest = e.scissorTest, this.viewport.copy(e.viewport), this.textures.length = 0;
+		for (let t = 0, n = e.textures.length; t < n; t++) {
+			this.textures[t] = e.textures[t].clone(), this.textures[t].isRenderTargetTexture = !0, this.textures[t].renderTarget = this;
+			let n = Object.assign({}, e.textures[t].image);
+			this.textures[t].source = new Ee(n);
+		}
+		return this.depthBuffer = e.depthBuffer, this.stencilBuffer = e.stencilBuffer, this.resolveDepthBuffer = e.resolveDepthBuffer, this.resolveStencilBuffer = e.resolveStencilBuffer, e.depthTexture !== null && (this.depthTexture = e.depthTexture.clone()), this.samples = e.samples, this.multiview = e.multiview, this.useArrayDepthTexture = e.useArrayDepthTexture, this;
+	}
+	dispose() {
+		this.dispatchEvent({ type: "dispose" });
+	}
+}, Me = class extends q {
+	constructor(e = 1, t = 1, n = {}) {
+		super(e, t, n), this.isWebGLRenderTarget = !0;
+	}
+}, Ne = class extends Ae {
+	constructor(e = null, n = 1, i = 1, a = 1) {
+		super(null), this.isDataArrayTexture = !0, this.image = {
+			data: e,
+			width: n,
+			height: i,
+			depth: a
+		}, this.magFilter = r, this.minFilter = r, this.wrapR = t, this.generateMipmaps = !1, this.flipY = !1, this.unpackAlignment = 1, this.layerUpdates = /* @__PURE__ */ new Set();
+	}
+	addLayerUpdate(e) {
+		this.layerUpdates.add(e);
+	}
+	clearLayerUpdates() {
+		this.layerUpdates.clear();
+	}
+}, Pe = class extends Ae {
+	constructor(e = null, n = 1, i = 1, a = 1) {
+		super(null), this.isData3DTexture = !0, this.image = {
+			data: e,
+			width: n,
+			height: i,
+			depth: a
+		}, this.magFilter = r, this.minFilter = r, this.wrapR = t, this.generateMipmaps = !1, this.flipY = !1, this.unpackAlignment = 1;
+	}
+}, Fe = class e {
+	static {
+		e.prototype.isMatrix4 = !0;
+	}
+	constructor(e, t, n, r, i, a, o, s, c, l, u, d, f, p, m, h) {
+		this.elements = [
+			1,
+			0,
+			0,
+			0,
+			0,
+			1,
+			0,
+			0,
+			0,
+			0,
+			1,
+			0,
+			0,
+			0,
+			0,
+			1
+		], e !== void 0 && this.set(e, t, n, r, i, a, o, s, c, l, u, d, f, p, m, h);
+	}
+	set(e, t, n, r, i, a, o, s, c, l, u, d, f, p, m, h) {
+		let g = this.elements;
+		return g[0] = e, g[4] = t, g[8] = n, g[12] = r, g[1] = i, g[5] = a, g[9] = o, g[13] = s, g[2] = c, g[6] = l, g[10] = u, g[14] = d, g[3] = f, g[7] = p, g[11] = m, g[15] = h, this;
+	}
+	identity() {
+		return this.set(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1), this;
+	}
+	clone() {
+		return new e().fromArray(this.elements);
+	}
+	copy(e) {
+		let t = this.elements, n = e.elements;
+		return t[0] = n[0], t[1] = n[1], t[2] = n[2], t[3] = n[3], t[4] = n[4], t[5] = n[5], t[6] = n[6], t[7] = n[7], t[8] = n[8], t[9] = n[9], t[10] = n[10], t[11] = n[11], t[12] = n[12], t[13] = n[13], t[14] = n[14], t[15] = n[15], this;
+	}
+	copyPosition(e) {
+		let t = this.elements, n = e.elements;
+		return t[12] = n[12], t[13] = n[13], t[14] = n[14], this;
+	}
+	setFromMatrix3(e) {
+		let t = e.elements;
+		return this.set(t[0], t[3], t[6], 0, t[1], t[4], t[7], 0, t[2], t[5], t[8], 0, 0, 0, 0, 1), this;
+	}
+	extractBasis(e, t, n) {
+		return this.determinantAffine() === 0 ? (e.set(1, 0, 0), t.set(0, 1, 0), n.set(0, 0, 1), this) : (e.setFromMatrixColumn(this, 0), t.setFromMatrixColumn(this, 1), n.setFromMatrixColumn(this, 2), this);
+	}
+	makeBasis(e, t, n) {
+		return this.set(e.x, t.x, n.x, 0, e.y, t.y, n.y, 0, e.z, t.z, n.z, 0, 0, 0, 0, 1), this;
+	}
+	extractRotation(e) {
+		if (e.determinantAffine() === 0) return this.identity();
+		let t = this.elements, n = e.elements, r = 1 / Ie.setFromMatrixColumn(e, 0).length(), i = 1 / Ie.setFromMatrixColumn(e, 1).length(), a = 1 / Ie.setFromMatrixColumn(e, 2).length();
+		return t[0] = n[0] * r, t[1] = n[1] * r, t[2] = n[2] * r, t[3] = 0, t[4] = n[4] * i, t[5] = n[5] * i, t[6] = n[6] * i, t[7] = 0, t[8] = n[8] * a, t[9] = n[9] * a, t[10] = n[10] * a, t[11] = 0, t[12] = 0, t[13] = 0, t[14] = 0, t[15] = 1, this;
+	}
+	makeRotationFromEuler(e) {
+		let t = this.elements, n = e.x, r = e.y, i = e.z, a = Math.cos(n), o = Math.sin(n), s = Math.cos(r), c = Math.sin(r), l = Math.cos(i), u = Math.sin(i);
+		if (e.order === "XYZ") {
+			let e = a * l, n = a * u, r = o * l, i = o * u;
+			t[0] = s * l, t[4] = -s * u, t[8] = c, t[1] = n + r * c, t[5] = e - i * c, t[9] = -o * s, t[2] = i - e * c, t[6] = r + n * c, t[10] = a * s;
+		} else if (e.order === "YXZ") {
+			let e = s * l, n = s * u, r = c * l, i = c * u;
+			t[0] = e + i * o, t[4] = r * o - n, t[8] = a * c, t[1] = a * u, t[5] = a * l, t[9] = -o, t[2] = n * o - r, t[6] = i + e * o, t[10] = a * s;
+		} else if (e.order === "ZXY") {
+			let e = s * l, n = s * u, r = c * l, i = c * u;
+			t[0] = e - i * o, t[4] = -a * u, t[8] = r + n * o, t[1] = n + r * o, t[5] = a * l, t[9] = i - e * o, t[2] = -a * c, t[6] = o, t[10] = a * s;
+		} else if (e.order === "ZYX") {
+			let e = a * l, n = a * u, r = o * l, i = o * u;
+			t[0] = s * l, t[4] = r * c - n, t[8] = e * c + i, t[1] = s * u, t[5] = i * c + e, t[9] = n * c - r, t[2] = -c, t[6] = o * s, t[10] = a * s;
+		} else if (e.order === "YZX") {
+			let e = a * s, n = a * c, r = o * s, i = o * c;
+			t[0] = s * l, t[4] = i - e * u, t[8] = r * u + n, t[1] = u, t[5] = a * l, t[9] = -o * l, t[2] = -c * l, t[6] = n * u + r, t[10] = e - i * u;
+		} else if (e.order === "XZY") {
+			let e = a * s, n = a * c, r = o * s, i = o * c;
+			t[0] = s * l, t[4] = -u, t[8] = c * l, t[1] = e * u + i, t[5] = a * l, t[9] = n * u - r, t[2] = r * u - n, t[6] = o * l, t[10] = i * u + e;
+		}
+		return t[3] = 0, t[7] = 0, t[11] = 0, t[12] = 0, t[13] = 0, t[14] = 0, t[15] = 1, this;
+	}
+	makeRotationFromQuaternion(e) {
+		return this.compose(Le, e, Y);
+	}
+	lookAt(e, t, n) {
+		let r = this.elements;
+		return ze.subVectors(e, t), ze.lengthSq() === 0 && (ze.z = 1), ze.normalize(), X.crossVectors(n, ze), X.lengthSq() === 0 && (Math.abs(n.z) === 1 ? ze.x += 1e-4 : ze.z += 1e-4, ze.normalize(), X.crossVectors(n, ze)), X.normalize(), Re.crossVectors(ze, X), r[0] = X.x, r[4] = Re.x, r[8] = ze.x, r[1] = X.y, r[5] = Re.y, r[9] = ze.y, r[2] = X.z, r[6] = Re.z, r[10] = ze.z, this;
+	}
+	multiply(e) {
+		return this.multiplyMatrices(this, e);
+	}
+	premultiply(e) {
+		return this.multiplyMatrices(e, this);
+	}
+	multiplyMatrices(e, t) {
+		let n = e.elements, r = t.elements, i = this.elements, a = n[0], o = n[4], s = n[8], c = n[12], l = n[1], u = n[5], d = n[9], f = n[13], p = n[2], m = n[6], h = n[10], g = n[14], _ = n[3], v = n[7], y = n[11], b = n[15], x = r[0], S = r[4], C = r[8], w = r[12], T = r[1], E = r[5], D = r[9], O = r[13], k = r[2], A = r[6], ee = r[10], j = r[14], M = r[3], te = r[7], ne = r[11], N = r[15];
+		return i[0] = a * x + o * T + s * k + c * M, i[4] = a * S + o * E + s * A + c * te, i[8] = a * C + o * D + s * ee + c * ne, i[12] = a * w + o * O + s * j + c * N, i[1] = l * x + u * T + d * k + f * M, i[5] = l * S + u * E + d * A + f * te, i[9] = l * C + u * D + d * ee + f * ne, i[13] = l * w + u * O + d * j + f * N, i[2] = p * x + m * T + h * k + g * M, i[6] = p * S + m * E + h * A + g * te, i[10] = p * C + m * D + h * ee + g * ne, i[14] = p * w + m * O + h * j + g * N, i[3] = _ * x + v * T + y * k + b * M, i[7] = _ * S + v * E + y * A + b * te, i[11] = _ * C + v * D + y * ee + b * ne, i[15] = _ * w + v * O + y * j + b * N, this;
+	}
+	multiplyScalar(e) {
+		let t = this.elements;
+		return t[0] *= e, t[4] *= e, t[8] *= e, t[12] *= e, t[1] *= e, t[5] *= e, t[9] *= e, t[13] *= e, t[2] *= e, t[6] *= e, t[10] *= e, t[14] *= e, t[3] *= e, t[7] *= e, t[11] *= e, t[15] *= e, this;
+	}
+	determinant() {
+		let e = this.elements, t = e[0], n = e[4], r = e[8], i = e[12], a = e[1], o = e[5], s = e[9], c = e[13], l = e[2], u = e[6], d = e[10], f = e[14], p = e[3], m = e[7], h = e[11], g = e[15], _ = s * f - c * d, v = o * f - c * u, y = o * d - s * u, b = a * f - c * l, x = a * d - s * l, S = a * u - o * l;
+		return t * (m * _ - h * v + g * y) - n * (p * _ - h * b + g * x) + r * (p * v - m * b + g * S) - i * (p * y - m * x + h * S);
+	}
+	determinantAffine() {
+		let e = this.elements, t = e[0], n = e[4], r = e[8], i = e[1], a = e[5], o = e[9], s = e[2], c = e[6], l = e[10];
+		return t * (a * l - o * c) - n * (i * l - o * s) + r * (i * c - a * s);
+	}
+	transpose() {
+		let e = this.elements, t;
+		return t = e[1], e[1] = e[4], e[4] = t, t = e[2], e[2] = e[8], e[8] = t, t = e[6], e[6] = e[9], e[9] = t, t = e[3], e[3] = e[12], e[12] = t, t = e[7], e[7] = e[13], e[13] = t, t = e[11], e[11] = e[14], e[14] = t, this;
+	}
+	setPosition(e, t, n) {
+		let r = this.elements;
+		return e.isVector3 ? (r[12] = e.x, r[13] = e.y, r[14] = e.z) : (r[12] = e, r[13] = t, r[14] = n), this;
+	}
+	invert() {
+		let e = this.elements, t = e[0], n = e[1], r = e[2], i = e[3], a = e[4], o = e[5], s = e[6], c = e[7], l = e[8], u = e[9], d = e[10], f = e[11], p = e[12], m = e[13], h = e[14], g = e[15], _ = t * o - n * a, v = t * s - r * a, y = t * c - i * a, b = n * s - r * o, x = n * c - i * o, S = r * c - i * s, C = l * m - u * p, w = l * h - d * p, T = l * g - f * p, E = u * h - d * m, D = u * g - f * m, O = d * g - f * h, k = _ * O - v * D + y * E + b * T - x * w + S * C;
+		if (k === 0) return this.set(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+		let A = 1 / k;
+		return e[0] = (o * O - s * D + c * E) * A, e[1] = (r * D - n * O - i * E) * A, e[2] = (m * S - h * x + g * b) * A, e[3] = (d * x - u * S - f * b) * A, e[4] = (s * T - a * O - c * w) * A, e[5] = (t * O - r * T + i * w) * A, e[6] = (h * y - p * S - g * v) * A, e[7] = (l * S - d * y + f * v) * A, e[8] = (a * D - o * T + c * C) * A, e[9] = (n * T - t * D - i * C) * A, e[10] = (p * x - m * y + g * _) * A, e[11] = (u * y - l * x - f * _) * A, e[12] = (o * w - a * E - s * C) * A, e[13] = (t * E - n * w + r * C) * A, e[14] = (m * v - p * b - h * _) * A, e[15] = (l * b - u * v + d * _) * A, this;
+	}
+	scale(e) {
+		let t = this.elements, n = e.x, r = e.y, i = e.z;
+		return t[0] *= n, t[4] *= r, t[8] *= i, t[1] *= n, t[5] *= r, t[9] *= i, t[2] *= n, t[6] *= r, t[10] *= i, t[3] *= n, t[7] *= r, t[11] *= i, this;
+	}
+	getMaxScaleOnAxis() {
+		let e = this.elements, t = e[0] * e[0] + e[1] * e[1] + e[2] * e[2], n = e[4] * e[4] + e[5] * e[5] + e[6] * e[6], r = e[8] * e[8] + e[9] * e[9] + e[10] * e[10];
+		return Math.sqrt(Math.max(t, n, r));
+	}
+	makeTranslation(e, t, n) {
+		return e.isVector3 ? this.set(1, 0, 0, e.x, 0, 1, 0, e.y, 0, 0, 1, e.z, 0, 0, 0, 1) : this.set(1, 0, 0, e, 0, 1, 0, t, 0, 0, 1, n, 0, 0, 0, 1), this;
+	}
+	makeRotationX(e) {
+		let t = Math.cos(e), n = Math.sin(e);
+		return this.set(1, 0, 0, 0, 0, t, -n, 0, 0, n, t, 0, 0, 0, 0, 1), this;
+	}
+	makeRotationY(e) {
+		let t = Math.cos(e), n = Math.sin(e);
+		return this.set(t, 0, n, 0, 0, 1, 0, 0, -n, 0, t, 0, 0, 0, 0, 1), this;
+	}
+	makeRotationZ(e) {
+		let t = Math.cos(e), n = Math.sin(e);
+		return this.set(t, -n, 0, 0, n, t, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1), this;
+	}
+	makeRotationAxis(e, t) {
+		let n = Math.cos(t), r = Math.sin(t), i = 1 - n, a = e.x, o = e.y, s = e.z, c = i * a, l = i * o;
+		return this.set(c * a + n, c * o - r * s, c * s + r * o, 0, c * o + r * s, l * o + n, l * s - r * a, 0, c * s - r * o, l * s + r * a, i * s * s + n, 0, 0, 0, 0, 1), this;
+	}
+	makeScale(e, t, n) {
+		return this.set(e, 0, 0, 0, 0, t, 0, 0, 0, 0, n, 0, 0, 0, 0, 1), this;
+	}
+	makeShear(e, t, n, r, i, a) {
+		return this.set(1, n, i, 0, e, 1, a, 0, t, r, 1, 0, 0, 0, 0, 1), this;
+	}
+	compose(e, t, n) {
+		let r = this.elements, i = t._x, a = t._y, o = t._z, s = t._w, c = i + i, l = a + a, u = o + o, d = i * c, f = i * l, p = i * u, m = a * l, h = a * u, g = o * u, _ = s * c, v = s * l, y = s * u, b = n.x, x = n.y, S = n.z;
+		return r[0] = (1 - (m + g)) * b, r[1] = (f + y) * b, r[2] = (p - v) * b, r[3] = 0, r[4] = (f - y) * x, r[5] = (1 - (d + g)) * x, r[6] = (h + _) * x, r[7] = 0, r[8] = (p + v) * S, r[9] = (h - _) * S, r[10] = (1 - (d + m)) * S, r[11] = 0, r[12] = e.x, r[13] = e.y, r[14] = e.z, r[15] = 1, this;
+	}
+	decompose(e, t, n) {
+		let r = this.elements;
+		e.x = r[12], e.y = r[13], e.z = r[14];
+		let i = this.determinantAffine();
+		if (i === 0) return n.set(1, 1, 1), t.identity(), this;
+		let a = Ie.set(r[0], r[1], r[2]).length(), o = Ie.set(r[4], r[5], r[6]).length(), s = Ie.set(r[8], r[9], r[10]).length();
+		i < 0 && (a = -a), J.copy(this);
+		let c = 1 / a, l = 1 / o, u = 1 / s;
+		return J.elements[0] *= c, J.elements[1] *= c, J.elements[2] *= c, J.elements[4] *= l, J.elements[5] *= l, J.elements[6] *= l, J.elements[8] *= u, J.elements[9] *= u, J.elements[10] *= u, t.setFromRotationMatrix(J), n.x = a, n.y = o, n.z = s, this;
+	}
+	makePerspective(e, t, n, r, i, a, o = te, s = !1) {
+		let c = this.elements, l = 2 * i / (t - e), u = 2 * i / (n - r), d = (t + e) / (t - e), f = (n + r) / (n - r), p, m;
+		if (s) p = i / (a - i), m = a * i / (a - i);
+		else if (o === 2e3) p = -(a + i) / (a - i), m = -2 * a * i / (a - i);
+		else if (o === 2001) p = -a / (a - i), m = -a * i / (a - i);
+		else throw Error("THREE.Matrix4.makePerspective(): Invalid coordinate system: " + o);
+		return c[0] = l, c[4] = 0, c[8] = d, c[12] = 0, c[1] = 0, c[5] = u, c[9] = f, c[13] = 0, c[2] = 0, c[6] = 0, c[10] = p, c[14] = m, c[3] = 0, c[7] = 0, c[11] = -1, c[15] = 0, this;
+	}
+	makeOrthographic(e, t, n, r, i, a, o = te, s = !1) {
+		let c = this.elements, l = 2 / (t - e), u = 2 / (n - r), d = -(t + e) / (t - e), f = -(n + r) / (n - r), p, m;
+		if (s) p = 1 / (a - i), m = a / (a - i);
+		else if (o === 2e3) p = -2 / (a - i), m = -(a + i) / (a - i);
+		else if (o === 2001) p = -1 / (a - i), m = -i / (a - i);
+		else throw Error("THREE.Matrix4.makeOrthographic(): Invalid coordinate system: " + o);
+		return c[0] = l, c[4] = 0, c[8] = 0, c[12] = d, c[1] = 0, c[5] = u, c[9] = 0, c[13] = f, c[2] = 0, c[6] = 0, c[10] = p, c[14] = m, c[3] = 0, c[7] = 0, c[11] = 0, c[15] = 1, this;
+	}
+	equals(e) {
+		let t = this.elements, n = e.elements;
+		for (let e = 0; e < 16; e++) if (t[e] !== n[e]) return !1;
+		return !0;
+	}
+	fromArray(e, t = 0) {
+		for (let n = 0; n < 16; n++) this.elements[n] = e[n + t];
+		return this;
+	}
+	toArray(e = [], t = 0) {
+		let n = this.elements;
+		return e[t] = n[0], e[t + 1] = n[1], e[t + 2] = n[2], e[t + 3] = n[3], e[t + 4] = n[4], e[t + 5] = n[5], e[t + 6] = n[6], e[t + 7] = n[7], e[t + 8] = n[8], e[t + 9] = n[9], e[t + 10] = n[10], e[t + 11] = n[11], e[t + 12] = n[12], e[t + 13] = n[13], e[t + 14] = n[14], e[t + 15] = n[15], e;
+	}
+}, Ie = /*@__PURE__*/ new W(), J = /*@__PURE__*/ new Fe(), Le = /*@__PURE__*/ new W(0, 0, 0), Y = /*@__PURE__*/ new W(1, 1, 1), X = /*@__PURE__*/ new W(), Re = /*@__PURE__*/ new W(), ze = /*@__PURE__*/ new W(), Be = /*@__PURE__*/ new Fe(), Ve = /*@__PURE__*/ new me(), He = class e {
+	constructor(t = 0, n = 0, r = 0, i = e.DEFAULT_ORDER) {
+		this.isEuler = !0, this._x = t, this._y = n, this._z = r, this._order = i;
+	}
+	get x() {
+		return this._x;
+	}
+	set x(e) {
+		this._x = e, this._onChangeCallback();
+	}
+	get y() {
+		return this._y;
+	}
+	set y(e) {
+		this._y = e, this._onChangeCallback();
+	}
+	get z() {
+		return this._z;
+	}
+	set z(e) {
+		this._z = e, this._onChangeCallback();
+	}
+	get order() {
+		return this._order;
+	}
+	set order(e) {
+		this._order = e, this._onChangeCallback();
+	}
+	set(e, t, n, r = this._order) {
+		return this._x = e, this._y = t, this._z = n, this._order = r, this._onChangeCallback(), this;
+	}
+	clone() {
+		return new this.constructor(this._x, this._y, this._z, this._order);
+	}
+	copy(e) {
+		return this._x = e._x, this._y = e._y, this._z = e._z, this._order = e._order, this._onChangeCallback(), this;
+	}
+	setFromRotationMatrix(e, t = this._order, n = !0) {
+		let r = e.elements, i = r[0], a = r[4], o = r[8], s = r[1], c = r[5], l = r[9], u = r[2], d = r[6], f = r[10];
+		switch (t) {
+			case "XYZ":
+				this._y = Math.asin(V(o, -1, 1)), Math.abs(o) < .9999999 ? (this._x = Math.atan2(-l, f), this._z = Math.atan2(-a, i)) : (this._x = Math.atan2(d, c), this._z = 0);
+				break;
+			case "YXZ":
+				this._x = Math.asin(-V(l, -1, 1)), Math.abs(l) < .9999999 ? (this._y = Math.atan2(o, f), this._z = Math.atan2(s, c)) : (this._y = Math.atan2(-u, i), this._z = 0);
+				break;
+			case "ZXY":
+				this._x = Math.asin(V(d, -1, 1)), Math.abs(d) < .9999999 ? (this._y = Math.atan2(-u, f), this._z = Math.atan2(-a, c)) : (this._y = 0, this._z = Math.atan2(s, i));
+				break;
+			case "ZYX":
+				this._y = Math.asin(-V(u, -1, 1)), Math.abs(u) < .9999999 ? (this._x = Math.atan2(d, f), this._z = Math.atan2(s, i)) : (this._x = 0, this._z = Math.atan2(-a, c));
+				break;
+			case "YZX":
+				this._z = Math.asin(V(s, -1, 1)), Math.abs(s) < .9999999 ? (this._x = Math.atan2(-l, c), this._y = Math.atan2(-u, i)) : (this._x = 0, this._y = Math.atan2(o, f));
+				break;
+			case "XZY":
+				this._z = Math.asin(-V(a, -1, 1)), Math.abs(a) < .9999999 ? (this._x = Math.atan2(d, c), this._y = Math.atan2(o, i)) : (this._x = Math.atan2(-l, f), this._y = 0);
+				break;
+			default: F("Euler: .setFromRotationMatrix() encountered an unknown order: " + t);
+		}
+		return this._order = t, n === !0 && this._onChangeCallback(), this;
+	}
+	setFromQuaternion(e, t, n) {
+		return Be.makeRotationFromQuaternion(e), this.setFromRotationMatrix(Be, t, n);
+	}
+	setFromVector3(e, t = this._order) {
+		return this.set(e.x, e.y, e.z, t);
+	}
+	reorder(e) {
+		return Ve.setFromEuler(this), this.setFromQuaternion(Ve, e);
+	}
+	equals(e) {
+		return e._x === this._x && e._y === this._y && e._z === this._z && e._order === this._order;
+	}
+	fromArray(e) {
+		return this._x = e[0], this._y = e[1], this._z = e[2], e[3] !== void 0 && (this._order = e[3]), this._onChangeCallback(), this;
+	}
+	toArray(e = [], t = 0) {
+		return e[t] = this._x, e[t + 1] = this._y, e[t + 2] = this._z, e[t + 3] = this._order, e;
+	}
+	_onChange(e) {
+		return this._onChangeCallback = e, this;
+	}
+	_onChangeCallback() {}
+	*[Symbol.iterator]() {
+		yield this._x, yield this._y, yield this._z, yield this._order;
+	}
+};
+He.DEFAULT_ORDER = "XYZ";
+var Ue = class {
+	constructor() {
+		this.mask = 1;
+	}
+	set(e) {
+		this.mask = (1 << e | 0) >>> 0;
+	}
+	enable(e) {
+		this.mask |= 1 << e | 0;
+	}
+	enableAll() {
+		this.mask = -1;
+	}
+	toggle(e) {
+		this.mask ^= 1 << e | 0;
+	}
+	disable(e) {
+		this.mask &= ~(1 << e | 0);
+	}
+	disableAll() {
+		this.mask = 0;
+	}
+	test(e) {
+		return (this.mask & e.mask) !== 0;
+	}
+	isEnabled(e) {
+		return (this.mask & (1 << e | 0)) != 0;
+	}
+}, We = 0, Ge = /*@__PURE__*/ new W(), Ke = /*@__PURE__*/ new me(), qe = /*@__PURE__*/ new Fe(), Je = /*@__PURE__*/ new W(), Ye = /*@__PURE__*/ new W(), Xe = /*@__PURE__*/ new W(), Ze = /*@__PURE__*/ new me(), Qe = /*@__PURE__*/ new W(1, 0, 0), $e = /*@__PURE__*/ new W(0, 1, 0), et = /*@__PURE__*/ new W(0, 0, 1), tt = { type: "added" }, nt = { type: "removed" }, rt = {
+	type: "childadded",
+	child: null
+}, it = {
+	type: "childremoved",
+	child: null
+}, at = class e extends R {
+	constructor() {
+		super(), this.isObject3D = !0, Object.defineProperty(this, "id", { value: We++ }), this.uuid = B(), this.name = "", this.type = "Object3D", this.parent = null, this.children = [], this.up = e.DEFAULT_UP.clone();
+		let t = new W(), n = new He(), r = new me(), i = new W(1, 1, 1);
+		function a() {
+			r.setFromEuler(n, !1);
+		}
+		function o() {
+			n.setFromQuaternion(r, void 0, !1);
+		}
+		n._onChange(a), r._onChange(o), Object.defineProperties(this, {
+			position: {
+				configurable: !0,
+				enumerable: !0,
+				value: t
+			},
+			rotation: {
+				configurable: !0,
+				enumerable: !0,
+				value: n
+			},
+			quaternion: {
+				configurable: !0,
+				enumerable: !0,
+				value: r
+			},
+			scale: {
+				configurable: !0,
+				enumerable: !0,
+				value: i
+			},
+			modelViewMatrix: { value: new Fe() },
+			normalMatrix: { value: new G() }
+		}), this.matrix = new Fe(), this.matrixWorld = new Fe(), this.matrixAutoUpdate = e.DEFAULT_MATRIX_AUTO_UPDATE, this.matrixWorldAutoUpdate = e.DEFAULT_MATRIX_WORLD_AUTO_UPDATE, this.matrixWorldNeedsUpdate = !1, this.layers = new Ue(), this.visible = !0, this.castShadow = !1, this.receiveShadow = !1, this.frustumCulled = !0, this.renderOrder = 0, this.animations = [], this.customDepthMaterial = void 0, this.customDistanceMaterial = void 0, this.static = !1, this.userData = {}, this.pivot = null;
+	}
+	onBeforeShadow() {}
+	onAfterShadow() {}
+	onBeforeRender() {}
+	onAfterRender() {}
+	applyMatrix4(e) {
+		this.matrixAutoUpdate && this.updateMatrix(), this.matrix.premultiply(e), this.matrix.decompose(this.position, this.quaternion, this.scale);
+	}
+	applyQuaternion(e) {
+		return this.quaternion.premultiply(e), this;
+	}
+	setRotationFromAxisAngle(e, t) {
+		this.quaternion.setFromAxisAngle(e, t);
+	}
+	setRotationFromEuler(e) {
+		this.quaternion.setFromEuler(e, !0);
+	}
+	setRotationFromMatrix(e) {
+		this.quaternion.setFromRotationMatrix(e);
+	}
+	setRotationFromQuaternion(e) {
+		this.quaternion.copy(e);
+	}
+	rotateOnAxis(e, t) {
+		return Ke.setFromAxisAngle(e, t), this.quaternion.multiply(Ke), this;
+	}
+	rotateOnWorldAxis(e, t) {
+		return Ke.setFromAxisAngle(e, t), this.quaternion.premultiply(Ke), this;
+	}
+	rotateX(e) {
+		return this.rotateOnAxis(Qe, e);
+	}
+	rotateY(e) {
+		return this.rotateOnAxis($e, e);
+	}
+	rotateZ(e) {
+		return this.rotateOnAxis(et, e);
+	}
+	translateOnAxis(e, t) {
+		return Ge.copy(e).applyQuaternion(this.quaternion), this.position.add(Ge.multiplyScalar(t)), this;
+	}
+	translateX(e) {
+		return this.translateOnAxis(Qe, e);
+	}
+	translateY(e) {
+		return this.translateOnAxis($e, e);
+	}
+	translateZ(e) {
+		return this.translateOnAxis(et, e);
+	}
+	localToWorld(e) {
+		return this.updateWorldMatrix(!0, !1), e.applyMatrix4(this.matrixWorld);
+	}
+	worldToLocal(e) {
+		return this.updateWorldMatrix(!0, !1), e.applyMatrix4(qe.copy(this.matrixWorld).invert());
+	}
+	lookAt(e, t, n) {
+		e.isVector3 ? Je.copy(e) : Je.set(e, t, n);
+		let r = this.parent;
+		this.updateWorldMatrix(!0, !1), Ye.setFromMatrixPosition(this.matrixWorld), this.isCamera || this.isLight ? qe.lookAt(Ye, Je, this.up) : qe.lookAt(Je, Ye, this.up), this.quaternion.setFromRotationMatrix(qe), r && (qe.extractRotation(r.matrixWorld), Ke.setFromRotationMatrix(qe), this.quaternion.premultiply(Ke.invert()));
+	}
+	add(e) {
+		if (arguments.length > 1) {
+			for (let e = 0; e < arguments.length; e++) this.add(arguments[e]);
+			return this;
+		}
+		return e === this ? (I("Object3D.add: object can't be added as a child of itself.", e), this) : (e && e.isObject3D ? (e.removeFromParent(), e.parent = this, this.children.push(e), e.dispatchEvent(tt), rt.child = e, this.dispatchEvent(rt), rt.child = null) : I("Object3D.add: object not an instance of THREE.Object3D.", e), this);
+	}
+	remove(e) {
+		if (arguments.length > 1) {
+			for (let e = 0; e < arguments.length; e++) this.remove(arguments[e]);
+			return this;
+		}
+		let t = this.children.indexOf(e);
+		return t !== -1 && (e.parent = null, this.children.splice(t, 1), e.dispatchEvent(nt), it.child = e, this.dispatchEvent(it), it.child = null), this;
+	}
+	removeFromParent() {
+		let e = this.parent;
+		return e !== null && e.remove(this), this;
+	}
+	clear() {
+		return this.remove(...this.children);
+	}
+	attach(e) {
+		return this.updateWorldMatrix(!0, !1), qe.copy(this.matrixWorld).invert(), e.parent !== null && (e.parent.updateWorldMatrix(!0, !1), qe.multiply(e.parent.matrixWorld)), e.applyMatrix4(qe), e.removeFromParent(), e.parent = this, this.children.push(e), e.updateWorldMatrix(!1, !0), e.dispatchEvent(tt), rt.child = e, this.dispatchEvent(rt), rt.child = null, this;
+	}
+	getObjectById(e) {
+		return this.getObjectByProperty("id", e);
+	}
+	getObjectByName(e) {
+		return this.getObjectByProperty("name", e);
+	}
+	getObjectByProperty(e, t) {
+		if (this[e] === t) return this;
+		for (let n = 0, r = this.children.length; n < r; n++) {
+			let r = this.children[n].getObjectByProperty(e, t);
+			if (r !== void 0) return r;
+		}
+	}
+	getObjectsByProperty(e, t, n = []) {
+		this[e] === t && n.push(this);
+		let r = this.children;
+		for (let i = 0, a = r.length; i < a; i++) r[i].getObjectsByProperty(e, t, n);
+		return n;
+	}
+	getWorldPosition(e) {
+		return this.updateWorldMatrix(!0, !1), e.setFromMatrixPosition(this.matrixWorld);
+	}
+	getWorldQuaternion(e) {
+		return this.updateWorldMatrix(!0, !1), this.matrixWorld.decompose(Ye, e, Xe), e;
+	}
+	getWorldScale(e) {
+		return this.updateWorldMatrix(!0, !1), this.matrixWorld.decompose(Ye, Ze, e), e;
+	}
+	getWorldDirection(e) {
+		this.updateWorldMatrix(!0, !1);
+		let t = this.matrixWorld.elements;
+		return e.set(t[8], t[9], t[10]).normalize();
+	}
+	raycast() {}
+	traverse(e) {
+		e(this);
+		let t = this.children;
+		for (let n = 0, r = t.length; n < r; n++) t[n].traverse(e);
+	}
+	traverseVisible(e) {
+		if (this.visible === !1) return;
+		e(this);
+		let t = this.children;
+		for (let n = 0, r = t.length; n < r; n++) t[n].traverseVisible(e);
+	}
+	traverseAncestors(e) {
+		let t = this.parent;
+		t !== null && (e(t), t.traverseAncestors(e));
+	}
+	updateMatrix() {
+		this.matrix.compose(this.position, this.quaternion, this.scale);
+		let e = this.pivot;
+		if (e !== null) {
+			let t = e.x, n = e.y, r = e.z, i = this.matrix.elements;
+			i[12] += t - i[0] * t - i[4] * n - i[8] * r, i[13] += n - i[1] * t - i[5] * n - i[9] * r, i[14] += r - i[2] * t - i[6] * n - i[10] * r;
+		}
+		this.matrixWorldNeedsUpdate = !0;
+	}
+	updateMatrixWorld(e) {
+		this.matrixAutoUpdate && this.updateMatrix(), (this.matrixWorldNeedsUpdate || e) && (this.matrixWorldAutoUpdate === !0 && (this.parent === null ? this.matrixWorld.copy(this.matrix) : this.matrixWorld.multiplyMatrices(this.parent.matrixWorld, this.matrix)), this.matrixWorldNeedsUpdate = !1, e = !0);
+		let t = this.children;
+		for (let n = 0, r = t.length; n < r; n++) t[n].updateMatrixWorld(e);
+	}
+	updateWorldMatrix(e, t, n = !1) {
+		let r = this.parent;
+		if (e === !0 && r !== null && r.updateWorldMatrix(!0, !1), this.matrixAutoUpdate && this.updateMatrix(), (this.matrixWorldNeedsUpdate || n) && (this.matrixWorldAutoUpdate === !0 && (this.parent === null ? this.matrixWorld.copy(this.matrix) : this.matrixWorld.multiplyMatrices(this.parent.matrixWorld, this.matrix)), this.matrixWorldNeedsUpdate = !1, n = !0), t === !0) {
+			let e = this.children;
+			for (let t = 0, r = e.length; t < r; t++) e[t].updateWorldMatrix(!1, !0, n);
+		}
+	}
+	toJSON(e) {
+		let t = e === void 0 || typeof e == "string", n = {};
+		t && (e = {
+			geometries: {},
+			materials: {},
+			textures: {},
+			images: {},
+			shapes: {},
+			skeletons: {},
+			animations: {},
+			nodes: {}
+		}, n.metadata = {
+			version: 4.7,
+			type: "Object",
+			generator: "Object3D.toJSON"
+		});
+		let r = {};
+		r.uuid = this.uuid, r.type = this.type, this.name !== "" && (r.name = this.name), this.castShadow === !0 && (r.castShadow = !0), this.receiveShadow === !0 && (r.receiveShadow = !0), this.visible === !1 && (r.visible = !1), this.frustumCulled === !1 && (r.frustumCulled = !1), this.renderOrder !== 0 && (r.renderOrder = this.renderOrder), this.static !== !1 && (r.static = this.static), Object.keys(this.userData).length > 0 && (r.userData = this.userData), r.layers = this.layers.mask, r.matrix = this.matrix.toArray(), r.up = this.up.toArray(), this.pivot !== null && (r.pivot = this.pivot.toArray()), this.matrixAutoUpdate === !1 && (r.matrixAutoUpdate = !1), this.morphTargetDictionary !== void 0 && (r.morphTargetDictionary = Object.assign({}, this.morphTargetDictionary)), this.morphTargetInfluences !== void 0 && (r.morphTargetInfluences = this.morphTargetInfluences.slice()), this.isInstancedMesh && (r.type = "InstancedMesh", r.count = this.count, r.instanceMatrix = this.instanceMatrix.toJSON(), this.instanceColor !== null && (r.instanceColor = this.instanceColor.toJSON())), this.isBatchedMesh && (r.type = "BatchedMesh", r.perObjectFrustumCulled = this.perObjectFrustumCulled, r.sortObjects = this.sortObjects, r.drawRanges = this._drawRanges, r.reservedRanges = this._reservedRanges, r.geometryInfo = this._geometryInfo.map((e) => ({
+			...e,
+			boundingBox: e.boundingBox ? e.boundingBox.toJSON() : void 0,
+			boundingSphere: e.boundingSphere ? e.boundingSphere.toJSON() : void 0
+		})), r.instanceInfo = this._instanceInfo.map((e) => ({ ...e })), r.availableInstanceIds = this._availableInstanceIds.slice(), r.availableGeometryIds = this._availableGeometryIds.slice(), r.nextIndexStart = this._nextIndexStart, r.nextVertexStart = this._nextVertexStart, r.geometryCount = this._geometryCount, r.maxInstanceCount = this._maxInstanceCount, r.maxVertexCount = this._maxVertexCount, r.maxIndexCount = this._maxIndexCount, r.geometryInitialized = this._geometryInitialized, r.matricesTexture = this._matricesTexture.toJSON(e), r.indirectTexture = this._indirectTexture.toJSON(e), this._colorsTexture !== null && (r.colorsTexture = this._colorsTexture.toJSON(e)), this.boundingSphere !== null && (r.boundingSphere = this.boundingSphere.toJSON()), this.boundingBox !== null && (r.boundingBox = this.boundingBox.toJSON()));
+		function i(t, n) {
+			return t[n.uuid] === void 0 && (t[n.uuid] = n.toJSON(e)), n.uuid;
+		}
+		if (this.isScene) this.background && (this.background.isColor ? r.background = this.background.toJSON() : this.background.isTexture && (r.background = this.background.toJSON(e).uuid)), this.environment && this.environment.isTexture && this.environment.isRenderTargetTexture !== !0 && (r.environment = this.environment.toJSON(e).uuid);
+		else if (this.isMesh || this.isLine || this.isPoints) {
+			r.geometry = i(e.geometries, this.geometry);
+			let t = this.geometry.parameters;
+			if (t !== void 0 && t.shapes !== void 0) {
+				let n = t.shapes;
+				if (Array.isArray(n)) for (let t = 0, r = n.length; t < r; t++) {
+					let r = n[t];
+					i(e.shapes, r);
+				}
+				else i(e.shapes, n);
+			}
+		}
+		if (this.isSkinnedMesh && (r.bindMode = this.bindMode, r.bindMatrix = this.bindMatrix.toArray(), this.skeleton !== void 0 && (i(e.skeletons, this.skeleton), r.skeleton = this.skeleton.uuid)), this.material !== void 0) if (Array.isArray(this.material)) {
+			let t = [];
+			for (let n = 0, r = this.material.length; n < r; n++) t.push(i(e.materials, this.material[n]));
+			r.material = t;
+		} else r.material = i(e.materials, this.material);
+		if (this.children.length > 0) {
+			r.children = [];
+			for (let t = 0; t < this.children.length; t++) r.children.push(this.children[t].toJSON(e).object);
+		}
+		if (this.animations.length > 0) {
+			r.animations = [];
+			for (let t = 0; t < this.animations.length; t++) {
+				let n = this.animations[t];
+				r.animations.push(i(e.animations, n));
+			}
+		}
+		if (t) {
+			let t = a(e.geometries), r = a(e.materials), i = a(e.textures), o = a(e.images), s = a(e.shapes), c = a(e.skeletons), l = a(e.animations), u = a(e.nodes);
+			t.length > 0 && (n.geometries = t), r.length > 0 && (n.materials = r), i.length > 0 && (n.textures = i), o.length > 0 && (n.images = o), s.length > 0 && (n.shapes = s), c.length > 0 && (n.skeletons = c), l.length > 0 && (n.animations = l), u.length > 0 && (n.nodes = u);
+		}
+		return n.object = r, n;
+		function a(e) {
+			let t = [];
+			for (let n in e) {
+				let r = e[n];
+				delete r.metadata, t.push(r);
+			}
+			return t;
+		}
+	}
+	clone(e) {
+		return new this.constructor().copy(this, e);
+	}
+	copy(e, t = !0) {
+		if (this.name = e.name, this.up.copy(e.up), this.position.copy(e.position), this.rotation.order = e.rotation.order, this.quaternion.copy(e.quaternion), this.scale.copy(e.scale), this.pivot = e.pivot === null ? null : e.pivot.clone(), this.matrix.copy(e.matrix), this.matrixWorld.copy(e.matrixWorld), this.matrixAutoUpdate = e.matrixAutoUpdate, this.matrixWorldAutoUpdate = e.matrixWorldAutoUpdate, this.matrixWorldNeedsUpdate = e.matrixWorldNeedsUpdate, this.layers.mask = e.layers.mask, this.visible = e.visible, this.castShadow = e.castShadow, this.receiveShadow = e.receiveShadow, this.frustumCulled = e.frustumCulled, this.renderOrder = e.renderOrder, this.static = e.static, this.animations = e.animations.slice(), this.userData = JSON.parse(JSON.stringify(e.userData)), t === !0) for (let t = 0; t < e.children.length; t++) {
+			let n = e.children[t];
+			this.add(n.clone());
+		}
+		return this;
+	}
+};
+at.DEFAULT_UP = /*@__PURE__*/ new W(0, 1, 0), at.DEFAULT_MATRIX_AUTO_UPDATE = !0, at.DEFAULT_MATRIX_WORLD_AUTO_UPDATE = !0;
+var ot = class extends at {
+	constructor() {
+		super(), this.isGroup = !0, this.type = "Group";
+	}
+}, st = { type: "move" }, ct = class {
+	constructor() {
+		this._targetRay = null, this._grip = null, this._hand = null;
+	}
+	getHandSpace() {
+		return this._hand === null && (this._hand = new ot(), this._hand.matrixAutoUpdate = !1, this._hand.visible = !1, this._hand.joints = {}, this._hand.inputState = { pinching: !1 }), this._hand;
+	}
+	getTargetRaySpace() {
+		return this._targetRay === null && (this._targetRay = new ot(), this._targetRay.matrixAutoUpdate = !1, this._targetRay.visible = !1, this._targetRay.hasLinearVelocity = !1, this._targetRay.linearVelocity = new W(), this._targetRay.hasAngularVelocity = !1, this._targetRay.angularVelocity = new W()), this._targetRay;
+	}
+	getGripSpace() {
+		return this._grip === null && (this._grip = new ot(), this._grip.matrixAutoUpdate = !1, this._grip.visible = !1, this._grip.hasLinearVelocity = !1, this._grip.linearVelocity = new W(), this._grip.hasAngularVelocity = !1, this._grip.angularVelocity = new W(), this._grip.eventsEnabled = !1), this._grip;
+	}
+	dispatchEvent(e) {
+		return this._targetRay !== null && this._targetRay.dispatchEvent(e), this._grip !== null && this._grip.dispatchEvent(e), this._hand !== null && this._hand.dispatchEvent(e), this;
+	}
+	connect(e) {
+		if (e && e.hand) {
+			let t = this._hand;
+			if (t) for (let n of e.hand.values()) this._getHandJoint(t, n);
+		}
+		return this.dispatchEvent({
+			type: "connected",
+			data: e
+		}), this;
+	}
+	disconnect(e) {
+		return this.dispatchEvent({
+			type: "disconnected",
+			data: e
+		}), this._targetRay !== null && (this._targetRay.visible = !1), this._grip !== null && (this._grip.visible = !1), this._hand !== null && (this._hand.visible = !1), this;
+	}
+	update(e, t, n) {
+		let r = null, i = null, a = null, o = this._targetRay, s = this._grip, c = this._hand;
+		if (e && t.session.visibilityState !== "visible-blurred") {
+			if (c && e.hand) {
+				a = !0;
+				for (let r of e.hand.values()) {
+					let e = t.getJointPose(r, n), i = this._getHandJoint(c, r);
+					e !== null && (i.matrix.fromArray(e.transform.matrix), i.matrix.decompose(i.position, i.rotation, i.scale), i.matrixWorldNeedsUpdate = !0, i.jointRadius = e.radius), i.visible = e !== null;
+				}
+				let r = c.joints["index-finger-tip"], i = c.joints["thumb-tip"], o = r.position.distanceTo(i.position);
+				c.inputState.pinching && o > .025 ? (c.inputState.pinching = !1, this.dispatchEvent({
+					type: "pinchend",
+					handedness: e.handedness,
+					target: this
+				})) : !c.inputState.pinching && o <= .015 && (c.inputState.pinching = !0, this.dispatchEvent({
+					type: "pinchstart",
+					handedness: e.handedness,
+					target: this
+				}));
+			} else s !== null && e.gripSpace && (i = t.getPose(e.gripSpace, n), i !== null && (s.matrix.fromArray(i.transform.matrix), s.matrix.decompose(s.position, s.rotation, s.scale), s.matrixWorldNeedsUpdate = !0, i.linearVelocity ? (s.hasLinearVelocity = !0, s.linearVelocity.copy(i.linearVelocity)) : s.hasLinearVelocity = !1, i.angularVelocity ? (s.hasAngularVelocity = !0, s.angularVelocity.copy(i.angularVelocity)) : s.hasAngularVelocity = !1, s.eventsEnabled && s.dispatchEvent({
+				type: "gripUpdated",
+				data: e,
+				target: this
+			})));
+			o !== null && (r = t.getPose(e.targetRaySpace, n), r === null && i !== null && (r = i), r !== null && (o.matrix.fromArray(r.transform.matrix), o.matrix.decompose(o.position, o.rotation, o.scale), o.matrixWorldNeedsUpdate = !0, r.linearVelocity ? (o.hasLinearVelocity = !0, o.linearVelocity.copy(r.linearVelocity)) : o.hasLinearVelocity = !1, r.angularVelocity ? (o.hasAngularVelocity = !0, o.angularVelocity.copy(r.angularVelocity)) : o.hasAngularVelocity = !1, this.dispatchEvent(st)));
+		}
+		return o !== null && (o.visible = r !== null), s !== null && (s.visible = i !== null), c !== null && (c.visible = a !== null), this;
+	}
+	_getHandJoint(e, t) {
+		if (e.joints[t.jointName] === void 0) {
+			let n = new ot();
+			n.matrixAutoUpdate = !1, n.visible = !1, e.joints[t.jointName] = n, e.add(n);
+		}
+		return e.joints[t.jointName];
+	}
+}, lt = {
+	aliceblue: 15792383,
+	antiquewhite: 16444375,
+	aqua: 65535,
+	aquamarine: 8388564,
+	azure: 15794175,
+	beige: 16119260,
+	bisque: 16770244,
+	black: 0,
+	blanchedalmond: 16772045,
+	blue: 255,
+	blueviolet: 9055202,
+	brown: 10824234,
+	burlywood: 14596231,
+	cadetblue: 6266528,
+	chartreuse: 8388352,
+	chocolate: 13789470,
+	coral: 16744272,
+	cornflowerblue: 6591981,
+	cornsilk: 16775388,
+	crimson: 14423100,
+	cyan: 65535,
+	darkblue: 139,
+	darkcyan: 35723,
+	darkgoldenrod: 12092939,
+	darkgray: 11119017,
+	darkgreen: 25600,
+	darkgrey: 11119017,
+	darkkhaki: 12433259,
+	darkmagenta: 9109643,
+	darkolivegreen: 5597999,
+	darkorange: 16747520,
+	darkorchid: 10040012,
+	darkred: 9109504,
+	darksalmon: 15308410,
+	darkseagreen: 9419919,
+	darkslateblue: 4734347,
+	darkslategray: 3100495,
+	darkslategrey: 3100495,
+	darkturquoise: 52945,
+	darkviolet: 9699539,
+	deeppink: 16716947,
+	deepskyblue: 49151,
+	dimgray: 6908265,
+	dimgrey: 6908265,
+	dodgerblue: 2003199,
+	firebrick: 11674146,
+	floralwhite: 16775920,
+	forestgreen: 2263842,
+	fuchsia: 16711935,
+	gainsboro: 14474460,
+	ghostwhite: 16316671,
+	gold: 16766720,
+	goldenrod: 14329120,
+	gray: 8421504,
+	green: 32768,
+	greenyellow: 11403055,
+	grey: 8421504,
+	honeydew: 15794160,
+	hotpink: 16738740,
+	indianred: 13458524,
+	indigo: 4915330,
+	ivory: 16777200,
+	khaki: 15787660,
+	lavender: 15132410,
+	lavenderblush: 16773365,
+	lawngreen: 8190976,
+	lemonchiffon: 16775885,
+	lightblue: 11393254,
+	lightcoral: 15761536,
+	lightcyan: 14745599,
+	lightgoldenrodyellow: 16448210,
+	lightgray: 13882323,
+	lightgreen: 9498256,
+	lightgrey: 13882323,
+	lightpink: 16758465,
+	lightsalmon: 16752762,
+	lightseagreen: 2142890,
+	lightskyblue: 8900346,
+	lightslategray: 7833753,
+	lightslategrey: 7833753,
+	lightsteelblue: 11584734,
+	lightyellow: 16777184,
+	lime: 65280,
+	limegreen: 3329330,
+	linen: 16445670,
+	magenta: 16711935,
+	maroon: 8388608,
+	mediumaquamarine: 6737322,
+	mediumblue: 205,
+	mediumorchid: 12211667,
+	mediumpurple: 9662683,
+	mediumseagreen: 3978097,
+	mediumslateblue: 8087790,
+	mediumspringgreen: 64154,
+	mediumturquoise: 4772300,
+	mediumvioletred: 13047173,
+	midnightblue: 1644912,
+	mintcream: 16121850,
+	mistyrose: 16770273,
+	moccasin: 16770229,
+	navajowhite: 16768685,
+	navy: 128,
+	oldlace: 16643558,
+	olive: 8421376,
+	olivedrab: 7048739,
+	orange: 16753920,
+	orangered: 16729344,
+	orchid: 14315734,
+	palegoldenrod: 15657130,
+	palegreen: 10025880,
+	paleturquoise: 11529966,
+	palevioletred: 14381203,
+	papayawhip: 16773077,
+	peachpuff: 16767673,
+	peru: 13468991,
+	pink: 16761035,
+	plum: 14524637,
+	powderblue: 11591910,
+	purple: 8388736,
+	rebeccapurple: 6697881,
+	red: 16711680,
+	rosybrown: 12357519,
+	royalblue: 4286945,
+	saddlebrown: 9127187,
+	salmon: 16416882,
+	sandybrown: 16032864,
+	seagreen: 3050327,
+	seashell: 16774638,
+	sienna: 10506797,
+	silver: 12632256,
+	skyblue: 8900331,
+	slateblue: 6970061,
+	slategray: 7372944,
+	slategrey: 7372944,
+	snow: 16775930,
+	springgreen: 65407,
+	steelblue: 4620980,
+	tan: 13808780,
+	teal: 32896,
+	thistle: 14204888,
+	tomato: 16737095,
+	turquoise: 4251856,
+	violet: 15631086,
+	wheat: 16113331,
+	white: 16777215,
+	whitesmoke: 16119285,
+	yellow: 16776960,
+	yellowgreen: 10145074
+}, ut = {
+	h: 0,
+	s: 0,
+	l: 0
+}, dt = {
+	h: 0,
+	s: 0,
+	l: 0
+};
+function ft(e, t, n) {
+	return n < 0 && (n += 1), n > 1 && --n, n < 1 / 6 ? e + (t - e) * 6 * n : n < 1 / 2 ? t : n < 2 / 3 ? e + (t - e) * 6 * (2 / 3 - n) : e;
+}
+var Z = class {
+	constructor(e, t, n) {
+		return this.isColor = !0, this.r = 1, this.g = 1, this.b = 1, this.set(e, t, n);
+	}
+	set(e, t, n) {
+		if (t === void 0 && n === void 0) {
+			let t = e;
+			t && t.isColor ? this.copy(t) : typeof t == "number" ? this.setHex(t) : typeof t == "string" && this.setStyle(t);
+		} else this.setRGB(e, t, n);
+		return this;
+	}
+	setScalar(e) {
+		return this.r = e, this.g = e, this.b = e, this;
+	}
+	setHex(e, t = k) {
+		return e = Math.floor(e), this.r = (e >> 16 & 255) / 255, this.g = (e >> 8 & 255) / 255, this.b = (e & 255) / 255, K.colorSpaceToWorking(this, t), this;
+	}
+	setRGB(e, t, n, r = K.workingColorSpace) {
+		return this.r = e, this.g = t, this.b = n, K.colorSpaceToWorking(this, r), this;
+	}
+	setHSL(e, t, n, r = K.workingColorSpace) {
+		if (e = de(e, 1), t = V(t, 0, 1), n = V(n, 0, 1), t === 0) this.r = this.g = this.b = n;
+		else {
+			let r = n <= .5 ? n * (1 + t) : n + t - n * t, i = 2 * n - r;
+			this.r = ft(i, r, e + 1 / 3), this.g = ft(i, r, e), this.b = ft(i, r, e - 1 / 3);
+		}
+		return K.colorSpaceToWorking(this, r), this;
+	}
+	setStyle(e, t = k) {
+		function n(t) {
+			t !== void 0 && parseFloat(t) < 1 && F("Color: Alpha component of " + e + " will be ignored.");
+		}
+		let r;
+		if (r = /^(\w+)\(([^\)]*)\)/.exec(e)) {
+			let i, a = r[1], o = r[2];
+			switch (a) {
+				case "rgb":
+				case "rgba":
+					if (i = /^\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*(\d*\.?\d+)\s*)?$/.exec(o)) return n(i[4]), this.setRGB(Math.min(255, parseInt(i[1], 10)) / 255, Math.min(255, parseInt(i[2], 10)) / 255, Math.min(255, parseInt(i[3], 10)) / 255, t);
+					if (i = /^\s*(\d+)\%\s*,\s*(\d+)\%\s*,\s*(\d+)\%\s*(?:,\s*(\d*\.?\d+)\s*)?$/.exec(o)) return n(i[4]), this.setRGB(Math.min(100, parseInt(i[1], 10)) / 100, Math.min(100, parseInt(i[2], 10)) / 100, Math.min(100, parseInt(i[3], 10)) / 100, t);
+					break;
+				case "hsl":
+				case "hsla":
+					if (i = /^\s*(\d*\.?\d+)\s*,\s*(\d*\.?\d+)\%\s*,\s*(\d*\.?\d+)\%\s*(?:,\s*(\d*\.?\d+)\s*)?$/.exec(o)) return n(i[4]), this.setHSL(parseFloat(i[1]) / 360, parseFloat(i[2]) / 100, parseFloat(i[3]) / 100, t);
+					break;
+				default: F("Color: Unknown color model " + e);
+			}
+		} else if (r = /^\#([A-Fa-f\d]+)$/.exec(e)) {
+			let n = r[1], i = n.length;
+			if (i === 3) return this.setRGB(parseInt(n.charAt(0), 16) / 15, parseInt(n.charAt(1), 16) / 15, parseInt(n.charAt(2), 16) / 15, t);
+			if (i === 6) return this.setHex(parseInt(n, 16), t);
+			F("Color: Invalid hex color " + e);
+		} else if (e && e.length > 0) return this.setColorName(e, t);
+		return this;
+	}
+	setColorName(e, t = k) {
+		let n = lt[e.toLowerCase()];
+		return n === void 0 ? F("Color: Unknown color " + e) : this.setHex(n, t), this;
+	}
+	clone() {
+		return new this.constructor(this.r, this.g, this.b);
+	}
+	copy(e) {
+		return this.r = e.r, this.g = e.g, this.b = e.b, this;
+	}
+	copySRGBToLinear(e) {
+		return this.r = xe(e.r), this.g = xe(e.g), this.b = xe(e.b), this;
+	}
+	copyLinearToSRGB(e) {
+		return this.r = Se(e.r), this.g = Se(e.g), this.b = Se(e.b), this;
+	}
+	convertSRGBToLinear() {
+		return this.copySRGBToLinear(this), this;
+	}
+	convertLinearToSRGB() {
+		return this.copyLinearToSRGB(this), this;
+	}
+	getHex(e = k) {
+		return K.workingToColorSpace(pt.copy(this), e), Math.round(V(pt.r * 255, 0, 255)) * 65536 + Math.round(V(pt.g * 255, 0, 255)) * 256 + Math.round(V(pt.b * 255, 0, 255));
+	}
+	getHexString(e = k) {
+		return ("000000" + this.getHex(e).toString(16)).slice(-6);
+	}
+	getHSL(e, t = K.workingColorSpace) {
+		K.workingToColorSpace(pt.copy(this), t);
+		let n = pt.r, r = pt.g, i = pt.b, a = Math.max(n, r, i), o = Math.min(n, r, i), s, c, l = (o + a) / 2;
+		if (o === a) s = 0, c = 0;
+		else {
+			let e = a - o;
+			switch (c = l <= .5 ? e / (a + o) : e / (2 - a - o), a) {
+				case n:
+					s = (r - i) / e + (r < i ? 6 : 0);
+					break;
+				case r:
+					s = (i - n) / e + 2;
+					break;
+				case i:
+					s = (n - r) / e + 4;
+					break;
+			}
+			s /= 6;
+		}
+		return e.h = s, e.s = c, e.l = l, e;
+	}
+	getRGB(e, t = K.workingColorSpace) {
+		return K.workingToColorSpace(pt.copy(this), t), e.r = pt.r, e.g = pt.g, e.b = pt.b, e;
+	}
+	getStyle(e = k) {
+		K.workingToColorSpace(pt.copy(this), e);
+		let t = pt.r, n = pt.g, r = pt.b;
+		return e === "srgb" ? `rgb(${Math.round(t * 255)},${Math.round(n * 255)},${Math.round(r * 255)})` : `color(${e} ${t.toFixed(3)} ${n.toFixed(3)} ${r.toFixed(3)})`;
+	}
+	offsetHSL(e, t, n) {
+		return this.getHSL(ut), this.setHSL(ut.h + e, ut.s + t, ut.l + n);
+	}
+	add(e) {
+		return this.r += e.r, this.g += e.g, this.b += e.b, this;
+	}
+	addColors(e, t) {
+		return this.r = e.r + t.r, this.g = e.g + t.g, this.b = e.b + t.b, this;
+	}
+	addScalar(e) {
+		return this.r += e, this.g += e, this.b += e, this;
+	}
+	sub(e) {
+		return this.r = Math.max(0, this.r - e.r), this.g = Math.max(0, this.g - e.g), this.b = Math.max(0, this.b - e.b), this;
+	}
+	multiply(e) {
+		return this.r *= e.r, this.g *= e.g, this.b *= e.b, this;
+	}
+	multiplyScalar(e) {
+		return this.r *= e, this.g *= e, this.b *= e, this;
+	}
+	lerp(e, t) {
+		return this.r += (e.r - this.r) * t, this.g += (e.g - this.g) * t, this.b += (e.b - this.b) * t, this;
+	}
+	lerpColors(e, t, n) {
+		return this.r = e.r + (t.r - e.r) * n, this.g = e.g + (t.g - e.g) * n, this.b = e.b + (t.b - e.b) * n, this;
+	}
+	lerpHSL(e, t) {
+		this.getHSL(ut), e.getHSL(dt);
+		let n = fe(ut.h, dt.h, t), r = fe(ut.s, dt.s, t), i = fe(ut.l, dt.l, t);
+		return this.setHSL(n, r, i), this;
+	}
+	setFromVector3(e) {
+		return this.r = e.x, this.g = e.y, this.b = e.z, this;
+	}
+	applyMatrix3(e) {
+		let t = this.r, n = this.g, r = this.b, i = e.elements;
+		return this.r = i[0] * t + i[3] * n + i[6] * r, this.g = i[1] * t + i[4] * n + i[7] * r, this.b = i[2] * t + i[5] * n + i[8] * r, this;
+	}
+	equals(e) {
+		return e.r === this.r && e.g === this.g && e.b === this.b;
+	}
+	fromArray(e, t = 0) {
+		return this.r = e[t], this.g = e[t + 1], this.b = e[t + 2], this;
+	}
+	toArray(e = [], t = 0) {
+		return e[t] = this.r, e[t + 1] = this.g, e[t + 2] = this.b, e;
+	}
+	fromBufferAttribute(e, t) {
+		return this.r = e.getX(t), this.g = e.getY(t), this.b = e.getZ(t), this;
+	}
+	toJSON() {
+		return this.getHex();
+	}
+	*[Symbol.iterator]() {
+		yield this.r, yield this.g, yield this.b;
+	}
+}, pt = /*@__PURE__*/ new Z();
+Z.NAMES = lt;
+var mt = class extends at {
+	constructor() {
+		super(), this.isScene = !0, this.type = "Scene", this.background = null, this.environment = null, this.fog = null, this.backgroundBlurriness = 0, this.backgroundIntensity = 1, this.backgroundRotation = new He(), this.environmentIntensity = 1, this.environmentRotation = new He(), this.overrideMaterial = null, typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("observe", { detail: this }));
+	}
+	copy(e, t) {
+		return super.copy(e, t), e.background !== null && (this.background = e.background.clone()), e.environment !== null && (this.environment = e.environment.clone()), e.fog !== null && (this.fog = e.fog.clone()), this.backgroundBlurriness = e.backgroundBlurriness, this.backgroundIntensity = e.backgroundIntensity, this.backgroundRotation.copy(e.backgroundRotation), this.environmentIntensity = e.environmentIntensity, this.environmentRotation.copy(e.environmentRotation), e.overrideMaterial !== null && (this.overrideMaterial = e.overrideMaterial.clone()), this.matrixAutoUpdate = e.matrixAutoUpdate, this;
+	}
+	toJSON(e) {
+		let t = super.toJSON(e);
+		return this.fog !== null && (t.object.fog = this.fog.toJSON()), this.backgroundBlurriness > 0 && (t.object.backgroundBlurriness = this.backgroundBlurriness), this.backgroundIntensity !== 1 && (t.object.backgroundIntensity = this.backgroundIntensity), t.object.backgroundRotation = this.backgroundRotation.toArray(), this.environmentIntensity !== 1 && (t.object.environmentIntensity = this.environmentIntensity), t.object.environmentRotation = this.environmentRotation.toArray(), t;
+	}
+}, ht = /*@__PURE__*/ new W(), gt = /*@__PURE__*/ new W(), _t = /*@__PURE__*/ new W(), vt = /*@__PURE__*/ new W(), yt = /*@__PURE__*/ new W(), bt = /*@__PURE__*/ new W(), xt = /*@__PURE__*/ new W(), St = /*@__PURE__*/ new W(), Ct = /*@__PURE__*/ new W(), wt = /*@__PURE__*/ new W(), Tt = /*@__PURE__*/ new je(), Et = /*@__PURE__*/ new je(), Dt = /*@__PURE__*/ new je(), Ot = class e {
+	constructor(e = new W(), t = new W(), n = new W()) {
+		this.a = e, this.b = t, this.c = n;
+	}
+	static getNormal(e, t, n, r) {
+		r.subVectors(n, t), ht.subVectors(e, t), r.cross(ht);
+		let i = r.lengthSq();
+		return i > 0 ? r.multiplyScalar(1 / Math.sqrt(i)) : r.set(0, 0, 0);
+	}
+	static getBarycoord(e, t, n, r, i) {
+		ht.subVectors(r, t), gt.subVectors(n, t), _t.subVectors(e, t);
+		let a = ht.dot(ht), o = ht.dot(gt), s = ht.dot(_t), c = gt.dot(gt), l = gt.dot(_t), u = a * c - o * o;
+		if (u === 0) return i.set(0, 0, 0), null;
+		let d = 1 / u, f = (c * s - o * l) * d, p = (a * l - o * s) * d;
+		return i.set(1 - f - p, p, f);
+	}
+	static containsPoint(e, t, n, r) {
+		return this.getBarycoord(e, t, n, r, vt) !== null && vt.x >= 0 && vt.y >= 0 && vt.x + vt.y <= 1;
+	}
+	static getInterpolation(e, t, n, r, i, a, o, s) {
+		return this.getBarycoord(e, t, n, r, vt) === null ? (s.x = 0, s.y = 0, "z" in s && (s.z = 0), "w" in s && (s.w = 0), null) : (s.setScalar(0), s.addScaledVector(i, vt.x), s.addScaledVector(a, vt.y), s.addScaledVector(o, vt.z), s);
+	}
+	static getInterpolatedAttribute(e, t, n, r, i, a) {
+		return Tt.setScalar(0), Et.setScalar(0), Dt.setScalar(0), Tt.fromBufferAttribute(e, t), Et.fromBufferAttribute(e, n), Dt.fromBufferAttribute(e, r), a.setScalar(0), a.addScaledVector(Tt, i.x), a.addScaledVector(Et, i.y), a.addScaledVector(Dt, i.z), a;
+	}
+	static isFrontFacing(e, t, n, r) {
+		return ht.subVectors(n, t), gt.subVectors(e, t), ht.cross(gt).dot(r) < 0;
+	}
+	set(e, t, n) {
+		return this.a.copy(e), this.b.copy(t), this.c.copy(n), this;
+	}
+	setFromPointsAndIndices(e, t, n, r) {
+		return this.a.copy(e[t]), this.b.copy(e[n]), this.c.copy(e[r]), this;
+	}
+	setFromAttributeAndIndices(e, t, n, r) {
+		return this.a.fromBufferAttribute(e, t), this.b.fromBufferAttribute(e, n), this.c.fromBufferAttribute(e, r), this;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	copy(e) {
+		return this.a.copy(e.a), this.b.copy(e.b), this.c.copy(e.c), this;
+	}
+	getArea() {
+		return ht.subVectors(this.c, this.b), gt.subVectors(this.a, this.b), ht.cross(gt).length() * .5;
+	}
+	getMidpoint(e) {
+		return e.addVectors(this.a, this.b).add(this.c).multiplyScalar(1 / 3);
+	}
+	getNormal(t) {
+		return e.getNormal(this.a, this.b, this.c, t);
+	}
+	getPlane(e) {
+		return e.setFromCoplanarPoints(this.a, this.b, this.c);
+	}
+	getBarycoord(t, n) {
+		return e.getBarycoord(t, this.a, this.b, this.c, n);
+	}
+	getInterpolation(t, n, r, i, a) {
+		return e.getInterpolation(t, this.a, this.b, this.c, n, r, i, a);
+	}
+	containsPoint(t) {
+		return e.containsPoint(t, this.a, this.b, this.c);
+	}
+	isFrontFacing(t) {
+		return e.isFrontFacing(this.a, this.b, this.c, t);
+	}
+	intersectsBox(e) {
+		return e.intersectsTriangle(this);
+	}
+	closestPointToPoint(e, t) {
+		let n = this.a, r = this.b, i = this.c, a, o;
+		yt.subVectors(r, n), bt.subVectors(i, n), St.subVectors(e, n);
+		let s = yt.dot(St), c = bt.dot(St);
+		if (s <= 0 && c <= 0) return t.copy(n);
+		Ct.subVectors(e, r);
+		let l = yt.dot(Ct), u = bt.dot(Ct);
+		if (l >= 0 && u <= l) return t.copy(r);
+		let d = s * u - l * c;
+		if (d <= 0 && s >= 0 && l <= 0) return a = s / (s - l), t.copy(n).addScaledVector(yt, a);
+		wt.subVectors(e, i);
+		let f = yt.dot(wt), p = bt.dot(wt);
+		if (p >= 0 && f <= p) return t.copy(i);
+		let m = f * c - s * p;
+		if (m <= 0 && c >= 0 && p <= 0) return o = c / (c - p), t.copy(n).addScaledVector(bt, o);
+		let h = l * p - f * u;
+		if (h <= 0 && u - l >= 0 && f - p >= 0) return xt.subVectors(i, r), o = (u - l) / (u - l + (f - p)), t.copy(r).addScaledVector(xt, o);
+		let g = 1 / (h + m + d);
+		return a = m * g, o = d * g, t.copy(n).addScaledVector(yt, a).addScaledVector(bt, o);
+	}
+	equals(e) {
+		return e.a.equals(this.a) && e.b.equals(this.b) && e.c.equals(this.c);
+	}
+}, kt = class {
+	constructor(e = new W(Infinity, Infinity, Infinity), t = new W(-Infinity, -Infinity, -Infinity)) {
+		this.isBox3 = !0, this.min = e, this.max = t;
+	}
+	set(e, t) {
+		return this.min.copy(e), this.max.copy(t), this;
+	}
+	setFromArray(e) {
+		this.makeEmpty();
+		for (let t = 0, n = e.length; t < n; t += 3) this.expandByPoint(jt.fromArray(e, t));
+		return this;
+	}
+	setFromBufferAttribute(e) {
+		this.makeEmpty();
+		for (let t = 0, n = e.count; t < n; t++) this.expandByPoint(jt.fromBufferAttribute(e, t));
+		return this;
+	}
+	setFromPoints(e) {
+		this.makeEmpty();
+		for (let t = 0, n = e.length; t < n; t++) this.expandByPoint(e[t]);
+		return this;
+	}
+	setFromCenterAndSize(e, t) {
+		let n = jt.copy(t).multiplyScalar(.5);
+		return this.min.copy(e).sub(n), this.max.copy(e).add(n), this;
+	}
+	setFromObject(e, t = !1) {
+		return this.makeEmpty(), this.expandByObject(e, t);
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	copy(e) {
+		return this.min.copy(e.min), this.max.copy(e.max), this;
+	}
+	makeEmpty() {
+		return this.min.x = this.min.y = this.min.z = Infinity, this.max.x = this.max.y = this.max.z = -Infinity, this;
+	}
+	isEmpty() {
+		return this.max.x < this.min.x || this.max.y < this.min.y || this.max.z < this.min.z;
+	}
+	getCenter(e) {
+		return this.isEmpty() ? e.set(0, 0, 0) : e.addVectors(this.min, this.max).multiplyScalar(.5);
+	}
+	getSize(e) {
+		return this.isEmpty() ? e.set(0, 0, 0) : e.subVectors(this.max, this.min);
+	}
+	expandByPoint(e) {
+		return this.min.min(e), this.max.max(e), this;
+	}
+	expandByVector(e) {
+		return this.min.sub(e), this.max.add(e), this;
+	}
+	expandByScalar(e) {
+		return this.min.addScalar(-e), this.max.addScalar(e), this;
+	}
+	expandByObject(e, t = !1) {
+		e.updateWorldMatrix(!1, !1);
+		let n = e.geometry;
+		if (n !== void 0) {
+			let r = n.getAttribute("position");
+			if (t === !0 && r !== void 0 && e.isInstancedMesh !== !0) for (let t = 0, n = r.count; t < n; t++) e.isMesh === !0 ? e.getVertexPosition(t, jt) : jt.fromBufferAttribute(r, t), jt.applyMatrix4(e.matrixWorld), this.expandByPoint(jt);
+			else e.boundingBox === void 0 ? (n.boundingBox === null && n.computeBoundingBox(), Mt.copy(n.boundingBox)) : (e.boundingBox === null && e.computeBoundingBox(), Mt.copy(e.boundingBox)), Mt.applyMatrix4(e.matrixWorld), this.union(Mt);
+		}
+		let r = e.children;
+		for (let e = 0, n = r.length; e < n; e++) this.expandByObject(r[e], t);
+		return this;
+	}
+	containsPoint(e) {
+		return e.x >= this.min.x && e.x <= this.max.x && e.y >= this.min.y && e.y <= this.max.y && e.z >= this.min.z && e.z <= this.max.z;
+	}
+	containsBox(e) {
+		return this.min.x <= e.min.x && e.max.x <= this.max.x && this.min.y <= e.min.y && e.max.y <= this.max.y && this.min.z <= e.min.z && e.max.z <= this.max.z;
+	}
+	getParameter(e, t) {
+		return t.set((e.x - this.min.x) / (this.max.x - this.min.x), (e.y - this.min.y) / (this.max.y - this.min.y), (e.z - this.min.z) / (this.max.z - this.min.z));
+	}
+	intersectsBox(e) {
+		return e.max.x >= this.min.x && e.min.x <= this.max.x && e.max.y >= this.min.y && e.min.y <= this.max.y && e.max.z >= this.min.z && e.min.z <= this.max.z;
+	}
+	intersectsSphere(e) {
+		return this.clampPoint(e.center, jt), jt.distanceToSquared(e.center) <= e.radius * e.radius;
+	}
+	intersectsPlane(e) {
+		let t, n;
+		return e.normal.x > 0 ? (t = e.normal.x * this.min.x, n = e.normal.x * this.max.x) : (t = e.normal.x * this.max.x, n = e.normal.x * this.min.x), e.normal.y > 0 ? (t += e.normal.y * this.min.y, n += e.normal.y * this.max.y) : (t += e.normal.y * this.max.y, n += e.normal.y * this.min.y), e.normal.z > 0 ? (t += e.normal.z * this.min.z, n += e.normal.z * this.max.z) : (t += e.normal.z * this.max.z, n += e.normal.z * this.min.z), t <= -e.constant && n >= -e.constant;
+	}
+	intersectsTriangle(e) {
+		if (this.isEmpty()) return !1;
+		this.getCenter(zt), Bt.subVectors(this.max, zt), Nt.subVectors(e.a, zt), Pt.subVectors(e.b, zt), Ft.subVectors(e.c, zt), It.subVectors(Pt, Nt), Lt.subVectors(Ft, Pt), Rt.subVectors(Nt, Ft);
+		let t = [
+			0,
+			-It.z,
+			It.y,
+			0,
+			-Lt.z,
+			Lt.y,
+			0,
+			-Rt.z,
+			Rt.y,
+			It.z,
+			0,
+			-It.x,
+			Lt.z,
+			0,
+			-Lt.x,
+			Rt.z,
+			0,
+			-Rt.x,
+			-It.y,
+			It.x,
+			0,
+			-Lt.y,
+			Lt.x,
+			0,
+			-Rt.y,
+			Rt.x,
+			0
+		];
+		return !Ut(t, Nt, Pt, Ft, Bt) || (t = [
+			1,
+			0,
+			0,
+			0,
+			1,
+			0,
+			0,
+			0,
+			1
+		], !Ut(t, Nt, Pt, Ft, Bt)) ? !1 : (Vt.crossVectors(It, Lt), t = [
+			Vt.x,
+			Vt.y,
+			Vt.z
+		], Ut(t, Nt, Pt, Ft, Bt));
+	}
+	clampPoint(e, t) {
+		return t.copy(e).clamp(this.min, this.max);
+	}
+	distanceToPoint(e) {
+		return this.clampPoint(e, jt).distanceTo(e);
+	}
+	getBoundingSphere(e) {
+		return this.isEmpty() ? e.makeEmpty() : (this.getCenter(e.center), e.radius = this.getSize(jt).length() * .5), e;
+	}
+	intersect(e) {
+		return this.min.max(e.min), this.max.min(e.max), this.isEmpty() && this.makeEmpty(), this;
+	}
+	union(e) {
+		return this.min.min(e.min), this.max.max(e.max), this;
+	}
+	applyMatrix4(e) {
+		return this.isEmpty() ? this : (At[0].set(this.min.x, this.min.y, this.min.z).applyMatrix4(e), At[1].set(this.min.x, this.min.y, this.max.z).applyMatrix4(e), At[2].set(this.min.x, this.max.y, this.min.z).applyMatrix4(e), At[3].set(this.min.x, this.max.y, this.max.z).applyMatrix4(e), At[4].set(this.max.x, this.min.y, this.min.z).applyMatrix4(e), At[5].set(this.max.x, this.min.y, this.max.z).applyMatrix4(e), At[6].set(this.max.x, this.max.y, this.min.z).applyMatrix4(e), At[7].set(this.max.x, this.max.y, this.max.z).applyMatrix4(e), this.setFromPoints(At), this);
+	}
+	translate(e) {
+		return this.min.add(e), this.max.add(e), this;
+	}
+	equals(e) {
+		return e.min.equals(this.min) && e.max.equals(this.max);
+	}
+	toJSON() {
+		return {
+			min: this.min.toArray(),
+			max: this.max.toArray()
+		};
+	}
+	fromJSON(e) {
+		return this.min.fromArray(e.min), this.max.fromArray(e.max), this;
+	}
+}, At = [
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W(),
+	/*@__PURE__*/ new W()
+], jt = /*@__PURE__*/ new W(), Mt = /*@__PURE__*/ new kt(), Nt = /*@__PURE__*/ new W(), Pt = /*@__PURE__*/ new W(), Ft = /*@__PURE__*/ new W(), It = /*@__PURE__*/ new W(), Lt = /*@__PURE__*/ new W(), Rt = /*@__PURE__*/ new W(), zt = /*@__PURE__*/ new W(), Bt = /*@__PURE__*/ new W(), Vt = /*@__PURE__*/ new W(), Ht = /*@__PURE__*/ new W();
+function Ut(e, t, n, r, i) {
+	for (let a = 0, o = e.length - 3; a <= o; a += 3) {
+		Ht.fromArray(e, a);
+		let o = i.x * Math.abs(Ht.x) + i.y * Math.abs(Ht.y) + i.z * Math.abs(Ht.z), s = t.dot(Ht), c = n.dot(Ht), l = r.dot(Ht);
+		if (Math.max(-Math.max(s, c, l), Math.min(s, c, l)) > o) return !1;
+	}
+	return !0;
+}
+var Wt = /*@__PURE__*/ new W(), Gt = /*@__PURE__*/ new U(), Kt = 0, qt = class extends R {
+	constructor(e, t, n = !1) {
+		if (super(), Array.isArray(e)) throw TypeError("THREE.BufferAttribute: array should be a Typed Array.");
+		this.isBufferAttribute = !0, Object.defineProperty(this, "id", { value: Kt++ }), this.name = "", this.array = e, this.itemSize = t, this.count = e === void 0 ? 0 : e.length / t, this.normalized = n, this.usage = 35044, this.updateRanges = [], this.gpuType = l, this.version = 0;
+	}
+	onUploadCallback() {}
+	set needsUpdate(e) {
+		e === !0 && this.version++;
+	}
+	setUsage(e) {
+		return this.usage = e, this;
+	}
+	addUpdateRange(e, t) {
+		this.updateRanges.push({
+			start: e,
+			count: t
+		});
+	}
+	clearUpdateRanges() {
+		this.updateRanges.length = 0;
+	}
+	copy(e) {
+		return this.name = e.name, this.array = new e.array.constructor(e.array), this.itemSize = e.itemSize, this.count = e.count, this.normalized = e.normalized, this.usage = e.usage, this.gpuType = e.gpuType, this;
+	}
+	copyAt(e, t, n) {
+		e *= this.itemSize, n *= t.itemSize;
+		for (let r = 0, i = this.itemSize; r < i; r++) this.array[e + r] = t.array[n + r];
+		return this;
+	}
+	copyArray(e) {
+		return this.array.set(e), this;
+	}
+	applyMatrix3(e) {
+		if (this.itemSize === 2) for (let t = 0, n = this.count; t < n; t++) Gt.fromBufferAttribute(this, t), Gt.applyMatrix3(e), this.setXY(t, Gt.x, Gt.y);
+		else if (this.itemSize === 3) for (let t = 0, n = this.count; t < n; t++) Wt.fromBufferAttribute(this, t), Wt.applyMatrix3(e), this.setXYZ(t, Wt.x, Wt.y, Wt.z);
+		return this;
+	}
+	applyMatrix4(e) {
+		for (let t = 0, n = this.count; t < n; t++) Wt.fromBufferAttribute(this, t), Wt.applyMatrix4(e), this.setXYZ(t, Wt.x, Wt.y, Wt.z);
+		return this;
+	}
+	applyNormalMatrix(e) {
+		for (let t = 0, n = this.count; t < n; t++) Wt.fromBufferAttribute(this, t), Wt.applyNormalMatrix(e), this.setXYZ(t, Wt.x, Wt.y, Wt.z);
+		return this;
+	}
+	transformDirection(e) {
+		for (let t = 0, n = this.count; t < n; t++) Wt.fromBufferAttribute(this, t), Wt.transformDirection(e), this.setXYZ(t, Wt.x, Wt.y, Wt.z);
+		return this;
+	}
+	set(e, t = 0) {
+		return this.array.set(e, t), this;
+	}
+	getComponent(e, t) {
+		let n = this.array[e * this.itemSize + t];
+		return this.normalized && (n = pe(n, this.array)), n;
+	}
+	setComponent(e, t, n) {
+		return this.normalized && (n = H(n, this.array)), this.array[e * this.itemSize + t] = n, this;
+	}
+	getX(e) {
+		let t = this.array[e * this.itemSize];
+		return this.normalized && (t = pe(t, this.array)), t;
+	}
+	setX(e, t) {
+		return this.normalized && (t = H(t, this.array)), this.array[e * this.itemSize] = t, this;
+	}
+	getY(e) {
+		let t = this.array[e * this.itemSize + 1];
+		return this.normalized && (t = pe(t, this.array)), t;
+	}
+	setY(e, t) {
+		return this.normalized && (t = H(t, this.array)), this.array[e * this.itemSize + 1] = t, this;
+	}
+	getZ(e) {
+		let t = this.array[e * this.itemSize + 2];
+		return this.normalized && (t = pe(t, this.array)), t;
+	}
+	setZ(e, t) {
+		return this.normalized && (t = H(t, this.array)), this.array[e * this.itemSize + 2] = t, this;
+	}
+	getW(e) {
+		let t = this.array[e * this.itemSize + 3];
+		return this.normalized && (t = pe(t, this.array)), t;
+	}
+	setW(e, t) {
+		return this.normalized && (t = H(t, this.array)), this.array[e * this.itemSize + 3] = t, this;
+	}
+	setXY(e, t, n) {
+		return e *= this.itemSize, this.normalized && (t = H(t, this.array), n = H(n, this.array)), this.array[e + 0] = t, this.array[e + 1] = n, this;
+	}
+	setXYZ(e, t, n, r) {
+		return e *= this.itemSize, this.normalized && (t = H(t, this.array), n = H(n, this.array), r = H(r, this.array)), this.array[e + 0] = t, this.array[e + 1] = n, this.array[e + 2] = r, this;
+	}
+	setXYZW(e, t, n, r, i) {
+		return e *= this.itemSize, this.normalized && (t = H(t, this.array), n = H(n, this.array), r = H(r, this.array), i = H(i, this.array)), this.array[e + 0] = t, this.array[e + 1] = n, this.array[e + 2] = r, this.array[e + 3] = i, this;
+	}
+	onUpload(e) {
+		return this.onUploadCallback = e, this;
+	}
+	clone() {
+		return new this.constructor(this.array, this.itemSize).copy(this);
+	}
+	toJSON() {
+		let e = {
+			itemSize: this.itemSize,
+			type: this.array.constructor.name,
+			array: Array.from(this.array),
+			normalized: this.normalized
+		};
+		return this.name !== "" && (e.name = this.name), this.usage !== 35044 && (e.usage = this.usage), e;
+	}
+	dispose() {
+		this.dispatchEvent({ type: "dispose" });
+	}
+}, Jt = class extends qt {
+	constructor(e, t, n) {
+		super(new Uint16Array(e), t, n);
+	}
+}, Yt = class extends qt {
+	constructor(e, t, n) {
+		super(new Uint32Array(e), t, n);
+	}
+}, Xt = class extends qt {
+	constructor(e, t, n) {
+		super(new Float32Array(e), t, n);
+	}
+}, Zt = /*@__PURE__*/ new kt(), Qt = /*@__PURE__*/ new W(), $t = /*@__PURE__*/ new W(), en = class {
+	constructor(e = new W(), t = -1) {
+		this.isSphere = !0, this.center = e, this.radius = t;
+	}
+	set(e, t) {
+		return this.center.copy(e), this.radius = t, this;
+	}
+	setFromPoints(e, t) {
+		let n = this.center;
+		t === void 0 ? Zt.setFromPoints(e).getCenter(n) : n.copy(t);
+		let r = 0;
+		for (let t = 0, i = e.length; t < i; t++) r = Math.max(r, n.distanceToSquared(e[t]));
+		return this.radius = Math.sqrt(r), this;
+	}
+	copy(e) {
+		return this.center.copy(e.center), this.radius = e.radius, this;
+	}
+	isEmpty() {
+		return this.radius < 0;
+	}
+	makeEmpty() {
+		return this.center.set(0, 0, 0), this.radius = -1, this;
+	}
+	containsPoint(e) {
+		return e.distanceToSquared(this.center) <= this.radius * this.radius;
+	}
+	distanceToPoint(e) {
+		return e.distanceTo(this.center) - this.radius;
+	}
+	intersectsSphere(e) {
+		let t = this.radius + e.radius;
+		return e.center.distanceToSquared(this.center) <= t * t;
+	}
+	intersectsBox(e) {
+		return e.intersectsSphere(this);
+	}
+	intersectsPlane(e) {
+		return Math.abs(e.distanceToPoint(this.center)) <= this.radius;
+	}
+	clampPoint(e, t) {
+		let n = this.center.distanceToSquared(e);
+		return t.copy(e), n > this.radius * this.radius && (t.sub(this.center).normalize(), t.multiplyScalar(this.radius).add(this.center)), t;
+	}
+	getBoundingBox(e) {
+		return this.isEmpty() ? (e.makeEmpty(), e) : (e.set(this.center, this.center), e.expandByScalar(this.radius), e);
+	}
+	applyMatrix4(e) {
+		return this.center.applyMatrix4(e), this.radius *= e.getMaxScaleOnAxis(), this;
+	}
+	translate(e) {
+		return this.center.add(e), this;
+	}
+	expandByPoint(e) {
+		if (this.isEmpty()) return this.center.copy(e), this.radius = 0, this;
+		Qt.subVectors(e, this.center);
+		let t = Qt.lengthSq();
+		if (t > this.radius * this.radius) {
+			let e = Math.sqrt(t), n = (e - this.radius) * .5;
+			this.center.addScaledVector(Qt, n / e), this.radius += n;
+		}
+		return this;
+	}
+	union(e) {
+		return e.isEmpty() ? this : this.isEmpty() ? (this.copy(e), this) : (this.center.equals(e.center) === !0 ? this.radius = Math.max(this.radius, e.radius) : ($t.subVectors(e.center, this.center).setLength(e.radius), this.expandByPoint(Qt.copy(e.center).add($t)), this.expandByPoint(Qt.copy(e.center).sub($t))), this);
+	}
+	equals(e) {
+		return e.center.equals(this.center) && e.radius === this.radius;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	toJSON() {
+		return {
+			radius: this.radius,
+			center: this.center.toArray()
+		};
+	}
+	fromJSON(e) {
+		return this.radius = e.radius, this.center.fromArray(e.center), this;
+	}
+}, tn = 0, nn = /*@__PURE__*/ new Fe(), rn = /*@__PURE__*/ new at(), an = /*@__PURE__*/ new W(), on = /*@__PURE__*/ new kt(), sn = /*@__PURE__*/ new kt(), cn = /*@__PURE__*/ new W(), ln = class e extends R {
+	constructor() {
+		super(), this.isBufferGeometry = !0, Object.defineProperty(this, "id", { value: tn++ }), this.uuid = B(), this.name = "", this.type = "BufferGeometry", this.index = null, this.indirect = null, this.indirectOffset = 0, this.attributes = {}, this.morphAttributes = {}, this.morphTargetsRelative = !1, this.groups = [], this.boundingBox = null, this.boundingSphere = null, this.drawRange = {
+			start: 0,
+			count: Infinity
+		}, this.userData = {}, this._transformed = !1;
+	}
+	getIndex() {
+		return this.index;
+	}
+	setIndex(e) {
+		return Array.isArray(e) ? this.index = new (ne(e) ? Yt : Jt)(e, 1) : this.index = e, this;
+	}
+	setIndirect(e, t = 0) {
+		return this.indirect = e, this.indirectOffset = t, this;
+	}
+	getIndirect() {
+		return this.indirect;
+	}
+	getAttribute(e) {
+		return this.attributes[e];
+	}
+	setAttribute(e, t) {
+		return this.attributes[e] = t, this;
+	}
+	deleteAttribute(e) {
+		return delete this.attributes[e], this;
+	}
+	hasAttribute(e) {
+		return this.attributes[e] !== void 0;
+	}
+	addGroup(e, t, n = 0) {
+		this.groups.push({
+			start: e,
+			count: t,
+			materialIndex: n
+		});
+	}
+	clearGroups() {
+		this.groups = [];
+	}
+	setDrawRange(e, t) {
+		this.drawRange.start = e, this.drawRange.count = t;
+	}
+	applyMatrix4(e) {
+		let t = this.attributes.position;
+		t !== void 0 && (t.applyMatrix4(e), t.needsUpdate = !0);
+		let n = this.attributes.normal;
+		if (n !== void 0) {
+			let t = new G().getNormalMatrix(e);
+			n.applyNormalMatrix(t), n.needsUpdate = !0;
+		}
+		let r = this.attributes.tangent;
+		return r !== void 0 && (r.transformDirection(e), r.needsUpdate = !0), this.boundingBox !== null && this.computeBoundingBox(), this.boundingSphere !== null && this.computeBoundingSphere(), this._transformed = !0, this;
+	}
+	applyQuaternion(e) {
+		return nn.makeRotationFromQuaternion(e), this.applyMatrix4(nn), this;
+	}
+	rotateX(e) {
+		return nn.makeRotationX(e), this.applyMatrix4(nn), this;
+	}
+	rotateY(e) {
+		return nn.makeRotationY(e), this.applyMatrix4(nn), this;
+	}
+	rotateZ(e) {
+		return nn.makeRotationZ(e), this.applyMatrix4(nn), this;
+	}
+	translate(e, t, n) {
+		return nn.makeTranslation(e, t, n), this.applyMatrix4(nn), this;
+	}
+	scale(e, t, n) {
+		return nn.makeScale(e, t, n), this.applyMatrix4(nn), this;
+	}
+	lookAt(e) {
+		return rn.lookAt(e), rn.updateMatrix(), this.applyMatrix4(rn.matrix), this;
+	}
+	center() {
+		return this.computeBoundingBox(), this.boundingBox.getCenter(an).negate(), this.translate(an.x, an.y, an.z), this;
+	}
+	setFromPoints(e) {
+		let t = this.getAttribute("position");
+		if (t === void 0) {
+			let t = [];
+			for (let n = 0, r = e.length; n < r; n++) {
+				let r = e[n];
+				t.push(r.x, r.y, r.z || 0);
+			}
+			this.setAttribute("position", new Xt(t, 3));
+		} else {
+			let n = Math.min(e.length, t.count);
+			for (let r = 0; r < n; r++) {
+				let n = e[r];
+				t.setXYZ(r, n.x, n.y, n.z || 0);
+			}
+			e.length > t.count && F("BufferGeometry: Buffer size too small for points data. Use .dispose() and create a new geometry."), t.needsUpdate = !0;
+		}
+		return this;
+	}
+	computeBoundingBox() {
+		this.boundingBox === null && (this.boundingBox = new kt());
+		let e = this.attributes.position, t = this.morphAttributes.position;
+		if (e && e.isGLBufferAttribute) {
+			I("BufferGeometry.computeBoundingBox(): GLBufferAttribute requires a manual bounding box.", this), this.boundingBox.set(new W(-Infinity, -Infinity, -Infinity), new W(Infinity, Infinity, Infinity));
+			return;
+		}
+		if (e !== void 0) {
+			if (this.boundingBox.setFromBufferAttribute(e), t) for (let e = 0, n = t.length; e < n; e++) {
+				let n = t[e];
+				on.setFromBufferAttribute(n), this.morphTargetsRelative ? (cn.addVectors(this.boundingBox.min, on.min), this.boundingBox.expandByPoint(cn), cn.addVectors(this.boundingBox.max, on.max), this.boundingBox.expandByPoint(cn)) : (this.boundingBox.expandByPoint(on.min), this.boundingBox.expandByPoint(on.max));
+			}
+		} else this.boundingBox.makeEmpty();
+		(isNaN(this.boundingBox.min.x) || isNaN(this.boundingBox.min.y) || isNaN(this.boundingBox.min.z)) && I("BufferGeometry.computeBoundingBox(): Computed min/max have NaN values. The \"position\" attribute is likely to have NaN values.", this);
+	}
+	computeBoundingSphere() {
+		this.boundingSphere === null && (this.boundingSphere = new en());
+		let e = this.attributes.position, t = this.morphAttributes.position;
+		if (e && e.isGLBufferAttribute) {
+			I("BufferGeometry.computeBoundingSphere(): GLBufferAttribute requires a manual bounding sphere.", this), this.boundingSphere.set(new W(), Infinity);
+			return;
+		}
+		if (e) {
+			let n = this.boundingSphere.center;
+			if (on.setFromBufferAttribute(e), t) for (let e = 0, n = t.length; e < n; e++) {
+				let n = t[e];
+				sn.setFromBufferAttribute(n), this.morphTargetsRelative ? (cn.addVectors(on.min, sn.min), on.expandByPoint(cn), cn.addVectors(on.max, sn.max), on.expandByPoint(cn)) : (on.expandByPoint(sn.min), on.expandByPoint(sn.max));
+			}
+			on.getCenter(n);
+			let r = 0;
+			for (let t = 0, i = e.count; t < i; t++) cn.fromBufferAttribute(e, t), r = Math.max(r, n.distanceToSquared(cn));
+			if (t) for (let i = 0, a = t.length; i < a; i++) {
+				let a = t[i], o = this.morphTargetsRelative;
+				for (let t = 0, i = a.count; t < i; t++) cn.fromBufferAttribute(a, t), o && (an.fromBufferAttribute(e, t), cn.add(an)), r = Math.max(r, n.distanceToSquared(cn));
+			}
+			this.boundingSphere.radius = Math.sqrt(r), isNaN(this.boundingSphere.radius) && I("BufferGeometry.computeBoundingSphere(): Computed radius is NaN. The \"position\" attribute is likely to have NaN values.", this);
+		}
+	}
+	computeTangents() {
+		let e = this.index, t = this.attributes;
+		if (e === null || t.position === void 0 || t.normal === void 0 || t.uv === void 0) {
+			I("BufferGeometry: .computeTangents() failed. Missing required attributes (index, position, normal or uv)");
+			return;
+		}
+		let n = t.position, r = t.normal, i = t.uv, a = this.getAttribute("tangent");
+		(a === void 0 || a.count !== n.count) && (a = new qt(new Float32Array(4 * n.count), 4), this.setAttribute("tangent", a));
+		let o = [], s = [];
+		for (let e = 0; e < n.count; e++) o[e] = new W(), s[e] = new W();
+		let c = new W(), l = new W(), u = new W(), d = new U(), f = new U(), p = new U(), m = new W(), h = new W();
+		function g(e, t, r) {
+			c.fromBufferAttribute(n, e), l.fromBufferAttribute(n, t), u.fromBufferAttribute(n, r), d.fromBufferAttribute(i, e), f.fromBufferAttribute(i, t), p.fromBufferAttribute(i, r), l.sub(c), u.sub(c), f.sub(d), p.sub(d);
+			let a = 1 / (f.x * p.y - p.x * f.y);
+			isFinite(a) && (m.copy(l).multiplyScalar(p.y).addScaledVector(u, -f.y).multiplyScalar(a), h.copy(u).multiplyScalar(f.x).addScaledVector(l, -p.x).multiplyScalar(a), o[e].add(m), o[t].add(m), o[r].add(m), s[e].add(h), s[t].add(h), s[r].add(h));
+		}
+		let _ = this.groups;
+		_.length === 0 && (_ = [{
+			start: 0,
+			count: e.count
+		}]);
+		for (let t = 0, n = _.length; t < n; ++t) {
+			let n = _[t], r = n.start, i = n.count;
+			for (let t = r, n = r + i; t < n; t += 3) g(e.getX(t + 0), e.getX(t + 1), e.getX(t + 2));
+		}
+		let v = new W(), y = new W(), b = new W(), x = new W();
+		function S(e) {
+			b.fromBufferAttribute(r, e), x.copy(b);
+			let t = o[e];
+			v.copy(t), v.sub(b.multiplyScalar(b.dot(t))).normalize(), y.crossVectors(x, t);
+			let n = y.dot(s[e]) < 0 ? -1 : 1;
+			a.setXYZW(e, v.x, v.y, v.z, n);
+		}
+		for (let t = 0, n = _.length; t < n; ++t) {
+			let n = _[t], r = n.start, i = n.count;
+			for (let t = r, n = r + i; t < n; t += 3) S(e.getX(t + 0)), S(e.getX(t + 1)), S(e.getX(t + 2));
+		}
+		this._transformed = !0;
+	}
+	computeVertexNormals() {
+		let e = this.index, t = this.getAttribute("position");
+		if (t !== void 0) {
+			let n = this.getAttribute("normal");
+			if (n === void 0 || n.count !== t.count) n = new qt(new Float32Array(t.count * 3), 3), this.setAttribute("normal", n);
+			else for (let e = 0, t = n.count; e < t; e++) n.setXYZ(e, 0, 0, 0);
+			let r = new W(), i = new W(), a = new W(), o = new W(), s = new W(), c = new W(), l = new W(), u = new W();
+			if (e) for (let d = 0, f = e.count; d < f; d += 3) {
+				let f = e.getX(d + 0), p = e.getX(d + 1), m = e.getX(d + 2);
+				r.fromBufferAttribute(t, f), i.fromBufferAttribute(t, p), a.fromBufferAttribute(t, m), l.subVectors(a, i), u.subVectors(r, i), l.cross(u), o.fromBufferAttribute(n, f), s.fromBufferAttribute(n, p), c.fromBufferAttribute(n, m), o.add(l), s.add(l), c.add(l), n.setXYZ(f, o.x, o.y, o.z), n.setXYZ(p, s.x, s.y, s.z), n.setXYZ(m, c.x, c.y, c.z);
+			}
+			else for (let e = 0, o = t.count; e < o; e += 3) r.fromBufferAttribute(t, e + 0), i.fromBufferAttribute(t, e + 1), a.fromBufferAttribute(t, e + 2), l.subVectors(a, i), u.subVectors(r, i), l.cross(u), n.setXYZ(e + 0, l.x, l.y, l.z), n.setXYZ(e + 1, l.x, l.y, l.z), n.setXYZ(e + 2, l.x, l.y, l.z);
+			this.normalizeNormals(), n.needsUpdate = !0;
+		}
+	}
+	normalizeNormals() {
+		let e = this.attributes.normal;
+		for (let t = 0, n = e.count; t < n; t++) cn.fromBufferAttribute(e, t), cn.normalize(), e.setXYZ(t, cn.x, cn.y, cn.z);
+	}
+	toNonIndexed() {
+		function t(e, t) {
+			let n = e.array, r = e.itemSize, i = e.normalized, a = new n.constructor(t.length * r), o = 0, s = 0;
+			for (let i = 0, c = t.length; i < c; i++) {
+				o = e.isInterleavedBufferAttribute ? t[i] * e.data.stride + e.offset : t[i] * r;
+				for (let e = 0; e < r; e++) a[s++] = n[o++];
+			}
+			return new qt(a, r, i);
+		}
+		if (this.index === null) return F("BufferGeometry.toNonIndexed(): BufferGeometry is already non-indexed."), this;
+		let n = new e(), r = this.index.array, i = this.attributes;
+		for (let e in i) {
+			let a = i[e], o = t(a, r);
+			n.setAttribute(e, o);
+		}
+		let a = this.morphAttributes;
+		for (let e in a) {
+			let i = [], o = a[e];
+			for (let e = 0, n = o.length; e < n; e++) {
+				let n = o[e], a = t(n, r);
+				i.push(a);
+			}
+			n.morphAttributes[e] = i;
+		}
+		n.morphTargetsRelative = this.morphTargetsRelative;
+		let o = this.groups;
+		for (let e = 0, t = o.length; e < t; e++) {
+			let t = o[e];
+			n.addGroup(t.start, t.count, t.materialIndex);
+		}
+		return n;
+	}
+	toJSON() {
+		let e = { metadata: {
+			version: 4.7,
+			type: "BufferGeometry",
+			generator: "BufferGeometry.toJSON"
+		} };
+		if (e.uuid = this.uuid, e.type = this.parameters !== void 0 && this._transformed === !0 ? "BufferGeometry" : this.type, this.name !== "" && (e.name = this.name), Object.keys(this.userData).length > 0 && (e.userData = this.userData), this.parameters !== void 0 && this._transformed !== !0) {
+			let t = this.parameters;
+			for (let n in t) t[n] !== void 0 && (e[n] = t[n]);
+			return e;
+		}
+		e.data = { attributes: {} };
+		let t = this.index;
+		t !== null && (e.data.index = {
+			type: t.array.constructor.name,
+			array: Array.prototype.slice.call(t.array)
+		});
+		let n = this.attributes;
+		for (let t in n) {
+			let r = n[t];
+			e.data.attributes[t] = r.toJSON(e.data);
+		}
+		let r = {}, i = !1;
+		for (let t in this.morphAttributes) {
+			let n = this.morphAttributes[t], a = [];
+			for (let t = 0, r = n.length; t < r; t++) {
+				let r = n[t];
+				a.push(r.toJSON(e.data));
+			}
+			a.length > 0 && (r[t] = a, i = !0);
+		}
+		i && (e.data.morphAttributes = r, e.data.morphTargetsRelative = this.morphTargetsRelative);
+		let a = this.groups;
+		a.length > 0 && (e.data.groups = JSON.parse(JSON.stringify(a)));
+		let o = this.boundingSphere;
+		return o !== null && (e.data.boundingSphere = o.toJSON()), e;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	copy(e) {
+		this.index = null, this.attributes = {}, this.morphAttributes = {}, this.groups = [], this.boundingBox = null, this.boundingSphere = null;
+		let t = {};
+		this.name = e.name;
+		let n = e.index;
+		n !== null && this.setIndex(n.clone());
+		let r = e.attributes;
+		for (let e in r) {
+			let n = r[e];
+			this.setAttribute(e, n.clone(t));
+		}
+		let i = e.morphAttributes;
+		for (let e in i) {
+			let n = [], r = i[e];
+			for (let e = 0, i = r.length; e < i; e++) n.push(r[e].clone(t));
+			this.morphAttributes[e] = n;
+		}
+		this.morphTargetsRelative = e.morphTargetsRelative;
+		let a = e.groups;
+		for (let e = 0, t = a.length; e < t; e++) {
+			let t = a[e];
+			this.addGroup(t.start, t.count, t.materialIndex);
+		}
+		let o = e.boundingBox;
+		o !== null && (this.boundingBox = o.clone());
+		let s = e.boundingSphere;
+		return s !== null && (this.boundingSphere = s.clone()), this.drawRange.start = e.drawRange.start, this.drawRange.count = e.drawRange.count, this.userData = e.userData, this._transformed = e._transformed, this;
+	}
+	dispose() {
+		this.dispatchEvent({ type: "dispose" });
+	}
+}, un = 0, dn = class extends R {
+	constructor() {
+		super(), this.isMaterial = !0, Object.defineProperty(this, "id", { value: un++ }), this.uuid = B(), this.name = "", this.type = "Material", this.blending = 1, this.side = 0, this.vertexColors = !1, this.opacity = 1, this.transparent = !1, this.alphaHash = !1, this.blendSrc = 204, this.blendDst = 205, this.blendEquation = 100, this.blendSrcAlpha = null, this.blendDstAlpha = null, this.blendEquationAlpha = null, this.blendColor = new Z(0, 0, 0), this.blendAlpha = 0, this.depthFunc = 3, this.depthTest = !0, this.depthWrite = !0, this.stencilWriteMask = 255, this.stencilFunc = 519, this.stencilRef = 0, this.stencilFuncMask = 255, this.stencilFail = M, this.stencilZFail = M, this.stencilZPass = M, this.stencilWrite = !1, this.clippingPlanes = null, this.clipIntersection = !1, this.clipShadows = !1, this.shadowSide = null, this.colorWrite = !0, this.precision = null, this.polygonOffset = !1, this.polygonOffsetFactor = 0, this.polygonOffsetUnits = 0, this.dithering = !1, this.alphaToCoverage = !1, this.premultipliedAlpha = !1, this.forceSinglePass = !1, this.allowOverride = !0, this.visible = !0, this.toneMapped = !0, this.userData = {}, this.version = 0, this._alphaTest = 0;
+	}
+	get alphaTest() {
+		return this._alphaTest;
+	}
+	set alphaTest(e) {
+		this._alphaTest > 0 != e > 0 && this.version++, this._alphaTest = e;
+	}
+	onBeforeRender() {}
+	onBeforeCompile() {}
+	customProgramCacheKey() {
+		return this.onBeforeCompile.toString();
+	}
+	setValues(e) {
+		if (e !== void 0) for (let t in e) {
+			let n = e[t];
+			if (n === void 0) {
+				F(`Material: parameter '${t}' has value of undefined.`);
+				continue;
+			}
+			let r = this[t];
+			if (r === void 0) {
+				F(`Material: '${t}' is not a property of THREE.${this.type}.`);
+				continue;
+			}
+			r && r.isColor ? r.set(n) : r && r.isVector2 && n && n.isVector2 || r && r.isEuler && n && n.isEuler || r && r.isVector3 && n && n.isVector3 ? r.copy(n) : this[t] = n;
+		}
+	}
+	toJSON(e) {
+		let t = e === void 0 || typeof e == "string";
+		t && (e = {
+			textures: {},
+			images: {}
+		});
+		let n = { metadata: {
+			version: 4.7,
+			type: "Material",
+			generator: "Material.toJSON"
+		} };
+		n.uuid = this.uuid, n.type = this.type, this.name !== "" && (n.name = this.name), this.color && this.color.isColor && (n.color = this.color.getHex()), this.roughness !== void 0 && (n.roughness = this.roughness), this.metalness !== void 0 && (n.metalness = this.metalness), this.sheen !== void 0 && (n.sheen = this.sheen), this.sheenColor && this.sheenColor.isColor && (n.sheenColor = this.sheenColor.getHex()), this.sheenRoughness !== void 0 && (n.sheenRoughness = this.sheenRoughness), this.emissive && this.emissive.isColor && (n.emissive = this.emissive.getHex()), this.emissiveIntensity !== void 0 && this.emissiveIntensity !== 1 && (n.emissiveIntensity = this.emissiveIntensity), this.specular && this.specular.isColor && (n.specular = this.specular.getHex()), this.specularIntensity !== void 0 && (n.specularIntensity = this.specularIntensity), this.specularColor && this.specularColor.isColor && (n.specularColor = this.specularColor.getHex()), this.shininess !== void 0 && (n.shininess = this.shininess), this.clearcoat !== void 0 && (n.clearcoat = this.clearcoat), this.clearcoatRoughness !== void 0 && (n.clearcoatRoughness = this.clearcoatRoughness), this.clearcoatMap && this.clearcoatMap.isTexture && (n.clearcoatMap = this.clearcoatMap.toJSON(e).uuid), this.clearcoatRoughnessMap && this.clearcoatRoughnessMap.isTexture && (n.clearcoatRoughnessMap = this.clearcoatRoughnessMap.toJSON(e).uuid), this.clearcoatNormalMap && this.clearcoatNormalMap.isTexture && (n.clearcoatNormalMap = this.clearcoatNormalMap.toJSON(e).uuid, n.clearcoatNormalScale = this.clearcoatNormalScale.toArray()), this.sheenColorMap && this.sheenColorMap.isTexture && (n.sheenColorMap = this.sheenColorMap.toJSON(e).uuid), this.sheenRoughnessMap && this.sheenRoughnessMap.isTexture && (n.sheenRoughnessMap = this.sheenRoughnessMap.toJSON(e).uuid), this.dispersion !== void 0 && (n.dispersion = this.dispersion), this.iridescence !== void 0 && (n.iridescence = this.iridescence), this.iridescenceIOR !== void 0 && (n.iridescenceIOR = this.iridescenceIOR), this.iridescenceThicknessRange !== void 0 && (n.iridescenceThicknessRange = this.iridescenceThicknessRange), this.iridescenceMap && this.iridescenceMap.isTexture && (n.iridescenceMap = this.iridescenceMap.toJSON(e).uuid), this.iridescenceThicknessMap && this.iridescenceThicknessMap.isTexture && (n.iridescenceThicknessMap = this.iridescenceThicknessMap.toJSON(e).uuid), this.anisotropy !== void 0 && (n.anisotropy = this.anisotropy), this.anisotropyRotation !== void 0 && (n.anisotropyRotation = this.anisotropyRotation), this.anisotropyMap && this.anisotropyMap.isTexture && (n.anisotropyMap = this.anisotropyMap.toJSON(e).uuid), this.map && this.map.isTexture && (n.map = this.map.toJSON(e).uuid), this.matcap && this.matcap.isTexture && (n.matcap = this.matcap.toJSON(e).uuid), this.alphaMap && this.alphaMap.isTexture && (n.alphaMap = this.alphaMap.toJSON(e).uuid), this.lightMap && this.lightMap.isTexture && (n.lightMap = this.lightMap.toJSON(e).uuid, n.lightMapIntensity = this.lightMapIntensity), this.aoMap && this.aoMap.isTexture && (n.aoMap = this.aoMap.toJSON(e).uuid, n.aoMapIntensity = this.aoMapIntensity), this.bumpMap && this.bumpMap.isTexture && (n.bumpMap = this.bumpMap.toJSON(e).uuid, n.bumpScale = this.bumpScale), this.normalMap && this.normalMap.isTexture && (n.normalMap = this.normalMap.toJSON(e).uuid, n.normalMapType = this.normalMapType, n.normalScale = this.normalScale.toArray()), this.displacementMap && this.displacementMap.isTexture && (n.displacementMap = this.displacementMap.toJSON(e).uuid, n.displacementScale = this.displacementScale, n.displacementBias = this.displacementBias), this.roughnessMap && this.roughnessMap.isTexture && (n.roughnessMap = this.roughnessMap.toJSON(e).uuid), this.metalnessMap && this.metalnessMap.isTexture && (n.metalnessMap = this.metalnessMap.toJSON(e).uuid), this.emissiveMap && this.emissiveMap.isTexture && (n.emissiveMap = this.emissiveMap.toJSON(e).uuid), this.specularMap && this.specularMap.isTexture && (n.specularMap = this.specularMap.toJSON(e).uuid), this.specularIntensityMap && this.specularIntensityMap.isTexture && (n.specularIntensityMap = this.specularIntensityMap.toJSON(e).uuid), this.specularColorMap && this.specularColorMap.isTexture && (n.specularColorMap = this.specularColorMap.toJSON(e).uuid), this.envMap && this.envMap.isTexture && (n.envMap = this.envMap.toJSON(e).uuid, this.combine !== void 0 && (n.combine = this.combine)), this.envMapRotation !== void 0 && (n.envMapRotation = this.envMapRotation.toArray()), this.envMapIntensity !== void 0 && (n.envMapIntensity = this.envMapIntensity), this.reflectivity !== void 0 && (n.reflectivity = this.reflectivity), this.refractionRatio !== void 0 && (n.refractionRatio = this.refractionRatio), this.gradientMap && this.gradientMap.isTexture && (n.gradientMap = this.gradientMap.toJSON(e).uuid), this.transmission !== void 0 && (n.transmission = this.transmission), this.transmissionMap && this.transmissionMap.isTexture && (n.transmissionMap = this.transmissionMap.toJSON(e).uuid), this.thickness !== void 0 && (n.thickness = this.thickness), this.thicknessMap && this.thicknessMap.isTexture && (n.thicknessMap = this.thicknessMap.toJSON(e).uuid), this.attenuationDistance !== void 0 && this.attenuationDistance !== Infinity && (n.attenuationDistance = this.attenuationDistance), this.attenuationColor !== void 0 && (n.attenuationColor = this.attenuationColor.getHex()), this.size !== void 0 && (n.size = this.size), this.shadowSide !== null && (n.shadowSide = this.shadowSide), this.sizeAttenuation !== void 0 && (n.sizeAttenuation = this.sizeAttenuation), this.blending !== 1 && (n.blending = this.blending), this.side !== 0 && (n.side = this.side), this.vertexColors === !0 && (n.vertexColors = !0), this.opacity < 1 && (n.opacity = this.opacity), this.transparent === !0 && (n.transparent = !0), this.blendSrc !== 204 && (n.blendSrc = this.blendSrc), this.blendDst !== 205 && (n.blendDst = this.blendDst), this.blendEquation !== 100 && (n.blendEquation = this.blendEquation), this.blendSrcAlpha !== null && (n.blendSrcAlpha = this.blendSrcAlpha), this.blendDstAlpha !== null && (n.blendDstAlpha = this.blendDstAlpha), this.blendEquationAlpha !== null && (n.blendEquationAlpha = this.blendEquationAlpha), this.blendColor && this.blendColor.isColor && (n.blendColor = this.blendColor.getHex()), this.blendAlpha !== 0 && (n.blendAlpha = this.blendAlpha), this.depthFunc !== 3 && (n.depthFunc = this.depthFunc), this.depthTest === !1 && (n.depthTest = this.depthTest), this.depthWrite === !1 && (n.depthWrite = this.depthWrite), this.colorWrite === !1 && (n.colorWrite = this.colorWrite), this.stencilWriteMask !== 255 && (n.stencilWriteMask = this.stencilWriteMask), this.stencilFunc !== 519 && (n.stencilFunc = this.stencilFunc), this.stencilRef !== 0 && (n.stencilRef = this.stencilRef), this.stencilFuncMask !== 255 && (n.stencilFuncMask = this.stencilFuncMask), this.stencilFail !== 7680 && (n.stencilFail = this.stencilFail), this.stencilZFail !== 7680 && (n.stencilZFail = this.stencilZFail), this.stencilZPass !== 7680 && (n.stencilZPass = this.stencilZPass), this.stencilWrite === !0 && (n.stencilWrite = this.stencilWrite), this.rotation !== void 0 && this.rotation !== 0 && (n.rotation = this.rotation), this.polygonOffset === !0 && (n.polygonOffset = !0), this.polygonOffsetFactor !== 0 && (n.polygonOffsetFactor = this.polygonOffsetFactor), this.polygonOffsetUnits !== 0 && (n.polygonOffsetUnits = this.polygonOffsetUnits), this.linewidth !== void 0 && this.linewidth !== 1 && (n.linewidth = this.linewidth), this.dashSize !== void 0 && (n.dashSize = this.dashSize), this.gapSize !== void 0 && (n.gapSize = this.gapSize), this.scale !== void 0 && (n.scale = this.scale), this.dithering === !0 && (n.dithering = !0), this.alphaTest > 0 && (n.alphaTest = this.alphaTest), this.alphaHash === !0 && (n.alphaHash = !0), this.alphaToCoverage === !0 && (n.alphaToCoverage = !0), this.premultipliedAlpha === !0 && (n.premultipliedAlpha = !0), this.forceSinglePass === !0 && (n.forceSinglePass = !0), this.allowOverride === !1 && (n.allowOverride = !1), this.wireframe === !0 && (n.wireframe = !0), this.wireframeLinewidth > 1 && (n.wireframeLinewidth = this.wireframeLinewidth), this.wireframeLinecap !== "round" && (n.wireframeLinecap = this.wireframeLinecap), this.wireframeLinejoin !== "round" && (n.wireframeLinejoin = this.wireframeLinejoin), this.flatShading === !0 && (n.flatShading = !0), this.visible === !1 && (n.visible = !1), this.toneMapped === !1 && (n.toneMapped = !1), this.fog === !1 && (n.fog = !1), Object.keys(this.userData).length > 0 && (n.userData = this.userData);
+		function r(e) {
+			let t = [];
+			for (let n in e) {
+				let r = e[n];
+				delete r.metadata, t.push(r);
+			}
+			return t;
+		}
+		if (t) {
+			let t = r(e.textures), i = r(e.images);
+			t.length > 0 && (n.textures = t), i.length > 0 && (n.images = i);
+		}
+		return n;
+	}
+	fromJSON(e, t) {
+		if (e.uuid !== void 0 && (this.uuid = e.uuid), e.name !== void 0 && (this.name = e.name), e.color !== void 0 && this.color !== void 0 && this.color.setHex(e.color), e.roughness !== void 0 && (this.roughness = e.roughness), e.metalness !== void 0 && (this.metalness = e.metalness), e.sheen !== void 0 && (this.sheen = e.sheen), e.sheenColor !== void 0 && (this.sheenColor = new Z().setHex(e.sheenColor)), e.sheenRoughness !== void 0 && (this.sheenRoughness = e.sheenRoughness), e.emissive !== void 0 && this.emissive !== void 0 && this.emissive.setHex(e.emissive), e.specular !== void 0 && this.specular !== void 0 && this.specular.setHex(e.specular), e.specularIntensity !== void 0 && (this.specularIntensity = e.specularIntensity), e.specularColor !== void 0 && this.specularColor !== void 0 && this.specularColor.setHex(e.specularColor), e.shininess !== void 0 && (this.shininess = e.shininess), e.clearcoat !== void 0 && (this.clearcoat = e.clearcoat), e.clearcoatRoughness !== void 0 && (this.clearcoatRoughness = e.clearcoatRoughness), e.dispersion !== void 0 && (this.dispersion = e.dispersion), e.iridescence !== void 0 && (this.iridescence = e.iridescence), e.iridescenceIOR !== void 0 && (this.iridescenceIOR = e.iridescenceIOR), e.iridescenceThicknessRange !== void 0 && (this.iridescenceThicknessRange = e.iridescenceThicknessRange), e.transmission !== void 0 && (this.transmission = e.transmission), e.thickness !== void 0 && (this.thickness = e.thickness), e.attenuationDistance !== void 0 && (this.attenuationDistance = e.attenuationDistance), e.attenuationColor !== void 0 && this.attenuationColor !== void 0 && this.attenuationColor.setHex(e.attenuationColor), e.anisotropy !== void 0 && (this.anisotropy = e.anisotropy), e.anisotropyRotation !== void 0 && (this.anisotropyRotation = e.anisotropyRotation), e.fog !== void 0 && (this.fog = e.fog), e.flatShading !== void 0 && (this.flatShading = e.flatShading), e.blending !== void 0 && (this.blending = e.blending), e.combine !== void 0 && (this.combine = e.combine), e.side !== void 0 && (this.side = e.side), e.shadowSide !== void 0 && (this.shadowSide = e.shadowSide), e.opacity !== void 0 && (this.opacity = e.opacity), e.transparent !== void 0 && (this.transparent = e.transparent), e.alphaTest !== void 0 && (this.alphaTest = e.alphaTest), e.alphaHash !== void 0 && (this.alphaHash = e.alphaHash), e.depthFunc !== void 0 && (this.depthFunc = e.depthFunc), e.depthTest !== void 0 && (this.depthTest = e.depthTest), e.depthWrite !== void 0 && (this.depthWrite = e.depthWrite), e.colorWrite !== void 0 && (this.colorWrite = e.colorWrite), e.blendSrc !== void 0 && (this.blendSrc = e.blendSrc), e.blendDst !== void 0 && (this.blendDst = e.blendDst), e.blendEquation !== void 0 && (this.blendEquation = e.blendEquation), e.blendSrcAlpha !== void 0 && (this.blendSrcAlpha = e.blendSrcAlpha), e.blendDstAlpha !== void 0 && (this.blendDstAlpha = e.blendDstAlpha), e.blendEquationAlpha !== void 0 && (this.blendEquationAlpha = e.blendEquationAlpha), e.blendColor !== void 0 && this.blendColor !== void 0 && this.blendColor.setHex(e.blendColor), e.blendAlpha !== void 0 && (this.blendAlpha = e.blendAlpha), e.stencilWriteMask !== void 0 && (this.stencilWriteMask = e.stencilWriteMask), e.stencilFunc !== void 0 && (this.stencilFunc = e.stencilFunc), e.stencilRef !== void 0 && (this.stencilRef = e.stencilRef), e.stencilFuncMask !== void 0 && (this.stencilFuncMask = e.stencilFuncMask), e.stencilFail !== void 0 && (this.stencilFail = e.stencilFail), e.stencilZFail !== void 0 && (this.stencilZFail = e.stencilZFail), e.stencilZPass !== void 0 && (this.stencilZPass = e.stencilZPass), e.stencilWrite !== void 0 && (this.stencilWrite = e.stencilWrite), e.wireframe !== void 0 && (this.wireframe = e.wireframe), e.wireframeLinewidth !== void 0 && (this.wireframeLinewidth = e.wireframeLinewidth), e.wireframeLinecap !== void 0 && (this.wireframeLinecap = e.wireframeLinecap), e.wireframeLinejoin !== void 0 && (this.wireframeLinejoin = e.wireframeLinejoin), e.rotation !== void 0 && (this.rotation = e.rotation), e.linewidth !== void 0 && (this.linewidth = e.linewidth), e.dashSize !== void 0 && (this.dashSize = e.dashSize), e.gapSize !== void 0 && (this.gapSize = e.gapSize), e.scale !== void 0 && (this.scale = e.scale), e.polygonOffset !== void 0 && (this.polygonOffset = e.polygonOffset), e.polygonOffsetFactor !== void 0 && (this.polygonOffsetFactor = e.polygonOffsetFactor), e.polygonOffsetUnits !== void 0 && (this.polygonOffsetUnits = e.polygonOffsetUnits), e.dithering !== void 0 && (this.dithering = e.dithering), e.alphaToCoverage !== void 0 && (this.alphaToCoverage = e.alphaToCoverage), e.premultipliedAlpha !== void 0 && (this.premultipliedAlpha = e.premultipliedAlpha), e.forceSinglePass !== void 0 && (this.forceSinglePass = e.forceSinglePass), e.allowOverride !== void 0 && (this.allowOverride = e.allowOverride), e.visible !== void 0 && (this.visible = e.visible), e.toneMapped !== void 0 && (this.toneMapped = e.toneMapped), e.userData !== void 0 && (this.userData = e.userData), e.vertexColors !== void 0 && (typeof e.vertexColors == "number" ? this.vertexColors = e.vertexColors > 0 : this.vertexColors = e.vertexColors), e.size !== void 0 && (this.size = e.size), e.sizeAttenuation !== void 0 && (this.sizeAttenuation = e.sizeAttenuation), e.map !== void 0 && (this.map = t[e.map] || null), e.matcap !== void 0 && (this.matcap = t[e.matcap] || null), e.alphaMap !== void 0 && (this.alphaMap = t[e.alphaMap] || null), e.bumpMap !== void 0 && (this.bumpMap = t[e.bumpMap] || null), e.bumpScale !== void 0 && (this.bumpScale = e.bumpScale), e.normalMap !== void 0 && (this.normalMap = t[e.normalMap] || null), e.normalMapType !== void 0 && (this.normalMapType = e.normalMapType), e.normalScale !== void 0) {
+			let t = e.normalScale;
+			Array.isArray(t) === !1 && (t = [t, t]), this.normalScale = new U().fromArray(t);
+		}
+		return e.displacementMap !== void 0 && (this.displacementMap = t[e.displacementMap] || null), e.displacementScale !== void 0 && (this.displacementScale = e.displacementScale), e.displacementBias !== void 0 && (this.displacementBias = e.displacementBias), e.roughnessMap !== void 0 && (this.roughnessMap = t[e.roughnessMap] || null), e.metalnessMap !== void 0 && (this.metalnessMap = t[e.metalnessMap] || null), e.emissiveMap !== void 0 && (this.emissiveMap = t[e.emissiveMap] || null), e.emissiveIntensity !== void 0 && (this.emissiveIntensity = e.emissiveIntensity), e.specularMap !== void 0 && (this.specularMap = t[e.specularMap] || null), e.specularIntensityMap !== void 0 && (this.specularIntensityMap = t[e.specularIntensityMap] || null), e.specularColorMap !== void 0 && (this.specularColorMap = t[e.specularColorMap] || null), e.envMap !== void 0 && (this.envMap = t[e.envMap] || null), e.envMapRotation !== void 0 && this.envMapRotation.fromArray(e.envMapRotation), e.envMapIntensity !== void 0 && (this.envMapIntensity = e.envMapIntensity), e.reflectivity !== void 0 && (this.reflectivity = e.reflectivity), e.refractionRatio !== void 0 && (this.refractionRatio = e.refractionRatio), e.lightMap !== void 0 && (this.lightMap = t[e.lightMap] || null), e.lightMapIntensity !== void 0 && (this.lightMapIntensity = e.lightMapIntensity), e.aoMap !== void 0 && (this.aoMap = t[e.aoMap] || null), e.aoMapIntensity !== void 0 && (this.aoMapIntensity = e.aoMapIntensity), e.gradientMap !== void 0 && (this.gradientMap = t[e.gradientMap] || null), e.clearcoatMap !== void 0 && (this.clearcoatMap = t[e.clearcoatMap] || null), e.clearcoatRoughnessMap !== void 0 && (this.clearcoatRoughnessMap = t[e.clearcoatRoughnessMap] || null), e.clearcoatNormalMap !== void 0 && (this.clearcoatNormalMap = t[e.clearcoatNormalMap] || null), e.clearcoatNormalScale !== void 0 && (this.clearcoatNormalScale = new U().fromArray(e.clearcoatNormalScale)), e.iridescenceMap !== void 0 && (this.iridescenceMap = t[e.iridescenceMap] || null), e.iridescenceThicknessMap !== void 0 && (this.iridescenceThicknessMap = t[e.iridescenceThicknessMap] || null), e.transmissionMap !== void 0 && (this.transmissionMap = t[e.transmissionMap] || null), e.thicknessMap !== void 0 && (this.thicknessMap = t[e.thicknessMap] || null), e.anisotropyMap !== void 0 && (this.anisotropyMap = t[e.anisotropyMap] || null), e.sheenColorMap !== void 0 && (this.sheenColorMap = t[e.sheenColorMap] || null), e.sheenRoughnessMap !== void 0 && (this.sheenRoughnessMap = t[e.sheenRoughnessMap] || null), this;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+	copy(e) {
+		this.name = e.name, this.blending = e.blending, this.side = e.side, this.vertexColors = e.vertexColors, this.opacity = e.opacity, this.transparent = e.transparent, this.blendSrc = e.blendSrc, this.blendDst = e.blendDst, this.blendEquation = e.blendEquation, this.blendSrcAlpha = e.blendSrcAlpha, this.blendDstAlpha = e.blendDstAlpha, this.blendEquationAlpha = e.blendEquationAlpha, this.blendColor.copy(e.blendColor), this.blendAlpha = e.blendAlpha, this.depthFunc = e.depthFunc, this.depthTest = e.depthTest, this.depthWrite = e.depthWrite, this.stencilWriteMask = e.stencilWriteMask, this.stencilFunc = e.stencilFunc, this.stencilRef = e.stencilRef, this.stencilFuncMask = e.stencilFuncMask, this.stencilFail = e.stencilFail, this.stencilZFail = e.stencilZFail, this.stencilZPass = e.stencilZPass, this.stencilWrite = e.stencilWrite;
+		let t = e.clippingPlanes, n = null;
+		if (t !== null) {
+			let e = t.length;
+			n = Array(e);
+			for (let r = 0; r !== e; ++r) n[r] = t[r].clone();
+		}
+		return this.clippingPlanes = n, this.clipIntersection = e.clipIntersection, this.clipShadows = e.clipShadows, this.shadowSide = e.shadowSide, this.colorWrite = e.colorWrite, this.precision = e.precision, this.polygonOffset = e.polygonOffset, this.polygonOffsetFactor = e.polygonOffsetFactor, this.polygonOffsetUnits = e.polygonOffsetUnits, this.dithering = e.dithering, this.alphaTest = e.alphaTest, this.alphaHash = e.alphaHash, this.alphaToCoverage = e.alphaToCoverage, this.premultipliedAlpha = e.premultipliedAlpha, this.forceSinglePass = e.forceSinglePass, this.allowOverride = e.allowOverride, this.visible = e.visible, this.toneMapped = e.toneMapped, this.userData = JSON.parse(JSON.stringify(e.userData)), this;
+	}
+	dispose() {
+		this.dispatchEvent({ type: "dispose" });
+	}
+	set needsUpdate(e) {
+		e === !0 && this.version++;
+	}
+}, fn = /*@__PURE__*/ new W(), pn = /*@__PURE__*/ new W(), mn = /*@__PURE__*/ new W(), hn = /*@__PURE__*/ new W(), gn = /*@__PURE__*/ new W(), _n = /*@__PURE__*/ new W(), vn = /*@__PURE__*/ new W(), yn = class {
+	constructor(e = new W(), t = new W(0, 0, -1)) {
+		this.origin = e, this.direction = t;
+	}
+	set(e, t) {
+		return this.origin.copy(e), this.direction.copy(t), this;
+	}
+	copy(e) {
+		return this.origin.copy(e.origin), this.direction.copy(e.direction), this;
+	}
+	at(e, t) {
+		return t.copy(this.origin).addScaledVector(this.direction, e);
+	}
+	lookAt(e) {
+		return this.direction.copy(e).sub(this.origin).normalize(), this;
+	}
+	recast(e) {
+		return this.origin.copy(this.at(e, fn)), this;
+	}
+	closestPointToPoint(e, t) {
+		t.subVectors(e, this.origin);
+		let n = t.dot(this.direction);
+		return n < 0 ? t.copy(this.origin) : t.copy(this.origin).addScaledVector(this.direction, n);
+	}
+	distanceToPoint(e) {
+		return Math.sqrt(this.distanceSqToPoint(e));
+	}
+	distanceSqToPoint(e) {
+		let t = fn.subVectors(e, this.origin).dot(this.direction);
+		return t < 0 ? this.origin.distanceToSquared(e) : (fn.copy(this.origin).addScaledVector(this.direction, t), fn.distanceToSquared(e));
+	}
+	distanceSqToSegment(e, t, n, r) {
+		pn.copy(e).add(t).multiplyScalar(.5), mn.copy(t).sub(e).normalize(), hn.copy(this.origin).sub(pn);
+		let i = e.distanceTo(t) * .5, a = -this.direction.dot(mn), o = hn.dot(this.direction), s = -hn.dot(mn), c = hn.lengthSq(), l = Math.abs(1 - a * a), u, d, f, p;
+		if (l > 0) if (u = a * s - o, d = a * o - s, p = i * l, u >= 0) if (d >= -p) if (d <= p) {
+			let e = 1 / l;
+			u *= e, d *= e, f = u * (u + a * d + 2 * o) + d * (a * u + d + 2 * s) + c;
+		} else d = i, u = Math.max(0, -(a * d + o)), f = -u * u + d * (d + 2 * s) + c;
+		else d = -i, u = Math.max(0, -(a * d + o)), f = -u * u + d * (d + 2 * s) + c;
+		else d <= -p ? (u = Math.max(0, -(-a * i + o)), d = u > 0 ? -i : Math.min(Math.max(-i, -s), i), f = -u * u + d * (d + 2 * s) + c) : d <= p ? (u = 0, d = Math.min(Math.max(-i, -s), i), f = d * (d + 2 * s) + c) : (u = Math.max(0, -(a * i + o)), d = u > 0 ? i : Math.min(Math.max(-i, -s), i), f = -u * u + d * (d + 2 * s) + c);
+		else d = a > 0 ? -i : i, u = Math.max(0, -(a * d + o)), f = -u * u + d * (d + 2 * s) + c;
+		return n && n.copy(this.origin).addScaledVector(this.direction, u), r && r.copy(pn).addScaledVector(mn, d), f;
+	}
+	intersectSphere(e, t) {
+		fn.subVectors(e.center, this.origin);
+		let n = fn.dot(this.direction), r = fn.dot(fn) - n * n, i = e.radius * e.radius;
+		if (r > i) return null;
+		let a = Math.sqrt(i - r), o = n - a, s = n + a;
+		return s < 0 ? null : o < 0 ? this.at(s, t) : this.at(o, t);
+	}
+	intersectsSphere(e) {
+		return e.radius < 0 ? !1 : this.distanceSqToPoint(e.center) <= e.radius * e.radius;
+	}
+	distanceToPlane(e) {
+		let t = e.normal.dot(this.direction);
+		if (t === 0) return e.distanceToPoint(this.origin) === 0 ? 0 : null;
+		let n = -(this.origin.dot(e.normal) + e.constant) / t;
+		return n >= 0 ? n : null;
+	}
+	intersectPlane(e, t) {
+		let n = this.distanceToPlane(e);
+		return n === null ? null : this.at(n, t);
+	}
+	intersectsPlane(e) {
+		let t = e.distanceToPoint(this.origin);
+		return t === 0 || e.normal.dot(this.direction) * t < 0;
+	}
+	intersectBox(e, t) {
+		let n, r, i, a, o, s, c = 1 / this.direction.x, l = 1 / this.direction.y, u = 1 / this.direction.z, d = this.origin;
+		return c >= 0 ? (n = (e.min.x - d.x) * c, r = (e.max.x - d.x) * c) : (n = (e.max.x - d.x) * c, r = (e.min.x - d.x) * c), l >= 0 ? (i = (e.min.y - d.y) * l, a = (e.max.y - d.y) * l) : (i = (e.max.y - d.y) * l, a = (e.min.y - d.y) * l), n > a || i > r || ((i > n || isNaN(n)) && (n = i), (a < r || isNaN(r)) && (r = a), u >= 0 ? (o = (e.min.z - d.z) * u, s = (e.max.z - d.z) * u) : (o = (e.max.z - d.z) * u, s = (e.min.z - d.z) * u), n > s || o > r) || ((o > n || n !== n) && (n = o), (s < r || r !== r) && (r = s), r < 0) ? null : this.at(n >= 0 ? n : r, t);
+	}
+	intersectsBox(e) {
+		return this.intersectBox(e, fn) !== null;
+	}
+	intersectTriangle(e, t, n, r, i) {
+		gn.subVectors(t, e), _n.subVectors(n, e), vn.crossVectors(gn, _n);
+		let a = this.direction.dot(vn), o;
+		if (a > 0) {
+			if (r) return null;
+			o = 1;
+		} else if (a < 0) o = -1, a = -a;
+		else return null;
+		hn.subVectors(this.origin, e);
+		let s = o * this.direction.dot(_n.crossVectors(hn, _n));
+		if (s < 0) return null;
+		let c = o * this.direction.dot(gn.cross(hn));
+		if (c < 0 || s + c > a) return null;
+		let l = -o * hn.dot(vn);
+		return l < 0 ? null : this.at(l / a, i);
+	}
+	applyMatrix4(e) {
+		return this.origin.applyMatrix4(e), this.direction.transformDirection(e), this;
+	}
+	equals(e) {
+		return e.origin.equals(this.origin) && e.direction.equals(this.direction);
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+}, bn = class extends dn {
+	constructor(e) {
+		super(), this.isMeshBasicMaterial = !0, this.type = "MeshBasicMaterial", this.color = new Z(16777215), this.map = null, this.lightMap = null, this.lightMapIntensity = 1, this.aoMap = null, this.aoMapIntensity = 1, this.specularMap = null, this.alphaMap = null, this.envMap = null, this.envMapRotation = new He(), this.combine = 0, this.reflectivity = 1, this.refractionRatio = .98, this.wireframe = !1, this.wireframeLinewidth = 1, this.wireframeLinecap = "round", this.wireframeLinejoin = "round", this.fog = !0, this.setValues(e);
+	}
+	copy(e) {
+		return super.copy(e), this.color.copy(e.color), this.map = e.map, this.lightMap = e.lightMap, this.lightMapIntensity = e.lightMapIntensity, this.aoMap = e.aoMap, this.aoMapIntensity = e.aoMapIntensity, this.specularMap = e.specularMap, this.alphaMap = e.alphaMap, this.envMap = e.envMap, this.envMapRotation.copy(e.envMapRotation), this.combine = e.combine, this.reflectivity = e.reflectivity, this.refractionRatio = e.refractionRatio, this.wireframe = e.wireframe, this.wireframeLinewidth = e.wireframeLinewidth, this.wireframeLinecap = e.wireframeLinecap, this.wireframeLinejoin = e.wireframeLinejoin, this.fog = e.fog, this;
+	}
+}, xn = /*@__PURE__*/ new Fe(), Sn = /*@__PURE__*/ new yn(), Cn = /*@__PURE__*/ new en(), wn = /*@__PURE__*/ new W(), Tn = /*@__PURE__*/ new W(), En = /*@__PURE__*/ new W(), Dn = /*@__PURE__*/ new W(), On = /*@__PURE__*/ new W(), kn = /*@__PURE__*/ new W(), An = /*@__PURE__*/ new W(), jn = /*@__PURE__*/ new W(), Mn = class extends at {
+	constructor(e = new ln(), t = new bn()) {
+		super(), this.isMesh = !0, this.type = "Mesh", this.geometry = e, this.material = t, this.morphTargetDictionary = void 0, this.morphTargetInfluences = void 0, this.count = 1, this.updateMorphTargets();
+	}
+	copy(e, t) {
+		return super.copy(e, t), e.morphTargetInfluences !== void 0 && (this.morphTargetInfluences = e.morphTargetInfluences.slice()), e.morphTargetDictionary !== void 0 && (this.morphTargetDictionary = Object.assign({}, e.morphTargetDictionary)), this.material = Array.isArray(e.material) ? e.material.slice() : e.material, this.geometry = e.geometry, this;
+	}
+	updateMorphTargets() {
+		let e = this.geometry.morphAttributes, t = Object.keys(e);
+		if (t.length > 0) {
+			let n = e[t[0]];
+			if (n !== void 0) {
+				this.morphTargetInfluences = [], this.morphTargetDictionary = {};
+				for (let e = 0, t = n.length; e < t; e++) {
+					let t = n[e].name || String(e);
+					this.morphTargetInfluences.push(0), this.morphTargetDictionary[t] = e;
+				}
+			}
+		}
+	}
+	getVertexPosition(e, t) {
+		let n = this.geometry, r = n.attributes.position, i = n.morphAttributes.position, a = n.morphTargetsRelative;
+		t.fromBufferAttribute(r, e);
+		let o = this.morphTargetInfluences;
+		if (i && o) {
+			kn.set(0, 0, 0);
+			for (let n = 0, r = i.length; n < r; n++) {
+				let r = o[n], s = i[n];
+				r !== 0 && (On.fromBufferAttribute(s, e), a ? kn.addScaledVector(On, r) : kn.addScaledVector(On.sub(t), r));
+			}
+			t.add(kn);
+		}
+		return t;
+	}
+	raycast(e, t) {
+		let n = this.geometry, r = this.material, i = this.matrixWorld;
+		r !== void 0 && (n.boundingSphere === null && n.computeBoundingSphere(), Cn.copy(n.boundingSphere), Cn.applyMatrix4(i), Sn.copy(e.ray).recast(e.near), !(Cn.containsPoint(Sn.origin) === !1 && (Sn.intersectSphere(Cn, wn) === null || Sn.origin.distanceToSquared(wn) > (e.far - e.near) ** 2)) && (xn.copy(i).invert(), Sn.copy(e.ray).applyMatrix4(xn), !(n.boundingBox !== null && Sn.intersectsBox(n.boundingBox) === !1) && this._computeIntersections(e, t, Sn)));
+	}
+	_computeIntersections(e, t, n) {
+		let r, i = this.geometry, a = this.material, o = i.index, s = i.attributes.position, c = i.attributes.uv, l = i.attributes.uv1, u = i.attributes.normal, d = i.groups, f = i.drawRange;
+		if (o !== null) if (Array.isArray(a)) for (let i = 0, s = d.length; i < s; i++) {
+			let s = d[i], p = a[s.materialIndex], m = Math.max(s.start, f.start), h = Math.min(o.count, Math.min(s.start + s.count, f.start + f.count));
+			for (let i = m, a = h; i < a; i += 3) {
+				let a = o.getX(i), d = o.getX(i + 1), f = o.getX(i + 2);
+				r = Pn(this, p, e, n, c, l, u, a, d, f), r && (r.faceIndex = Math.floor(i / 3), r.face.materialIndex = s.materialIndex, t.push(r));
+			}
+		}
+		else {
+			let i = Math.max(0, f.start), s = Math.min(o.count, f.start + f.count);
+			for (let d = i, f = s; d < f; d += 3) {
+				let i = o.getX(d), s = o.getX(d + 1), f = o.getX(d + 2);
+				r = Pn(this, a, e, n, c, l, u, i, s, f), r && (r.faceIndex = Math.floor(d / 3), t.push(r));
+			}
+		}
+		else if (s !== void 0) if (Array.isArray(a)) for (let i = 0, o = d.length; i < o; i++) {
+			let o = d[i], p = a[o.materialIndex], m = Math.max(o.start, f.start), h = Math.min(s.count, Math.min(o.start + o.count, f.start + f.count));
+			for (let i = m, a = h; i < a; i += 3) {
+				let a = i, s = i + 1, d = i + 2;
+				r = Pn(this, p, e, n, c, l, u, a, s, d), r && (r.faceIndex = Math.floor(i / 3), r.face.materialIndex = o.materialIndex, t.push(r));
+			}
+		}
+		else {
+			let i = Math.max(0, f.start), o = Math.min(s.count, f.start + f.count);
+			for (let s = i, d = o; s < d; s += 3) {
+				let i = s, o = s + 1, d = s + 2;
+				r = Pn(this, a, e, n, c, l, u, i, o, d), r && (r.faceIndex = Math.floor(s / 3), t.push(r));
+			}
+		}
+	}
+};
+function Nn(e, t, n, r, i, a, o, s) {
+	let c;
+	if (c = t.side === 1 ? r.intersectTriangle(o, a, i, !0, s) : r.intersectTriangle(i, a, o, t.side === 0, s), c === null) return null;
+	jn.copy(s), jn.applyMatrix4(e.matrixWorld);
+	let l = n.ray.origin.distanceTo(jn);
+	return l < n.near || l > n.far ? null : {
+		distance: l,
+		point: jn.clone(),
+		object: e
+	};
+}
+function Pn(e, t, n, r, i, a, o, s, c, l) {
+	e.getVertexPosition(s, Tn), e.getVertexPosition(c, En), e.getVertexPosition(l, Dn);
+	let u = Nn(e, t, n, r, Tn, En, Dn, An);
+	if (u) {
+		let e = new W();
+		Ot.getBarycoord(An, Tn, En, Dn, e), i && (u.uv = Ot.getInterpolatedAttribute(i, s, c, l, e, new U())), a && (u.uv1 = Ot.getInterpolatedAttribute(a, s, c, l, e, new U())), o && (u.normal = Ot.getInterpolatedAttribute(o, s, c, l, e, new W()), u.normal.dot(r.direction) > 0 && u.normal.multiplyScalar(-1));
+		let t = {
+			a: s,
+			b: c,
+			c: l,
+			normal: new W(),
+			materialIndex: 0
+		};
+		Ot.getNormal(Tn, En, Dn, t.normal), u.face = t, u.barycoord = e;
+	}
+	return u;
+}
+var Fn = class extends Ae {
+	constructor(e = null, t = 1, n = 1, i, a, o, s, c, l = r, u = r, d, f) {
+		super(null, o, s, c, l, u, i, a, d, f), this.isDataTexture = !0, this.image = {
+			data: e,
+			width: t,
+			height: n
+		}, this.generateMipmaps = !1, this.flipY = !1, this.unpackAlignment = 1;
+	}
+}, In = class extends qt {
+	constructor(e, t, n, r = 1) {
+		super(e, t, n), this.isInstancedBufferAttribute = !0, this.meshPerAttribute = r;
+	}
+	copy(e) {
+		return super.copy(e), this.meshPerAttribute = e.meshPerAttribute, this;
+	}
+	toJSON() {
+		let e = super.toJSON();
+		return e.meshPerAttribute = this.meshPerAttribute, e.isInstancedBufferAttribute = !0, e;
+	}
+}, Ln = /*@__PURE__*/ new Fe(), Rn = /*@__PURE__*/ new Fe(), zn = [], Bn = /*@__PURE__*/ new kt(), Vn = /*@__PURE__*/ new Fe(), Hn = /*@__PURE__*/ new Mn(), Un = /*@__PURE__*/ new en(), Wn = class extends Mn {
+	constructor(e, t, n) {
+		super(e, t), this.isInstancedMesh = !0, this.instanceMatrix = new In(new Float32Array(n * 16), 16), this.instanceColor = null, this.morphTexture = null, this.count = n, this.boundingBox = null, this.boundingSphere = null;
+		for (let e = 0; e < n; e++) this.setMatrixAt(e, Vn);
+	}
+	computeBoundingBox() {
+		let e = this.geometry, t = this.count;
+		this.boundingBox === null && (this.boundingBox = new kt()), e.boundingBox === null && e.computeBoundingBox(), this.boundingBox.makeEmpty();
+		for (let n = 0; n < t; n++) this.getMatrixAt(n, Ln), Bn.copy(e.boundingBox).applyMatrix4(Ln), this.boundingBox.union(Bn);
+	}
+	computeBoundingSphere() {
+		let e = this.geometry, t = this.count;
+		this.boundingSphere === null && (this.boundingSphere = new en()), e.boundingSphere === null && e.computeBoundingSphere(), this.boundingSphere.makeEmpty();
+		for (let n = 0; n < t; n++) this.getMatrixAt(n, Ln), Un.copy(e.boundingSphere).applyMatrix4(Ln), this.boundingSphere.union(Un);
+	}
+	copy(e, t) {
+		return super.copy(e, t), this.instanceMatrix.copy(e.instanceMatrix), e.morphTexture !== null && (this.morphTexture = e.morphTexture.clone()), e.instanceColor !== null && (this.instanceColor = e.instanceColor.clone()), this.count = e.count, e.boundingBox !== null && (this.boundingBox = e.boundingBox.clone()), e.boundingSphere !== null && (this.boundingSphere = e.boundingSphere.clone()), this;
+	}
+	getColorAt(e, t) {
+		return this.instanceColor === null ? t.setRGB(1, 1, 1) : t.fromArray(this.instanceColor.array, e * 3);
+	}
+	getMatrixAt(e, t) {
+		return t.fromArray(this.instanceMatrix.array, e * 16);
+	}
+	getMorphAt(e, t) {
+		let n = t.morphTargetInfluences, r = this.morphTexture.source.data.data, i = e * (n.length + 1) + 1;
+		for (let e = 0; e < n.length; e++) n[e] = r[i + e];
+	}
+	raycast(e, t) {
+		let n = this.matrixWorld, r = this.count;
+		if (Hn.geometry = this.geometry, Hn.material = this.material, Hn.material !== void 0 && (this.boundingSphere === null && this.computeBoundingSphere(), Un.copy(this.boundingSphere), Un.applyMatrix4(n), e.ray.intersectsSphere(Un) !== !1)) for (let i = 0; i < r; i++) {
+			this.getMatrixAt(i, Ln), Rn.multiplyMatrices(n, Ln), Hn.matrixWorld = Rn, Hn.raycast(e, zn);
+			for (let e = 0, n = zn.length; e < n; e++) {
+				let n = zn[e];
+				n.instanceId = i, n.object = this, t.push(n);
+			}
+			zn.length = 0;
+		}
+	}
+	setColorAt(e, t) {
+		return this.instanceColor === null && (this.instanceColor = new In(new Float32Array(this.instanceMatrix.count * 3).fill(1), 3)), t.toArray(this.instanceColor.array, e * 3), this;
+	}
+	setMatrixAt(e, t) {
+		return t.toArray(this.instanceMatrix.array, e * 16), this;
+	}
+	setMorphAt(e, t) {
+		let n = t.morphTargetInfluences, r = n.length + 1;
+		this.morphTexture === null && (this.morphTexture = new Fn(new Float32Array(r * this.count), r, this.count, _, l));
+		let i = this.morphTexture.source.data.data, a = 0;
+		for (let e = 0; e < n.length; e++) a += n[e];
+		let o = this.geometry.morphTargetsRelative ? 1 : 1 - a, s = r * e;
+		return i[s] = o, i.set(n, s + 1), this;
+	}
+	updateMorphTargets() {}
+	dispose() {
+		this.dispatchEvent({ type: "dispose" }), this.morphTexture !== null && (this.morphTexture.dispose(), this.morphTexture = null);
+	}
+}, Gn = /*@__PURE__*/ new W(), Kn = /*@__PURE__*/ new W(), qn = /*@__PURE__*/ new G(), Jn = class {
+	constructor(e = new W(1, 0, 0), t = 0) {
+		this.isPlane = !0, this.normal = e, this.constant = t;
+	}
+	set(e, t) {
+		return this.normal.copy(e), this.constant = t, this;
+	}
+	setComponents(e, t, n, r) {
+		return this.normal.set(e, t, n), this.constant = r, this;
+	}
+	setFromNormalAndCoplanarPoint(e, t) {
+		return this.normal.copy(e), this.constant = -t.dot(this.normal), this;
+	}
+	setFromCoplanarPoints(e, t, n) {
+		let r = Gn.subVectors(n, t).cross(Kn.subVectors(e, t)).normalize();
+		return this.setFromNormalAndCoplanarPoint(r, e), this;
+	}
+	copy(e) {
+		return this.normal.copy(e.normal), this.constant = e.constant, this;
+	}
+	normalize() {
+		let e = 1 / this.normal.length();
+		return this.normal.multiplyScalar(e), this.constant *= e, this;
+	}
+	negate() {
+		return this.constant *= -1, this.normal.negate(), this;
+	}
+	distanceToPoint(e) {
+		return this.normal.dot(e) + this.constant;
+	}
+	distanceToSphere(e) {
+		return this.distanceToPoint(e.center) - e.radius;
+	}
+	projectPoint(e, t) {
+		return t.copy(e).addScaledVector(this.normal, -this.distanceToPoint(e));
+	}
+	intersectLine(e, t, n = !0) {
+		let r = e.delta(Gn), i = this.normal.dot(r);
+		if (i === 0) return this.distanceToPoint(e.start) === 0 ? t.copy(e.start) : null;
+		let a = -(e.start.dot(this.normal) + this.constant) / i;
+		return n === !0 && (a < 0 || a > 1) ? null : t.copy(e.start).addScaledVector(r, a);
+	}
+	intersectsLine(e) {
+		let t = this.distanceToPoint(e.start), n = this.distanceToPoint(e.end);
+		return t < 0 && n > 0 || n < 0 && t > 0;
+	}
+	intersectsBox(e) {
+		return e.intersectsPlane(this);
+	}
+	intersectsSphere(e) {
+		return e.intersectsPlane(this);
+	}
+	coplanarPoint(e) {
+		return e.copy(this.normal).multiplyScalar(-this.constant);
+	}
+	applyMatrix4(e, t) {
+		let n = t || qn.getNormalMatrix(e), r = this.coplanarPoint(Gn).applyMatrix4(e), i = this.normal.applyMatrix3(n).normalize();
+		return this.constant = -r.dot(i), this;
+	}
+	translate(e) {
+		return this.constant -= e.dot(this.normal), this;
+	}
+	equals(e) {
+		return e.normal.equals(this.normal) && e.constant === this.constant;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+}, Yn = /*@__PURE__*/ new en(), Xn = /*@__PURE__*/ new U(.5, .5), Zn = /*@__PURE__*/ new W(), Qn = class {
+	constructor(e = new Jn(), t = new Jn(), n = new Jn(), r = new Jn(), i = new Jn(), a = new Jn()) {
+		this.planes = [
+			e,
+			t,
+			n,
+			r,
+			i,
+			a
+		];
+	}
+	set(e, t, n, r, i, a) {
+		let o = this.planes;
+		return o[0].copy(e), o[1].copy(t), o[2].copy(n), o[3].copy(r), o[4].copy(i), o[5].copy(a), this;
+	}
+	copy(e) {
+		let t = this.planes;
+		for (let n = 0; n < 6; n++) t[n].copy(e.planes[n]);
+		return this;
+	}
+	setFromProjectionMatrix(e, t = te, n = !1) {
+		let r = this.planes, i = e.elements, a = i[0], o = i[1], s = i[2], c = i[3], l = i[4], u = i[5], d = i[6], f = i[7], p = i[8], m = i[9], h = i[10], g = i[11], _ = i[12], v = i[13], y = i[14], b = i[15];
+		if (r[0].setComponents(c - a, f - l, g - p, b - _).normalize(), r[1].setComponents(c + a, f + l, g + p, b + _).normalize(), r[2].setComponents(c + o, f + u, g + m, b + v).normalize(), r[3].setComponents(c - o, f - u, g - m, b - v).normalize(), n) r[4].setComponents(s, d, h, y).normalize(), r[5].setComponents(c - s, f - d, g - h, b - y).normalize();
+		else if (r[4].setComponents(c - s, f - d, g - h, b - y).normalize(), t === 2e3) r[5].setComponents(c + s, f + d, g + h, b + y).normalize();
+		else if (t === 2001) r[5].setComponents(s, d, h, y).normalize();
+		else throw Error("THREE.Frustum.setFromProjectionMatrix(): Invalid coordinate system: " + t);
+		return this;
+	}
+	intersectsObject(e) {
+		if (e.boundingSphere !== void 0) e.boundingSphere === null && e.computeBoundingSphere(), Yn.copy(e.boundingSphere).applyMatrix4(e.matrixWorld);
+		else {
+			let t = e.geometry;
+			t.boundingSphere === null && t.computeBoundingSphere(), Yn.copy(t.boundingSphere).applyMatrix4(e.matrixWorld);
+		}
+		return this.intersectsSphere(Yn);
+	}
+	intersectsSprite(e) {
+		return Yn.center.set(0, 0, 0), Yn.radius = .7071067811865476 + Xn.distanceTo(e.center), Yn.applyMatrix4(e.matrixWorld), this.intersectsSphere(Yn);
+	}
+	intersectsSphere(e) {
+		let t = this.planes, n = e.center, r = -e.radius;
+		for (let e = 0; e < 6; e++) if (t[e].distanceToPoint(n) < r) return !1;
+		return !0;
+	}
+	intersectsBox(e) {
+		let t = this.planes;
+		for (let n = 0; n < 6; n++) {
+			let r = t[n];
+			if (Zn.x = r.normal.x > 0 ? e.max.x : e.min.x, Zn.y = r.normal.y > 0 ? e.max.y : e.min.y, Zn.z = r.normal.z > 0 ? e.max.z : e.min.z, r.distanceToPoint(Zn) < 0) return !1;
+		}
+		return !0;
+	}
+	containsPoint(e) {
+		let t = this.planes;
+		for (let n = 0; n < 6; n++) if (t[n].distanceToPoint(e) < 0) return !1;
+		return !0;
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+}, $n = class extends Ae {
+	constructor(e = [], t = 301, n, r, i, a, o, s, c, l) {
+		super(e, t, n, r, i, a, o, s, c, l), this.isCubeTexture = !0, this.flipY = !1;
+	}
+	get images() {
+		return this.image;
+	}
+	set images(e) {
+		this.image = e;
+	}
+}, er = class extends Ae {
+	constructor(e, t, n = c, i, a, o, s = r, l = r, u, d = h, f = 1) {
+		if (d !== 1026 && d !== 1027) throw Error("THREE.DepthTexture: format must be either THREE.DepthFormat or THREE.DepthStencilFormat");
+		super({
+			width: e,
+			height: t,
+			depth: f
+		}, i, a, o, s, l, d, n, u), this.isDepthTexture = !0, this.flipY = !1, this.generateMipmaps = !1, this.compareFunction = null;
+	}
+	copy(e) {
+		return super.copy(e), this.source = new Ee(Object.assign({}, e.image)), this.compareFunction = e.compareFunction, this;
+	}
+	toJSON(e) {
+		let t = super.toJSON(e);
+		return this.compareFunction !== null && (t.compareFunction = this.compareFunction), t;
+	}
+}, tr = class extends er {
+	constructor(e, t = c, n = 301, i, a, o = r, s = r, l, u = h) {
+		let d = {
+			width: e,
+			height: e,
+			depth: 1
+		}, f = [
+			d,
+			d,
+			d,
+			d,
+			d,
+			d
+		];
+		super(e, e, t, n, i, a, o, s, l, u), this.image = f, this.isCubeDepthTexture = !0, this.isCubeTexture = !0;
+	}
+	get images() {
+		return this.image;
+	}
+	set images(e) {
+		this.image = e;
+	}
+}, nr = class extends Ae {
+	constructor(e = null) {
+		super(), this.sourceTexture = e, this.isExternalTexture = !0;
+	}
+	copy(e) {
+		return super.copy(e), this.sourceTexture = e.sourceTexture, this;
+	}
+}, rr = class e extends ln {
+	constructor(e = 1, t = 1, n = 1, r = 1, i = 1, a = 1) {
+		super(), this.type = "BoxGeometry", this.parameters = {
+			width: e,
+			height: t,
+			depth: n,
+			widthSegments: r,
+			heightSegments: i,
+			depthSegments: a
+		};
+		let o = this;
+		r = Math.floor(r), i = Math.floor(i), a = Math.floor(a);
+		let s = [], c = [], l = [], u = [], d = 0, f = 0;
+		p("z", "y", "x", -1, -1, n, t, e, a, i, 0), p("z", "y", "x", 1, -1, n, t, -e, a, i, 1), p("x", "z", "y", 1, 1, e, n, t, r, a, 2), p("x", "z", "y", 1, -1, e, n, -t, r, a, 3), p("x", "y", "z", 1, -1, e, t, n, r, i, 4), p("x", "y", "z", -1, -1, e, t, -n, r, i, 5), this.setIndex(s), this.setAttribute("position", new Xt(c, 3)), this.setAttribute("normal", new Xt(l, 3)), this.setAttribute("uv", new Xt(u, 2));
+		function p(e, t, n, r, i, a, p, m, h, g, _) {
+			let v = a / h, y = p / g, b = a / 2, x = p / 2, S = m / 2, C = h + 1, w = g + 1, T = 0, E = 0, D = new W();
+			for (let a = 0; a < w; a++) {
+				let o = a * y - x;
+				for (let s = 0; s < C; s++) D[e] = (s * v - b) * r, D[t] = o * i, D[n] = S, c.push(D.x, D.y, D.z), D[e] = 0, D[t] = 0, D[n] = m > 0 ? 1 : -1, l.push(D.x, D.y, D.z), u.push(s / h), u.push(1 - a / g), T += 1;
+			}
+			for (let e = 0; e < g; e++) for (let t = 0; t < h; t++) {
+				let n = d + t + C * e, r = d + t + C * (e + 1), i = d + (t + 1) + C * (e + 1), a = d + (t + 1) + C * e;
+				s.push(n, r, a), s.push(r, i, a), E += 6;
+			}
+			o.addGroup(f, E, _), f += E, d += T;
+		}
+	}
+	copy(e) {
+		return super.copy(e), this.parameters = Object.assign({}, e.parameters), this;
+	}
+	static fromJSON(t) {
+		return new e(t.width, t.height, t.depth, t.widthSegments, t.heightSegments, t.depthSegments);
+	}
+}, ir = class e extends ln {
+	constructor(e = 1, t = 32, n = 0, r = Math.PI * 2) {
+		super(), this.type = "CircleGeometry", this.parameters = {
+			radius: e,
+			segments: t,
+			thetaStart: n,
+			thetaLength: r
+		}, t = Math.max(3, t);
+		let i = [], a = [], o = [], s = [], c = new W(), l = new U();
+		a.push(0, 0, 0), o.push(0, 0, 1), s.push(.5, .5);
+		for (let i = 0, u = 3; i <= t; i++, u += 3) {
+			let d = n + i / t * r;
+			c.x = e * Math.cos(d), c.y = e * Math.sin(d), a.push(c.x, c.y, c.z), o.push(0, 0, 1), l.x = (a[u] / e + 1) / 2, l.y = (a[u + 1] / e + 1) / 2, s.push(l.x, l.y);
+		}
+		for (let e = 1; e <= t; e++) i.push(e, e + 1, 0);
+		this.setIndex(i), this.setAttribute("position", new Xt(a, 3)), this.setAttribute("normal", new Xt(o, 3)), this.setAttribute("uv", new Xt(s, 2));
+	}
+	copy(e) {
+		return super.copy(e), this.parameters = Object.assign({}, e.parameters), this;
+	}
+	static fromJSON(t) {
+		return new e(t.radius, t.segments, t.thetaStart, t.thetaLength);
+	}
+}, ar = class e extends ln {
+	constructor(e = 1, t = 1, n = 1, r = 1) {
+		super(), this.type = "PlaneGeometry", this.parameters = {
+			width: e,
+			height: t,
+			widthSegments: n,
+			heightSegments: r
+		};
+		let i = e / 2, a = t / 2, o = Math.floor(n), s = Math.floor(r), c = o + 1, l = s + 1, u = e / o, d = t / s, f = [], p = [], m = [], h = [];
+		for (let e = 0; e < l; e++) {
+			let t = e * d - a;
+			for (let n = 0; n < c; n++) {
+				let r = n * u - i;
+				p.push(r, -t, 0), m.push(0, 0, 1), h.push(n / o), h.push(1 - e / s);
+			}
+		}
+		for (let e = 0; e < s; e++) for (let t = 0; t < o; t++) {
+			let n = t + c * e, r = t + c * (e + 1), i = t + 1 + c * (e + 1), a = t + 1 + c * e;
+			f.push(n, r, a), f.push(r, i, a);
+		}
+		this.setIndex(f), this.setAttribute("position", new Xt(p, 3)), this.setAttribute("normal", new Xt(m, 3)), this.setAttribute("uv", new Xt(h, 2));
+	}
+	copy(e) {
+		return super.copy(e), this.parameters = Object.assign({}, e.parameters), this;
+	}
+	static fromJSON(t) {
+		return new e(t.width, t.height, t.widthSegments, t.heightSegments);
+	}
+};
+function or(e) {
+	let t = {};
+	for (let n in e) {
+		t[n] = {};
+		for (let r in e[n]) {
+			let i = e[n][r];
+			if (cr(i)) i.isRenderTargetTexture ? (F("UniformsUtils: Textures of render targets cannot be cloned via cloneUniforms() or mergeUniforms()."), t[n][r] = null) : t[n][r] = i.clone();
+			else if (Array.isArray(i)) if (cr(i[0])) {
+				let e = [];
+				for (let t = 0, n = i.length; t < n; t++) e[t] = i[t].clone();
+				t[n][r] = e;
+			} else t[n][r] = i.slice();
+			else t[n][r] = i;
+		}
+	}
+	return t;
+}
+function sr(e) {
+	let t = {};
+	for (let n = 0; n < e.length; n++) {
+		let r = or(e[n]);
+		for (let e in r) t[e] = r[e];
+	}
+	return t;
+}
+function cr(e) {
+	return e && (e.isColor || e.isMatrix3 || e.isMatrix4 || e.isVector2 || e.isVector3 || e.isVector4 || e.isTexture || e.isQuaternion);
+}
+function lr(e) {
+	let t = [];
+	for (let n = 0; n < e.length; n++) t.push(e[n].clone());
+	return t;
+}
+function ur(e) {
+	let t = e.getRenderTarget();
+	return t === null ? e.outputColorSpace : t.isXRRenderTarget === !0 ? t.texture.colorSpace : K.workingColorSpace;
+}
+var dr = {
+	clone: or,
+	merge: sr
+}, fr = "void main() {\n	gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n}", pr = "void main() {\n	gl_FragColor = vec4( 1.0, 0.0, 0.0, 1.0 );\n}", mr = class extends dn {
+	constructor(e) {
+		super(), this.isShaderMaterial = !0, this.type = "ShaderMaterial", this.defines = {}, this.uniforms = {}, this.uniformsGroups = [], this.vertexShader = fr, this.fragmentShader = pr, this.linewidth = 1, this.wireframe = !1, this.wireframeLinewidth = 1, this.fog = !1, this.lights = !1, this.clipping = !1, this.forceSinglePass = !0, this.extensions = {
+			clipCullDistance: !1,
+			multiDraw: !1
+		}, this.defaultAttributeValues = {
+			color: [
+				1,
+				1,
+				1
+			],
+			uv: [0, 0],
+			uv1: [0, 0]
+		}, this.index0AttributeName = void 0, this.uniformsNeedUpdate = !1, this.glslVersion = null, e !== void 0 && this.setValues(e);
+	}
+	copy(e) {
+		return super.copy(e), this.fragmentShader = e.fragmentShader, this.vertexShader = e.vertexShader, this.uniforms = or(e.uniforms), this.uniformsGroups = lr(e.uniformsGroups), this.defines = Object.assign({}, e.defines), this.wireframe = e.wireframe, this.wireframeLinewidth = e.wireframeLinewidth, this.fog = e.fog, this.lights = e.lights, this.clipping = e.clipping, this.extensions = Object.assign({}, e.extensions), this.glslVersion = e.glslVersion, this.defaultAttributeValues = Object.assign({}, e.defaultAttributeValues), this.index0AttributeName = e.index0AttributeName, this.uniformsNeedUpdate = e.uniformsNeedUpdate, this;
+	}
+	toJSON(e) {
+		let t = super.toJSON(e);
+		t.glslVersion = this.glslVersion, t.uniforms = {};
+		for (let n in this.uniforms) {
+			let r = this.uniforms[n].value;
+			r && r.isTexture ? t.uniforms[n] = {
+				type: "t",
+				value: r.toJSON(e).uuid
+			} : r && r.isColor ? t.uniforms[n] = {
+				type: "c",
+				value: r.getHex()
+			} : r && r.isVector2 ? t.uniforms[n] = {
+				type: "v2",
+				value: r.toArray()
+			} : r && r.isVector3 ? t.uniforms[n] = {
+				type: "v3",
+				value: r.toArray()
+			} : r && r.isVector4 ? t.uniforms[n] = {
+				type: "v4",
+				value: r.toArray()
+			} : r && r.isMatrix3 ? t.uniforms[n] = {
+				type: "m3",
+				value: r.toArray()
+			} : r && r.isMatrix4 ? t.uniforms[n] = {
+				type: "m4",
+				value: r.toArray()
+			} : t.uniforms[n] = { value: r };
+		}
+		Object.keys(this.defines).length > 0 && (t.defines = this.defines), t.vertexShader = this.vertexShader, t.fragmentShader = this.fragmentShader, t.lights = this.lights, t.clipping = this.clipping;
+		let n = {};
+		for (let e in this.extensions) this.extensions[e] === !0 && (n[e] = !0);
+		return Object.keys(n).length > 0 && (t.extensions = n), t;
+	}
+	fromJSON(e, t) {
+		if (super.fromJSON(e, t), e.uniforms !== void 0) for (let n in e.uniforms) {
+			let r = e.uniforms[n];
+			switch (this.uniforms[n] = {}, r.type) {
+				case "t":
+					this.uniforms[n].value = t[r.value] || null;
+					break;
+				case "c":
+					this.uniforms[n].value = new Z().setHex(r.value);
+					break;
+				case "v2":
+					this.uniforms[n].value = new U().fromArray(r.value);
+					break;
+				case "v3":
+					this.uniforms[n].value = new W().fromArray(r.value);
+					break;
+				case "v4":
+					this.uniforms[n].value = new je().fromArray(r.value);
+					break;
+				case "m3":
+					this.uniforms[n].value = new G().fromArray(r.value);
+					break;
+				case "m4":
+					this.uniforms[n].value = new Fe().fromArray(r.value);
+					break;
+				default: this.uniforms[n].value = r.value;
+			}
+		}
+		if (e.defines !== void 0 && (this.defines = e.defines), e.vertexShader !== void 0 && (this.vertexShader = e.vertexShader), e.fragmentShader !== void 0 && (this.fragmentShader = e.fragmentShader), e.glslVersion !== void 0 && (this.glslVersion = e.glslVersion), e.extensions !== void 0) for (let t in e.extensions) this.extensions[t] = e.extensions[t];
+		return e.lights !== void 0 && (this.lights = e.lights), e.clipping !== void 0 && (this.clipping = e.clipping), this;
+	}
+}, hr = class extends mr {
+	constructor(e) {
+		super(e), this.isRawShaderMaterial = !0, this.type = "RawShaderMaterial";
+	}
+}, gr = class extends dn {
+	constructor(e) {
+		super(), this.isMeshDepthMaterial = !0, this.type = "MeshDepthMaterial", this.depthPacking = 3200, this.map = null, this.alphaMap = null, this.displacementMap = null, this.displacementScale = 1, this.displacementBias = 0, this.wireframe = !1, this.wireframeLinewidth = 1, this.setValues(e);
+	}
+	copy(e) {
+		return super.copy(e), this.depthPacking = e.depthPacking, this.map = e.map, this.alphaMap = e.alphaMap, this.displacementMap = e.displacementMap, this.displacementScale = e.displacementScale, this.displacementBias = e.displacementBias, this.wireframe = e.wireframe, this.wireframeLinewidth = e.wireframeLinewidth, this;
+	}
+}, _r = class extends dn {
+	constructor(e) {
+		super(), this.isMeshDistanceMaterial = !0, this.type = "MeshDistanceMaterial", this.map = null, this.alphaMap = null, this.displacementMap = null, this.displacementScale = 1, this.displacementBias = 0, this.setValues(e);
+	}
+	copy(e) {
+		return super.copy(e), this.map = e.map, this.alphaMap = e.alphaMap, this.displacementMap = e.displacementMap, this.displacementScale = e.displacementScale, this.displacementBias = e.displacementBias, this;
+	}
+};
+function vr(e, t) {
+	return !e || e.constructor === t ? e : typeof t.BYTES_PER_ELEMENT == "number" ? new t(e) : Array.prototype.slice.call(e);
+}
+var yr = class {
+	constructor(e, t, n, r) {
+		this.parameterPositions = e, this._cachedIndex = 0, this.resultBuffer = r === void 0 ? new t.constructor(n) : r, this.sampleValues = t, this.valueSize = n, this.settings = null, this.DefaultSettings_ = {};
+	}
+	evaluate(e) {
+		let t = this.parameterPositions, n = this._cachedIndex, r = t[n], i = t[n - 1];
+		validate_interval: {
+			seek: {
+				let a;
+				linear_scan: {
+					forward_scan: if (!(e < r)) {
+						for (let a = n + 2;;) {
+							if (r === void 0) {
+								if (e < i) break forward_scan;
+								return n = t.length, this._cachedIndex = n, this.copySampleValue_(n - 1);
+							}
+							if (n === a) break;
+							if (i = r, r = t[++n], e < r) break seek;
+						}
+						a = t.length;
+						break linear_scan;
+					}
+					if (!(e >= i)) {
+						let o = t[1];
+						e < o && (n = 2, i = o);
+						for (let a = n - 2;;) {
+							if (i === void 0) return this._cachedIndex = 0, this.copySampleValue_(0);
+							if (n === a) break;
+							if (r = i, i = t[--n - 1], e >= i) break seek;
+						}
+						a = n, n = 0;
+						break linear_scan;
+					}
+					break validate_interval;
+				}
+				for (; n < a;) {
+					let r = n + a >>> 1;
+					e < t[r] ? a = r : n = r + 1;
+				}
+				if (r = t[n], i = t[n - 1], i === void 0) return this._cachedIndex = 0, this.copySampleValue_(0);
+				if (r === void 0) return n = t.length, this._cachedIndex = n, this.copySampleValue_(n - 1);
+			}
+			this._cachedIndex = n, this.intervalChanged_(n, i, r);
+		}
+		return this.interpolate_(n, i, e, r);
+	}
+	getSettings_() {
+		return this.settings || this.DefaultSettings_;
+	}
+	copySampleValue_(e) {
+		let t = this.resultBuffer, n = this.sampleValues, r = this.valueSize, i = e * r;
+		for (let e = 0; e !== r; ++e) t[e] = n[i + e];
+		return t;
+	}
+	interpolate_() {
+		throw Error("THREE.Interpolant: Call to abstract method.");
+	}
+	intervalChanged_() {}
+}, br = class extends yr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r), this._weightPrev = -0, this._offsetPrev = -0, this._weightNext = -0, this._offsetNext = -0, this.DefaultSettings_ = {
+			endingStart: E,
+			endingEnd: E
+		};
+	}
+	intervalChanged_(e, t, n) {
+		let r = this.parameterPositions, i = e - 2, a = e + 1, o = r[i], s = r[a];
+		if (o === void 0) switch (this.getSettings_().endingStart) {
+			case D:
+				i = e, o = 2 * t - n;
+				break;
+			case O:
+				i = r.length - 2, o = t + r[i] - r[i + 1];
+				break;
+			default: i = e, o = n;
+		}
+		if (s === void 0) switch (this.getSettings_().endingEnd) {
+			case D:
+				a = e, s = 2 * n - t;
+				break;
+			case O:
+				a = 1, s = n + r[1] - r[0];
+				break;
+			default: a = e - 1, s = t;
+		}
+		let c = (n - t) * .5, l = this.valueSize;
+		this._weightPrev = c / (t - o), this._weightNext = c / (s - n), this._offsetPrev = i * l, this._offsetNext = a * l;
+	}
+	interpolate_(e, t, n, r) {
+		let i = this.resultBuffer, a = this.sampleValues, o = this.valueSize, s = e * o, c = s - o, l = this._offsetPrev, u = this._offsetNext, d = this._weightPrev, f = this._weightNext, p = (n - t) / (r - t), m = p * p, h = m * p, g = -d * h + 2 * d * m - d * p, _ = (1 + d) * h + (-1.5 - 2 * d) * m + (-.5 + d) * p + 1, v = (-1 - f) * h + (1.5 + f) * m + .5 * p, y = f * h - f * m;
+		for (let e = 0; e !== o; ++e) i[e] = g * a[l + e] + _ * a[c + e] + v * a[s + e] + y * a[u + e];
+		return i;
+	}
+}, xr = class extends yr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+	interpolate_(e, t, n, r) {
+		let i = this.resultBuffer, a = this.sampleValues, o = this.valueSize, s = e * o, c = s - o, l = (n - t) / (r - t), u = 1 - l;
+		for (let e = 0; e !== o; ++e) i[e] = a[c + e] * u + a[s + e] * l;
+		return i;
+	}
+}, Sr = class extends yr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+	interpolate_(e) {
+		return this.copySampleValue_(e - 1);
+	}
+}, Cr = class extends yr {
+	interpolate_(e, t, n, r) {
+		let i = this.resultBuffer, a = this.sampleValues, o = this.valueSize, s = e * o, c = s - o, l = this.inTangents, u = this.outTangents;
+		if (!l || !u) {
+			let e = (n - t) / (r - t), l = 1 - e;
+			for (let t = 0; t !== o; ++t) i[t] = a[c + t] * l + a[s + t] * e;
+			return i;
+		}
+		let d = o * 2, f = e - 1;
+		for (let p = 0; p !== o; ++p) {
+			let o = a[c + p], m = a[s + p], h = f * d + p * 2, g = u[h], _ = u[h + 1], v = e * d + p * 2, y = l[v], b = l[v + 1], x = (n - t) / (r - t), S, C, w, T, E;
+			for (let e = 0; e < 8; e++) {
+				S = x * x, C = S * x, w = 1 - x, T = w * w, E = T * w;
+				let e = E * t + 3 * T * x * g + 3 * w * S * y + C * r - n;
+				if (Math.abs(e) < 1e-10) break;
+				let i = 3 * T * (g - t) + 6 * w * x * (y - g) + 3 * S * (r - y);
+				if (Math.abs(i) < 1e-10) break;
+				x -= e / i, x = Math.max(0, Math.min(1, x));
+			}
+			i[p] = E * o + 3 * T * x * _ + 3 * w * S * b + C * m;
+		}
+		return i;
+	}
+}, wr = class {
+	constructor(e, t, n, r) {
+		if (e === void 0) throw Error("THREE.KeyframeTrack: track name is undefined");
+		if (t === void 0 || t.length === 0) throw Error("THREE.KeyframeTrack: no keyframes in track named " + e);
+		this.name = e, this.times = vr(t, this.TimeBufferType), this.values = vr(n, this.ValueBufferType), this.setInterpolation(r || this.DefaultInterpolation);
+	}
+	static toJSON(e) {
+		let t = e.constructor, n;
+		if (t.toJSON !== this.toJSON) n = t.toJSON(e);
+		else {
+			n = {
+				name: e.name,
+				times: vr(e.times, Array),
+				values: vr(e.values, Array)
+			};
+			let t = e.getInterpolation();
+			t !== e.DefaultInterpolation && (n.interpolation = t);
+		}
+		return n.type = e.ValueTypeName, n;
+	}
+	InterpolantFactoryMethodDiscrete(e) {
+		return new Sr(this.times, this.values, this.getValueSize(), e);
+	}
+	InterpolantFactoryMethodLinear(e) {
+		return new xr(this.times, this.values, this.getValueSize(), e);
+	}
+	InterpolantFactoryMethodSmooth(e) {
+		return new br(this.times, this.values, this.getValueSize(), e);
+	}
+	InterpolantFactoryMethodBezier(e) {
+		let t = new Cr(this.times, this.values, this.getValueSize(), e);
+		return this.settings && (t.inTangents = this.settings.inTangents, t.outTangents = this.settings.outTangents), t;
+	}
+	setInterpolation(e) {
+		let t;
+		switch (e) {
+			case S:
+				t = this.InterpolantFactoryMethodDiscrete;
+				break;
+			case C:
+				t = this.InterpolantFactoryMethodLinear;
+				break;
+			case w:
+				t = this.InterpolantFactoryMethodSmooth;
+				break;
+			case T:
+				t = this.InterpolantFactoryMethodBezier;
+				break;
+		}
+		if (t === void 0) {
+			let t = "unsupported interpolation for " + this.ValueTypeName + " keyframe track named " + this.name;
+			if (this.createInterpolant === void 0) if (e !== this.DefaultInterpolation) this.setInterpolation(this.DefaultInterpolation);
+			else throw Error(t);
+			return F("KeyframeTrack:", t), this;
+		}
+		return this.createInterpolant = t, this;
+	}
+	getInterpolation() {
+		switch (this.createInterpolant) {
+			case this.InterpolantFactoryMethodDiscrete: return S;
+			case this.InterpolantFactoryMethodLinear: return C;
+			case this.InterpolantFactoryMethodSmooth: return w;
+			case this.InterpolantFactoryMethodBezier: return T;
+		}
+	}
+	getValueSize() {
+		return this.values.length / this.times.length;
+	}
+	shift(e) {
+		if (e !== 0) {
+			let t = this.times;
+			for (let n = 0, r = t.length; n !== r; ++n) t[n] += e;
+		}
+		return this;
+	}
+	scale(e) {
+		if (e !== 1) {
+			let t = this.times;
+			for (let n = 0, r = t.length; n !== r; ++n) t[n] *= e;
+		}
+		return this;
+	}
+	trim(e, t) {
+		let n = this.times, r = n.length, i = 0, a = r - 1;
+		for (; i !== r && n[i] < e;) ++i;
+		for (; a !== -1 && n[a] > t;) --a;
+		if (++a, i !== 0 || a !== r) {
+			i >= a && (a = Math.max(a, 1), i = a - 1);
+			let e = this.getValueSize();
+			this.times = n.slice(i, a), this.values = this.values.slice(i * e, a * e);
+		}
+		return this;
+	}
+	validate() {
+		let e = !0, t = this.getValueSize();
+		t - Math.floor(t) !== 0 && (I("KeyframeTrack: Invalid value size in track.", this), e = !1);
+		let n = this.times, r = this.values, i = n.length;
+		i === 0 && (I("KeyframeTrack: Track is empty.", this), e = !1);
+		let a = null;
+		for (let t = 0; t !== i; t++) {
+			let r = n[t];
+			if (typeof r == "number" && isNaN(r)) {
+				I("KeyframeTrack: Time is not a valid number.", this, t, r), e = !1;
+				break;
+			}
+			if (a !== null && a > r) {
+				I("KeyframeTrack: Out of order keys.", this, t, r, a), e = !1;
+				break;
+			}
+			a = r;
+		}
+		if (r !== void 0 && N(r)) for (let t = 0, n = r.length; t !== n; ++t) {
+			let n = r[t];
+			if (isNaN(n)) {
+				I("KeyframeTrack: Value is not a valid number.", this, t, n), e = !1;
+				break;
+			}
+		}
+		return e;
+	}
+	optimize() {
+		let e = this.times.slice(), t = this.values.slice(), n = this.getValueSize(), r = this.getInterpolation() === w, i = e.length - 1, a = 1;
+		for (let o = 1; o < i; ++o) {
+			let i = !1, s = e[o];
+			if (s !== e[o + 1] && (o !== 1 || s !== e[0])) if (r) i = !0;
+			else {
+				let e = o * n, r = e - n, a = e + n;
+				for (let o = 0; o !== n; ++o) {
+					let n = t[e + o];
+					if (n !== t[r + o] || n !== t[a + o]) {
+						i = !0;
+						break;
+					}
+				}
+			}
+			if (i) {
+				if (o !== a) {
+					e[a] = e[o];
+					let r = o * n, i = a * n;
+					for (let e = 0; e !== n; ++e) t[i + e] = t[r + e];
+				}
+				++a;
+			}
+		}
+		if (i > 0) {
+			e[a] = e[i];
+			for (let e = i * n, r = a * n, o = 0; o !== n; ++o) t[r + o] = t[e + o];
+			++a;
+		}
+		return a === e.length ? (this.times = e, this.values = t) : (this.times = e.slice(0, a), this.values = t.slice(0, a * n)), this;
+	}
+	clone() {
+		let e = this.times.slice(), t = this.values.slice(), n = this.constructor, r = new n(this.name, e, t);
+		return r.createInterpolant = this.createInterpolant, r;
+	}
+};
+wr.prototype.ValueTypeName = "", wr.prototype.TimeBufferType = Float32Array, wr.prototype.ValueBufferType = Float32Array, wr.prototype.DefaultInterpolation = C;
+var Tr = class extends wr {
+	constructor(e, t, n) {
+		super(e, t, n);
+	}
+};
+Tr.prototype.ValueTypeName = "bool", Tr.prototype.ValueBufferType = Array, Tr.prototype.DefaultInterpolation = S, Tr.prototype.InterpolantFactoryMethodLinear = void 0, Tr.prototype.InterpolantFactoryMethodSmooth = void 0;
+var Er = class extends wr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+};
+Er.prototype.ValueTypeName = "color";
+var Dr = class extends wr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+};
+Dr.prototype.ValueTypeName = "number";
+var Or = class extends yr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+	interpolate_(e, t, n, r) {
+		let i = this.resultBuffer, a = this.sampleValues, o = this.valueSize, s = (n - t) / (r - t), c = e * o;
+		for (let e = c + o; c !== e; c += 4) me.slerpFlat(i, 0, a, c - o, a, c, s);
+		return i;
+	}
+}, kr = class extends wr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+	InterpolantFactoryMethodLinear(e) {
+		return new Or(this.times, this.values, this.getValueSize(), e);
+	}
+};
+kr.prototype.ValueTypeName = "quaternion", kr.prototype.InterpolantFactoryMethodSmooth = void 0;
+var Ar = class extends wr {
+	constructor(e, t, n) {
+		super(e, t, n);
+	}
+};
+Ar.prototype.ValueTypeName = "string", Ar.prototype.ValueBufferType = Array, Ar.prototype.DefaultInterpolation = S, Ar.prototype.InterpolantFactoryMethodLinear = void 0, Ar.prototype.InterpolantFactoryMethodSmooth = void 0;
+var jr = class extends wr {
+	constructor(e, t, n, r) {
+		super(e, t, n, r);
+	}
+};
+jr.prototype.ValueTypeName = "vector";
+var Mr = /*@__PURE__*/ new class {
+	constructor(e, t, n) {
+		let r = this, i = !1, a = 0, o = 0, s, c = [];
+		this.onStart = void 0, this.onLoad = e, this.onProgress = t, this.onError = n, this._abortController = null, this.itemStart = function(e) {
+			o++, i === !1 && r.onStart !== void 0 && r.onStart(e, a, o), i = !0;
+		}, this.itemEnd = function(e) {
+			a++, r.onProgress !== void 0 && r.onProgress(e, a, o), a === o && (i = !1, r.onLoad !== void 0 && r.onLoad());
+		}, this.itemError = function(e) {
+			r.onError !== void 0 && r.onError(e);
+		}, this.resolveURL = function(e) {
+			return e = e.normalize("NFC"), s ? s(e) : e;
+		}, this.setURLModifier = function(e) {
+			return s = e, this;
+		}, this.addHandler = function(e, t) {
+			return c.push(e, t), this;
+		}, this.removeHandler = function(e) {
+			let t = c.indexOf(e);
+			return t !== -1 && c.splice(t, 2), this;
+		}, this.getHandler = function(e) {
+			for (let t = 0, n = c.length; t < n; t += 2) {
+				let n = c[t], r = c[t + 1];
+				if (n.global && (n.lastIndex = 0), n.test(e)) return r;
+			}
+			return null;
+		}, this.abort = function() {
+			return this.abortController.abort(), this._abortController = null, this;
+		};
+	}
+	get abortController() {
+		return this._abortController ||= new AbortController(), this._abortController;
+	}
+}(), Nr = class {
+	constructor(e) {
+		this.manager = e === void 0 ? Mr : e, this.crossOrigin = "anonymous", this.withCredentials = !1, this.path = "", this.resourcePath = "", this.requestHeader = {}, typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("observe", { detail: this }));
+	}
+	load() {}
+	loadAsync(e, t) {
+		let n = this;
+		return new Promise(function(r, i) {
+			n.load(e, r, t, i);
+		});
+	}
+	parse() {}
+	setCrossOrigin(e) {
+		return this.crossOrigin = e, this;
+	}
+	setWithCredentials(e) {
+		return this.withCredentials = e, this;
+	}
+	setPath(e) {
+		return this.path = e, this;
+	}
+	setResourcePath(e) {
+		return this.resourcePath = e, this;
+	}
+	setRequestHeader(e) {
+		return this.requestHeader = e, this;
+	}
+	abort() {
+		return this;
+	}
+};
+Nr.DEFAULT_MATERIAL_NAME = "__DEFAULT";
+var Pr = /*@__PURE__*/ new W(), Fr = /*@__PURE__*/ new me(), Ir = /*@__PURE__*/ new W(), Lr = class extends at {
+	constructor() {
+		super(), this.isCamera = !0, this.type = "Camera", this.matrixWorldInverse = new Fe(), this.projectionMatrix = new Fe(), this.projectionMatrixInverse = new Fe(), this.coordinateSystem = te, this._reversedDepth = !1;
+	}
+	get reversedDepth() {
+		return this._reversedDepth;
+	}
+	copy(e, t) {
+		return super.copy(e, t), this.matrixWorldInverse.copy(e.matrixWorldInverse), this.projectionMatrix.copy(e.projectionMatrix), this.projectionMatrixInverse.copy(e.projectionMatrixInverse), this.coordinateSystem = e.coordinateSystem, this;
+	}
+	getWorldDirection(e) {
+		return super.getWorldDirection(e).negate();
+	}
+	updateMatrixWorld(e) {
+		super.updateMatrixWorld(e), this.matrixWorld.decompose(Pr, Fr, Ir), Ir.x === 1 && Ir.y === 1 && Ir.z === 1 ? this.matrixWorldInverse.copy(this.matrixWorld).invert() : this.matrixWorldInverse.compose(Pr, Fr, Ir.set(1, 1, 1)).invert();
+	}
+	updateWorldMatrix(e, t, n = !1) {
+		super.updateWorldMatrix(e, t, n), this.matrixWorld.decompose(Pr, Fr, Ir), Ir.x === 1 && Ir.y === 1 && Ir.z === 1 ? this.matrixWorldInverse.copy(this.matrixWorld).invert() : this.matrixWorldInverse.compose(Pr, Fr, Ir.set(1, 1, 1)).invert();
+	}
+	clone() {
+		return new this.constructor().copy(this);
+	}
+}, Rr = /*@__PURE__*/ new W(), zr = /*@__PURE__*/ new U(), Br = /*@__PURE__*/ new U(), Vr = class extends Lr {
+	constructor(e = 50, t = 1, n = .1, r = 2e3) {
+		super(), this.isPerspectiveCamera = !0, this.type = "PerspectiveCamera", this.fov = e, this.zoom = 1, this.near = n, this.far = r, this.focus = 10, this.aspect = t, this.view = null, this.filmGauge = 35, this.filmOffset = 0, this.updateProjectionMatrix();
+	}
+	copy(e, t) {
+		return super.copy(e, t), this.fov = e.fov, this.zoom = e.zoom, this.near = e.near, this.far = e.far, this.focus = e.focus, this.aspect = e.aspect, this.view = e.view === null ? null : Object.assign({}, e.view), this.filmGauge = e.filmGauge, this.filmOffset = e.filmOffset, this;
+	}
+	setFocalLength(e) {
+		let t = .5 * this.getFilmHeight() / e;
+		this.fov = ue * 2 * Math.atan(t), this.updateProjectionMatrix();
+	}
+	getFocalLength() {
+		let e = Math.tan(le * .5 * this.fov);
+		return .5 * this.getFilmHeight() / e;
+	}
+	getEffectiveFOV() {
+		return ue * 2 * Math.atan(Math.tan(le * .5 * this.fov) / this.zoom);
+	}
+	getFilmWidth() {
+		return this.filmGauge * Math.min(this.aspect, 1);
+	}
+	getFilmHeight() {
+		return this.filmGauge / Math.max(this.aspect, 1);
+	}
+	getViewBounds(e, t, n) {
+		Rr.set(-1, -1, .5).applyMatrix4(this.projectionMatrixInverse), t.set(Rr.x, Rr.y).multiplyScalar(-e / Rr.z), Rr.set(1, 1, .5).applyMatrix4(this.projectionMatrixInverse), n.set(Rr.x, Rr.y).multiplyScalar(-e / Rr.z);
+	}
+	getViewSize(e, t) {
+		return this.getViewBounds(e, zr, Br), t.subVectors(Br, zr);
+	}
+	setViewOffset(e, t, n, r, i, a) {
+		this.aspect = e / t, this.view === null && (this.view = {
+			enabled: !0,
+			fullWidth: 1,
+			fullHeight: 1,
+			offsetX: 0,
+			offsetY: 0,
+			width: 1,
+			height: 1
+		}), this.view.enabled = !0, this.view.fullWidth = e, this.view.fullHeight = t, this.view.offsetX = n, this.view.offsetY = r, this.view.width = i, this.view.height = a, this.updateProjectionMatrix();
+	}
+	clearViewOffset() {
+		this.view !== null && (this.view.enabled = !1), this.updateProjectionMatrix();
+	}
+	updateProjectionMatrix() {
+		let e = this.near, t = e * Math.tan(le * .5 * this.fov) / this.zoom, n = 2 * t, r = this.aspect * n, i = -.5 * r, a = this.view;
+		if (this.view !== null && this.view.enabled) {
+			let e = a.fullWidth, o = a.fullHeight;
+			i += a.offsetX * r / e, t -= a.offsetY * n / o, r *= a.width / e, n *= a.height / o;
+		}
+		let o = this.filmOffset;
+		o !== 0 && (i += e * o / this.getFilmWidth()), this.projectionMatrix.makePerspective(i, i + r, t, t - n, e, this.far, this.coordinateSystem, this.reversedDepth), this.projectionMatrixInverse.copy(this.projectionMatrix).invert();
+	}
+	toJSON(e) {
+		let t = super.toJSON(e);
+		return t.object.fov = this.fov, t.object.zoom = this.zoom, t.object.near = this.near, t.object.far = this.far, t.object.focus = this.focus, t.object.aspect = this.aspect, this.view !== null && (t.object.view = Object.assign({}, this.view)), t.object.filmGauge = this.filmGauge, t.object.filmOffset = this.filmOffset, t;
+	}
+}, Hr = class extends Lr {
+	constructor(e = -1, t = 1, n = 1, r = -1, i = .1, a = 2e3) {
+		super(), this.isOrthographicCamera = !0, this.type = "OrthographicCamera", this.zoom = 1, this.view = null, this.left = e, this.right = t, this.top = n, this.bottom = r, this.near = i, this.far = a, this.updateProjectionMatrix();
+	}
+	copy(e, t) {
+		return super.copy(e, t), this.left = e.left, this.right = e.right, this.top = e.top, this.bottom = e.bottom, this.near = e.near, this.far = e.far, this.zoom = e.zoom, this.view = e.view === null ? null : Object.assign({}, e.view), this;
+	}
+	setViewOffset(e, t, n, r, i, a) {
+		this.view === null && (this.view = {
+			enabled: !0,
+			fullWidth: 1,
+			fullHeight: 1,
+			offsetX: 0,
+			offsetY: 0,
+			width: 1,
+			height: 1
+		}), this.view.enabled = !0, this.view.fullWidth = e, this.view.fullHeight = t, this.view.offsetX = n, this.view.offsetY = r, this.view.width = i, this.view.height = a, this.updateProjectionMatrix();
+	}
+	clearViewOffset() {
+		this.view !== null && (this.view.enabled = !1), this.updateProjectionMatrix();
+	}
+	updateProjectionMatrix() {
+		let e = (this.right - this.left) / (2 * this.zoom), t = (this.top - this.bottom) / (2 * this.zoom), n = (this.right + this.left) / 2, r = (this.top + this.bottom) / 2, i = n - e, a = n + e, o = r + t, s = r - t;
+		if (this.view !== null && this.view.enabled) {
+			let e = (this.right - this.left) / this.view.fullWidth / this.zoom, t = (this.top - this.bottom) / this.view.fullHeight / this.zoom;
+			i += e * this.view.offsetX, a = i + e * this.view.width, o -= t * this.view.offsetY, s = o - t * this.view.height;
+		}
+		this.projectionMatrix.makeOrthographic(i, a, o, s, this.near, this.far, this.coordinateSystem, this.reversedDepth), this.projectionMatrixInverse.copy(this.projectionMatrix).invert();
+	}
+	toJSON(e) {
+		let t = super.toJSON(e);
+		return t.object.zoom = this.zoom, t.object.left = this.left, t.object.right = this.right, t.object.top = this.top, t.object.bottom = this.bottom, t.object.near = this.near, t.object.far = this.far, this.view !== null && (t.object.view = Object.assign({}, this.view)), t;
+	}
+}, Ur = -90, Wr = 1, Gr = class extends at {
+	constructor(e, t, n) {
+		super(), this.type = "CubeCamera", this.renderTarget = n, this.coordinateSystem = null, this.activeMipmapLevel = 0;
+		let r = new Vr(Ur, Wr, e, t);
+		r.layers = this.layers, this.add(r);
+		let i = new Vr(Ur, Wr, e, t);
+		i.layers = this.layers, this.add(i);
+		let a = new Vr(Ur, Wr, e, t);
+		a.layers = this.layers, this.add(a);
+		let o = new Vr(Ur, Wr, e, t);
+		o.layers = this.layers, this.add(o);
+		let s = new Vr(Ur, Wr, e, t);
+		s.layers = this.layers, this.add(s);
+		let c = new Vr(Ur, Wr, e, t);
+		c.layers = this.layers, this.add(c);
+	}
+	updateCoordinateSystem() {
+		let e = this.coordinateSystem, t = this.children.concat(), [n, r, i, a, o, s] = t;
+		for (let e of t) this.remove(e);
+		if (e === 2e3) n.up.set(0, 1, 0), n.lookAt(1, 0, 0), r.up.set(0, 1, 0), r.lookAt(-1, 0, 0), i.up.set(0, 0, -1), i.lookAt(0, 1, 0), a.up.set(0, 0, 1), a.lookAt(0, -1, 0), o.up.set(0, 1, 0), o.lookAt(0, 0, 1), s.up.set(0, 1, 0), s.lookAt(0, 0, -1);
+		else if (e === 2001) n.up.set(0, -1, 0), n.lookAt(-1, 0, 0), r.up.set(0, -1, 0), r.lookAt(1, 0, 0), i.up.set(0, 0, 1), i.lookAt(0, 1, 0), a.up.set(0, 0, -1), a.lookAt(0, -1, 0), o.up.set(0, -1, 0), o.lookAt(0, 0, 1), s.up.set(0, -1, 0), s.lookAt(0, 0, -1);
+		else throw Error("THREE.CubeCamera.updateCoordinateSystem(): Invalid coordinate system: " + e);
+		for (let e of t) this.add(e), e.updateMatrixWorld();
+	}
+	update(e, t) {
+		this.parent === null && this.updateMatrixWorld();
+		let { renderTarget: n, activeMipmapLevel: r } = this;
+		this.coordinateSystem !== e.coordinateSystem && (this.coordinateSystem = e.coordinateSystem, this.updateCoordinateSystem());
+		let [i, a, o, s, c, l] = this.children, u = e.getRenderTarget(), d = e.getActiveCubeFace(), f = e.getActiveMipmapLevel(), p = e.xr.enabled;
+		e.xr.enabled = !1;
+		let m = n.texture.generateMipmaps;
+		n.texture.generateMipmaps = !1;
+		let h = !1;
+		h = e.isWebGLRenderer === !0 ? e.state.buffers.depth.getReversed() : e.reversedDepthBuffer, e.setRenderTarget(n, 0, r), h && e.autoClear === !1 && e.clearDepth(), e.render(t, i), e.setRenderTarget(n, 1, r), h && e.autoClear === !1 && e.clearDepth(), e.render(t, a), e.setRenderTarget(n, 2, r), h && e.autoClear === !1 && e.clearDepth(), e.render(t, o), e.setRenderTarget(n, 3, r), h && e.autoClear === !1 && e.clearDepth(), e.render(t, s), e.setRenderTarget(n, 4, r), h && e.autoClear === !1 && e.clearDepth(), e.render(t, c), n.texture.generateMipmaps = m, e.setRenderTarget(n, 5, r), h && e.autoClear === !1 && e.clearDepth(), e.render(t, l), e.setRenderTarget(u, d, f), e.xr.enabled = p, n.texture.needsPMREMUpdate = !0;
+	}
+}, Kr = class extends Vr {
+	constructor(e = []) {
+		super(), this.isArrayCamera = !0, this.isMultiViewCamera = !1, this.cameras = e;
+	}
+}, qr = "\\[\\]\\.:\\/", Jr = /* @__PURE__ */ RegExp("[\\[\\]\\.:\\/]", "g"), Yr = "[^\\[\\]\\.:\\/]", Xr = "[^" + qr.replace("\\.", "") + "]", Zr = /*@__PURE__*/ "((?:WC+[\\/:])*)".replace("WC", Yr), Qr = /*@__PURE__*/ "(WCOD+)?".replace("WCOD", Xr), $r = /*@__PURE__*/ "(?:\\.(WC+)(?:\\[(.+)\\])?)?".replace("WC", Yr), ei = /*@__PURE__*/ "\\.(WC+)(?:\\[(.+)\\])?".replace("WC", Yr), ti = RegExp("^" + Zr + Qr + $r + ei + "$"), ni = [
+	"material",
+	"materials",
+	"bones",
+	"map"
+], ri = class {
+	constructor(e, t, n) {
+		let r = n || ii.parseTrackName(t);
+		this._targetGroup = e, this._bindings = e.subscribe_(t, r);
+	}
+	getValue(e, t) {
+		this.bind();
+		let n = this._targetGroup.nCachedObjects_, r = this._bindings[n];
+		r !== void 0 && r.getValue(e, t);
+	}
+	setValue(e, t) {
+		let n = this._bindings;
+		for (let r = this._targetGroup.nCachedObjects_, i = n.length; r !== i; ++r) n[r].setValue(e, t);
+	}
+	bind() {
+		let e = this._bindings;
+		for (let t = this._targetGroup.nCachedObjects_, n = e.length; t !== n; ++t) e[t].bind();
+	}
+	unbind() {
+		let e = this._bindings;
+		for (let t = this._targetGroup.nCachedObjects_, n = e.length; t !== n; ++t) e[t].unbind();
+	}
+}, ii = class e {
+	constructor(t, n, r) {
+		this.path = n, this.parsedPath = r || e.parseTrackName(n), this.node = e.findNode(t, this.parsedPath.nodeName), this.rootNode = t, this.getValue = this._getValue_unbound, this.setValue = this._setValue_unbound;
+	}
+	static create(t, n, r) {
+		return t && t.isAnimationObjectGroup ? new e.Composite(t, n, r) : new e(t, n, r);
+	}
+	static sanitizeNodeName(e) {
+		return e.replace(/\s/g, "_").replace(Jr, "");
+	}
+	static parseTrackName(e) {
+		let t = ti.exec(e);
+		if (t === null) throw Error("THREE.PropertyBinding: Cannot parse trackName: " + e);
+		let n = {
+			nodeName: t[2],
+			objectName: t[3],
+			objectIndex: t[4],
+			propertyName: t[5],
+			propertyIndex: t[6]
+		}, r = n.nodeName && n.nodeName.lastIndexOf(".");
+		if (r !== void 0 && r !== -1) {
+			let e = n.nodeName.substring(r + 1);
+			ni.indexOf(e) !== -1 && (n.nodeName = n.nodeName.substring(0, r), n.objectName = e);
+		}
+		if (n.propertyName === null || n.propertyName.length === 0) throw Error("THREE.PropertyBinding: can not parse propertyName from trackName: " + e);
+		return n;
+	}
+	static findNode(e, t) {
+		if (t === void 0 || t === "" || t === "." || t === -1 || t === e.name || t === e.uuid) return e;
+		if (e.skeleton) {
+			let n = e.skeleton.getBoneByName(t);
+			if (n !== void 0) return n;
+		}
+		if (e.children) {
+			let n = function(e) {
+				for (let r = 0; r < e.length; r++) {
+					let i = e[r];
+					if (i.name === t || i.uuid === t) return i;
+					let a = n(i.children);
+					if (a) return a;
+				}
+				return null;
+			}, r = n(e.children);
+			if (r) return r;
+		}
+		return null;
+	}
+	_getValue_unavailable() {}
+	_setValue_unavailable() {}
+	_getValue_direct(e, t) {
+		e[t] = this.targetObject[this.propertyName];
+	}
+	_getValue_array(e, t) {
+		let n = this.resolvedProperty;
+		for (let r = 0, i = n.length; r !== i; ++r) e[t++] = n[r];
+	}
+	_getValue_arrayElement(e, t) {
+		e[t] = this.resolvedProperty[this.propertyIndex];
+	}
+	_getValue_toArray(e, t) {
+		this.resolvedProperty.toArray(e, t);
+	}
+	_setValue_direct(e, t) {
+		this.targetObject[this.propertyName] = e[t];
+	}
+	_setValue_direct_setNeedsUpdate(e, t) {
+		this.targetObject[this.propertyName] = e[t], this.targetObject.needsUpdate = !0;
+	}
+	_setValue_direct_setMatrixWorldNeedsUpdate(e, t) {
+		this.targetObject[this.propertyName] = e[t], this.targetObject.matrixWorldNeedsUpdate = !0;
+	}
+	_setValue_array(e, t) {
+		let n = this.resolvedProperty;
+		for (let r = 0, i = n.length; r !== i; ++r) n[r] = e[t++];
+	}
+	_setValue_array_setNeedsUpdate(e, t) {
+		let n = this.resolvedProperty;
+		for (let r = 0, i = n.length; r !== i; ++r) n[r] = e[t++];
+		this.targetObject.needsUpdate = !0;
+	}
+	_setValue_array_setMatrixWorldNeedsUpdate(e, t) {
+		let n = this.resolvedProperty;
+		for (let r = 0, i = n.length; r !== i; ++r) n[r] = e[t++];
+		this.targetObject.matrixWorldNeedsUpdate = !0;
+	}
+	_setValue_arrayElement(e, t) {
+		this.resolvedProperty[this.propertyIndex] = e[t];
+	}
+	_setValue_arrayElement_setNeedsUpdate(e, t) {
+		this.resolvedProperty[this.propertyIndex] = e[t], this.targetObject.needsUpdate = !0;
+	}
+	_setValue_arrayElement_setMatrixWorldNeedsUpdate(e, t) {
+		this.resolvedProperty[this.propertyIndex] = e[t], this.targetObject.matrixWorldNeedsUpdate = !0;
+	}
+	_setValue_fromArray(e, t) {
+		this.resolvedProperty.fromArray(e, t);
+	}
+	_setValue_fromArray_setNeedsUpdate(e, t) {
+		this.resolvedProperty.fromArray(e, t), this.targetObject.needsUpdate = !0;
+	}
+	_setValue_fromArray_setMatrixWorldNeedsUpdate(e, t) {
+		this.resolvedProperty.fromArray(e, t), this.targetObject.matrixWorldNeedsUpdate = !0;
+	}
+	_getValue_unbound(e, t) {
+		this.bind(), this.getValue(e, t);
+	}
+	_setValue_unbound(e, t) {
+		this.bind(), this.setValue(e, t);
+	}
+	bind() {
+		let t = this.node, n = this.parsedPath, r = n.objectName, i = n.propertyName, a = n.propertyIndex;
+		if (t || (t = e.findNode(this.rootNode, n.nodeName), this.node = t), this.getValue = this._getValue_unavailable, this.setValue = this._setValue_unavailable, !t) {
+			F("PropertyBinding: No target node found for track: " + this.path + ".");
+			return;
+		}
+		if (r) {
+			let e = n.objectIndex;
+			switch (r) {
+				case "materials":
+					if (!t.material) {
+						I("PropertyBinding: Can not bind to material as node does not have a material.", this);
+						return;
+					}
+					if (!t.material.materials) {
+						I("PropertyBinding: Can not bind to material.materials as node.material does not have a materials array.", this);
+						return;
+					}
+					t = t.material.materials;
+					break;
+				case "bones":
+					if (!t.skeleton) {
+						I("PropertyBinding: Can not bind to bones as node does not have a skeleton.", this);
+						return;
+					}
+					t = t.skeleton.bones;
+					for (let n = 0; n < t.length; n++) if (t[n].name === e) {
+						e = n;
+						break;
+					}
+					break;
+				case "map":
+					if ("map" in t) {
+						t = t.map;
+						break;
+					}
+					if (!t.material) {
+						I("PropertyBinding: Can not bind to material as node does not have a material.", this);
+						return;
+					}
+					if (!t.material.map) {
+						I("PropertyBinding: Can not bind to material.map as node.material does not have a map.", this);
+						return;
+					}
+					t = t.material.map;
+					break;
+				default:
+					if (t[r] === void 0) {
+						I("PropertyBinding: Can not bind to objectName of node undefined.", this);
+						return;
+					}
+					t = t[r];
+			}
+			if (e !== void 0) {
+				if (t[e] === void 0) {
+					I("PropertyBinding: Trying to bind to objectIndex of objectName, but is undefined.", this, t);
+					return;
+				}
+				t = t[e];
+			}
+		}
+		let o = t[i];
+		if (o === void 0) {
+			let e = n.nodeName;
+			I("PropertyBinding: Trying to update property for track: " + e + "." + i + " but it wasn't found.", t);
+			return;
+		}
+		let s = this.Versioning.None;
+		this.targetObject = t, t.isMaterial === !0 ? s = this.Versioning.NeedsUpdate : t.isObject3D === !0 && (s = this.Versioning.MatrixWorldNeedsUpdate);
+		let c = this.BindingType.Direct;
+		if (a !== void 0) {
+			if (i === "morphTargetInfluences") {
+				if (!t.geometry) {
+					I("PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.", this);
+					return;
+				}
+				if (!t.geometry.morphAttributes) {
+					I("PropertyBinding: Can not bind to morphTargetInfluences because node does not have a geometry.morphAttributes.", this);
+					return;
+				}
+				t.morphTargetDictionary[a] !== void 0 && (a = t.morphTargetDictionary[a]);
+			}
+			c = this.BindingType.ArrayElement, this.resolvedProperty = o, this.propertyIndex = a;
+		} else o.fromArray !== void 0 && o.toArray !== void 0 ? (c = this.BindingType.HasFromToArray, this.resolvedProperty = o) : Array.isArray(o) ? (c = this.BindingType.EntireArray, this.resolvedProperty = o) : this.propertyName = i;
+		this.getValue = this.GetterByBindingType[c], this.setValue = this.SetterByBindingTypeAndVersioning[c][s];
+	}
+	unbind() {
+		this.node = null, this.getValue = this._getValue_unbound, this.setValue = this._setValue_unbound;
+	}
+};
+ii.Composite = ri, ii.prototype.BindingType = {
+	Direct: 0,
+	EntireArray: 1,
+	ArrayElement: 2,
+	HasFromToArray: 3
+}, ii.prototype.Versioning = {
+	None: 0,
+	NeedsUpdate: 1,
+	MatrixWorldNeedsUpdate: 2
+}, ii.prototype.GetterByBindingType = [
+	ii.prototype._getValue_direct,
+	ii.prototype._getValue_array,
+	ii.prototype._getValue_arrayElement,
+	ii.prototype._getValue_toArray
+], ii.prototype.SetterByBindingTypeAndVersioning = [
+	[
+		ii.prototype._setValue_direct,
+		ii.prototype._setValue_direct_setNeedsUpdate,
+		ii.prototype._setValue_direct_setMatrixWorldNeedsUpdate
+	],
+	[
+		ii.prototype._setValue_array,
+		ii.prototype._setValue_array_setNeedsUpdate,
+		ii.prototype._setValue_array_setMatrixWorldNeedsUpdate
+	],
+	[
+		ii.prototype._setValue_arrayElement,
+		ii.prototype._setValue_arrayElement_setNeedsUpdate,
+		ii.prototype._setValue_arrayElement_setMatrixWorldNeedsUpdate
+	],
+	[
+		ii.prototype._setValue_fromArray,
+		ii.prototype._setValue_fromArray_setNeedsUpdate,
+		ii.prototype._setValue_fromArray_setMatrixWorldNeedsUpdate
+	]
+], class e {
+	static {
+		e.prototype.isMatrix2 = !0;
+	}
+	constructor(e, t, n, r) {
+		this.elements = [
+			1,
+			0,
+			0,
+			1
+		], e !== void 0 && this.set(e, t, n, r);
+	}
+	identity() {
+		return this.set(1, 0, 0, 1), this;
+	}
+	fromArray(e, t = 0) {
+		for (let n = 0; n < 4; n++) this.elements[n] = e[n + t];
+		return this;
+	}
+	set(e, t, n, r) {
+		let i = this.elements;
+		return i[0] = e, i[2] = t, i[1] = n, i[3] = r, this;
+	}
+};
+function ai(e, t, n, r) {
+	let i = oi(r);
+	switch (n) {
+		case 1021: return e * t;
+		case _: return e * t / i.components * i.byteLength;
+		case v: return e * t / i.components * i.byteLength;
+		case y: return e * t * 2 / i.components * i.byteLength;
+		case b: return e * t * 2 / i.components * i.byteLength;
+		case 1022: return e * t * 3 / i.components * i.byteLength;
+		case m: return e * t * 4 / i.components * i.byteLength;
+		case x: return e * t * 4 / i.components * i.byteLength;
+		case 33776:
+		case 33777: return Math.floor((e + 3) / 4) * Math.floor((t + 3) / 4) * 8;
+		case 33778:
+		case 33779: return Math.floor((e + 3) / 4) * Math.floor((t + 3) / 4) * 16;
+		case 35841:
+		case 35843: return Math.max(e, 16) * Math.max(t, 8) / 4;
+		case 35840:
+		case 35842: return Math.max(e, 8) * Math.max(t, 8) / 2;
+		case 36196:
+		case 37492:
+		case 37488:
+		case 37489: return Math.floor((e + 3) / 4) * Math.floor((t + 3) / 4) * 8;
+		case 37496:
+		case 37490:
+		case 37491: return Math.floor((e + 3) / 4) * Math.floor((t + 3) / 4) * 16;
+		case 37808: return Math.floor((e + 3) / 4) * Math.floor((t + 3) / 4) * 16;
+		case 37809: return Math.floor((e + 4) / 5) * Math.floor((t + 3) / 4) * 16;
+		case 37810: return Math.floor((e + 4) / 5) * Math.floor((t + 4) / 5) * 16;
+		case 37811: return Math.floor((e + 5) / 6) * Math.floor((t + 4) / 5) * 16;
+		case 37812: return Math.floor((e + 5) / 6) * Math.floor((t + 5) / 6) * 16;
+		case 37813: return Math.floor((e + 7) / 8) * Math.floor((t + 4) / 5) * 16;
+		case 37814: return Math.floor((e + 7) / 8) * Math.floor((t + 5) / 6) * 16;
+		case 37815: return Math.floor((e + 7) / 8) * Math.floor((t + 7) / 8) * 16;
+		case 37816: return Math.floor((e + 9) / 10) * Math.floor((t + 4) / 5) * 16;
+		case 37817: return Math.floor((e + 9) / 10) * Math.floor((t + 5) / 6) * 16;
+		case 37818: return Math.floor((e + 9) / 10) * Math.floor((t + 7) / 8) * 16;
+		case 37819: return Math.floor((e + 9) / 10) * Math.floor((t + 9) / 10) * 16;
+		case 37820: return Math.floor((e + 11) / 12) * Math.floor((t + 9) / 10) * 16;
+		case 37821: return Math.floor((e + 11) / 12) * Math.floor((t + 11) / 12) * 16;
+		case 36492:
+		case 36494:
+		case 36495: return Math.ceil(e / 4) * Math.ceil(t / 4) * 16;
+		case 36283:
+		case 36284: return Math.ceil(e / 4) * Math.ceil(t / 4) * 8;
+		case 36285:
+		case 36286: return Math.ceil(e / 4) * Math.ceil(t / 4) * 16;
+	}
+	throw Error(`Unable to determine texture byte length for ${n} format.`);
+}
+function oi(e) {
+	switch (e) {
+		case o:
+		case 1010: return {
+			byteLength: 1,
+			components: 1
+		};
+		case s:
+		case 1011:
+		case u: return {
+			byteLength: 2,
+			components: 1
+		};
+		case d:
+		case f: return {
+			byteLength: 2,
+			components: 4
+		};
+		case c:
+		case 1013:
+		case l: return {
+			byteLength: 4,
+			components: 1
+		};
+		case 35902:
+		case 35899: return {
+			byteLength: 4,
+			components: 3
+		};
+	}
+	throw Error(`THREE.TextureUtils: Unknown texture type ${e}.`);
+}
+typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("register", { detail: { revision: "185" } })), typeof window < "u" && (window.__THREE__ ? F("WARNING: Multiple instances of Three.js being imported.") : window.__THREE__ = "185");
+//#endregion
+//#region node_modules/three/build/three.module.js
+function si() {
+	let e = null, t = !1, n = null, r = null;
+	function i(t, a) {
+		n(t, a), r = e.requestAnimationFrame(i);
+	}
+	return {
+		start: function() {
+			t !== !0 && n !== null && e !== null && (r = e.requestAnimationFrame(i), t = !0);
+		},
+		stop: function() {
+			e !== null && e.cancelAnimationFrame(r), t = !1;
+		},
+		setAnimationLoop: function(e) {
+			n = e;
+		},
+		setContext: function(t) {
+			e = t;
+		}
+	};
+}
+function ci(e) {
+	let t = /* @__PURE__ */ new WeakMap();
+	function n(t, n) {
+		let r = t.array, i = t.usage, a = r.byteLength, o = e.createBuffer();
+		e.bindBuffer(n, o), e.bufferData(n, r, i), t.onUploadCallback();
+		let s;
+		if (r instanceof Float32Array) s = e.FLOAT;
+		else if (typeof Float16Array < "u" && r instanceof Float16Array) s = e.HALF_FLOAT;
+		else if (r instanceof Uint16Array) s = t.isFloat16BufferAttribute ? e.HALF_FLOAT : e.UNSIGNED_SHORT;
+		else if (r instanceof Int16Array) s = e.SHORT;
+		else if (r instanceof Uint32Array) s = e.UNSIGNED_INT;
+		else if (r instanceof Int32Array) s = e.INT;
+		else if (r instanceof Int8Array) s = e.BYTE;
+		else if (r instanceof Uint8Array) s = e.UNSIGNED_BYTE;
+		else if (r instanceof Uint8ClampedArray) s = e.UNSIGNED_BYTE;
+		else throw Error("THREE.WebGLAttributes: Unsupported buffer data format: " + r);
+		return {
+			buffer: o,
+			type: s,
+			bytesPerElement: r.BYTES_PER_ELEMENT,
+			version: t.version,
+			size: a
+		};
+	}
+	function r(t, n, r) {
+		let i = n.array, a = n.updateRanges;
+		if (e.bindBuffer(r, t), a.length === 0) e.bufferSubData(r, 0, i);
+		else {
+			a.sort((e, t) => e.start - t.start);
+			let t = 0;
+			for (let e = 1; e < a.length; e++) {
+				let n = a[t], r = a[e];
+				r.start <= n.start + n.count + 1 ? n.count = Math.max(n.count, r.start + r.count - n.start) : (++t, a[t] = r);
+			}
+			a.length = t + 1;
+			for (let t = 0, n = a.length; t < n; t++) {
+				let n = a[t];
+				e.bufferSubData(r, n.start * i.BYTES_PER_ELEMENT, i, n.start, n.count);
+			}
+			n.clearUpdateRanges();
+		}
+		n.onUploadCallback();
+	}
+	function i(e) {
+		return e.isInterleavedBufferAttribute && (e = e.data), t.get(e);
+	}
+	function a(n) {
+		n.isInterleavedBufferAttribute && (n = n.data);
+		let r = t.get(n);
+		r && (e.deleteBuffer(r.buffer), t.delete(n));
+	}
+	function o(e, i) {
+		if (e.isInterleavedBufferAttribute && (e = e.data), e.isGLBufferAttribute) {
+			let n = t.get(e);
+			(!n || n.version < e.version) && t.set(e, {
+				buffer: e.buffer,
+				type: e.type,
+				bytesPerElement: e.elementSize,
+				version: e.version
+			});
+			return;
+		}
+		let a = t.get(e);
+		if (a === void 0) t.set(e, n(e, i));
+		else if (a.version < e.version) {
+			if (a.size !== e.array.byteLength) throw Error("THREE.WebGLAttributes: The size of the buffer attribute's array buffer does not match the original size. Resizing buffer attributes is not supported.");
+			r(a.buffer, e, i), a.version = e.version;
+		}
+	}
+	return {
+		get: i,
+		remove: a,
+		update: o
+	};
+}
+var Q = {
+	alphahash_fragment: "#ifdef USE_ALPHAHASH\n	if ( diffuseColor.a < getAlphaHashThreshold( vPosition ) ) discard;\n#endif",
+	alphahash_pars_fragment: "#ifdef USE_ALPHAHASH\n	const float ALPHA_HASH_SCALE = 0.05;\n	float hash2D( vec2 value ) {\n		return fract( 1.0e4 * sin( 17.0 * value.x + 0.1 * value.y ) * ( 0.1 + abs( sin( 13.0 * value.y + value.x ) ) ) );\n	}\n	float hash3D( vec3 value ) {\n		return hash2D( vec2( hash2D( value.xy ), value.z ) );\n	}\n	float getAlphaHashThreshold( vec3 position ) {\n		float maxDeriv = max(\n			length( dFdx( position.xyz ) ),\n			length( dFdy( position.xyz ) )\n		);\n		float pixScale = 1.0 / ( ALPHA_HASH_SCALE * maxDeriv );\n		vec2 pixScales = vec2(\n			exp2( floor( log2( pixScale ) ) ),\n			exp2( ceil( log2( pixScale ) ) )\n		);\n		vec2 alpha = vec2(\n			hash3D( floor( pixScales.x * position.xyz ) ),\n			hash3D( floor( pixScales.y * position.xyz ) )\n		);\n		float lerpFactor = fract( log2( pixScale ) );\n		float x = ( 1.0 - lerpFactor ) * alpha.x + lerpFactor * alpha.y;\n		float a = min( lerpFactor, 1.0 - lerpFactor );\n		vec3 cases = vec3(\n			x * x / ( 2.0 * a * ( 1.0 - a ) ),\n			( x - 0.5 * a ) / ( 1.0 - a ),\n			1.0 - ( ( 1.0 - x ) * ( 1.0 - x ) / ( 2.0 * a * ( 1.0 - a ) ) )\n		);\n		float threshold = ( x < ( 1.0 - a ) )\n			? ( ( x < a ) ? cases.x : cases.y )\n			: cases.z;\n		return clamp( threshold , 1.0e-6, 1.0 );\n	}\n#endif",
+	alphamap_fragment: "#ifdef USE_ALPHAMAP\n	diffuseColor.a *= texture2D( alphaMap, vAlphaMapUv ).g;\n#endif",
+	alphamap_pars_fragment: "#ifdef USE_ALPHAMAP\n	uniform sampler2D alphaMap;\n#endif",
+	alphatest_fragment: "#ifdef USE_ALPHATEST\n	#ifdef ALPHA_TO_COVERAGE\n	diffuseColor.a = smoothstep( alphaTest, alphaTest + fwidth( diffuseColor.a ), diffuseColor.a );\n	if ( diffuseColor.a == 0.0 ) discard;\n	#else\n	if ( diffuseColor.a < alphaTest ) discard;\n	#endif\n#endif",
+	alphatest_pars_fragment: "#ifdef USE_ALPHATEST\n	uniform float alphaTest;\n#endif",
+	aomap_fragment: "#ifdef USE_AOMAP\n	float ambientOcclusion = ( texture2D( aoMap, vAoMapUv ).r - 1.0 ) * aoMapIntensity + 1.0;\n	reflectedLight.indirectDiffuse *= ambientOcclusion;\n	#if defined( USE_CLEARCOAT ) \n		clearcoatSpecularIndirect *= ambientOcclusion;\n	#endif\n	#if defined( USE_SHEEN ) \n		sheenSpecularIndirect *= ambientOcclusion;\n	#endif\n	#if defined( USE_ENVMAP ) && defined( STANDARD )\n		float dotNV = saturate( dot( geometryNormal, geometryViewDir ) );\n		reflectedLight.indirectSpecular *= computeSpecularOcclusion( dotNV, ambientOcclusion, material.roughness );\n	#endif\n#endif",
+	aomap_pars_fragment: "#ifdef USE_AOMAP\n	uniform sampler2D aoMap;\n	uniform float aoMapIntensity;\n#endif",
+	batching_pars_vertex: "#ifdef USE_BATCHING\n	#if ! defined( GL_ANGLE_multi_draw )\n	#define gl_DrawID _gl_DrawID\n	uniform int _gl_DrawID;\n	#endif\n	uniform highp sampler2D batchingTexture;\n	uniform highp usampler2D batchingIdTexture;\n	mat4 getBatchingMatrix( const in float i ) {\n		int size = textureSize( batchingTexture, 0 ).x;\n		int j = int( i ) * 4;\n		int x = j % size;\n		int y = j / size;\n		vec4 v1 = texelFetch( batchingTexture, ivec2( x, y ), 0 );\n		vec4 v2 = texelFetch( batchingTexture, ivec2( x + 1, y ), 0 );\n		vec4 v3 = texelFetch( batchingTexture, ivec2( x + 2, y ), 0 );\n		vec4 v4 = texelFetch( batchingTexture, ivec2( x + 3, y ), 0 );\n		return mat4( v1, v2, v3, v4 );\n	}\n	float getIndirectIndex( const in int i ) {\n		int size = textureSize( batchingIdTexture, 0 ).x;\n		int x = i % size;\n		int y = i / size;\n		return float( texelFetch( batchingIdTexture, ivec2( x, y ), 0 ).r );\n	}\n#endif\n#ifdef USE_BATCHING_COLOR\n	uniform sampler2D batchingColorTexture;\n	vec4 getBatchingColor( const in float i ) {\n		int size = textureSize( batchingColorTexture, 0 ).x;\n		int j = int( i );\n		int x = j % size;\n		int y = j / size;\n		return texelFetch( batchingColorTexture, ivec2( x, y ), 0 );\n	}\n#endif",
+	batching_vertex: "#ifdef USE_BATCHING\n	mat4 batchingMatrix = getBatchingMatrix( getIndirectIndex( gl_DrawID ) );\n#endif",
+	begin_vertex: "vec3 transformed = vec3( position );\n#ifdef USE_ALPHAHASH\n	vPosition = vec3( position );\n#endif",
+	beginnormal_vertex: "vec3 objectNormal = vec3( normal );\n#ifdef USE_TANGENT\n	vec3 objectTangent = vec3( tangent.xyz );\n#endif",
+	bsdfs: "float G_BlinnPhong_Implicit( ) {\n	return 0.25;\n}\nfloat D_BlinnPhong( const in float shininess, const in float dotNH ) {\n	return RECIPROCAL_PI * ( shininess * 0.5 + 1.0 ) * pow( dotNH, shininess );\n}\nvec3 BRDF_BlinnPhong( const in vec3 lightDir, const in vec3 viewDir, const in vec3 normal, const in vec3 specularColor, const in float shininess ) {\n	vec3 halfDir = normalize( lightDir + viewDir );\n	float dotNH = saturate( dot( normal, halfDir ) );\n	float dotVH = saturate( dot( viewDir, halfDir ) );\n	vec3 F = F_Schlick( specularColor, 1.0, dotVH );\n	float G = G_BlinnPhong_Implicit( );\n	float D = D_BlinnPhong( shininess, dotNH );\n	return F * ( G * D );\n} // validated",
+	iridescence_fragment: "#ifdef USE_IRIDESCENCE\n	const mat3 XYZ_TO_REC709 = mat3(\n		 3.2404542, -0.9692660,  0.0556434,\n		-1.5371385,  1.8760108, -0.2040259,\n		-0.4985314,  0.0415560,  1.0572252\n	);\n	vec3 Fresnel0ToIor( vec3 fresnel0 ) {\n		vec3 sqrtF0 = sqrt( fresnel0 );\n		return ( vec3( 1.0 ) + sqrtF0 ) / ( vec3( 1.0 ) - sqrtF0 );\n	}\n	vec3 IorToFresnel0( vec3 transmittedIor, float incidentIor ) {\n		return pow2( ( transmittedIor - vec3( incidentIor ) ) / ( transmittedIor + vec3( incidentIor ) ) );\n	}\n	float IorToFresnel0( float transmittedIor, float incidentIor ) {\n		return pow2( ( transmittedIor - incidentIor ) / ( transmittedIor + incidentIor ));\n	}\n	vec3 evalSensitivity( float OPD, vec3 shift ) {\n		float phase = 2.0 * PI * OPD * 1.0e-9;\n		vec3 val = vec3( 5.4856e-13, 4.4201e-13, 5.2481e-13 );\n		vec3 pos = vec3( 1.6810e+06, 1.7953e+06, 2.2084e+06 );\n		vec3 var = vec3( 4.3278e+09, 9.3046e+09, 6.6121e+09 );\n		vec3 xyz = val * sqrt( 2.0 * PI * var ) * cos( pos * phase + shift ) * exp( - pow2( phase ) * var );\n		xyz.x += 9.7470e-14 * sqrt( 2.0 * PI * 4.5282e+09 ) * cos( 2.2399e+06 * phase + shift[ 0 ] ) * exp( - 4.5282e+09 * pow2( phase ) );\n		xyz /= 1.0685e-7;\n		vec3 rgb = XYZ_TO_REC709 * xyz;\n		return rgb;\n	}\n	vec3 evalIridescence( float outsideIOR, float eta2, float cosTheta1, float thinFilmThickness, vec3 baseF0 ) {\n		vec3 I;\n		float iridescenceIOR = mix( outsideIOR, eta2, smoothstep( 0.0, 0.03, thinFilmThickness ) );\n		float sinTheta2Sq = pow2( outsideIOR / iridescenceIOR ) * ( 1.0 - pow2( cosTheta1 ) );\n		float cosTheta2Sq = 1.0 - sinTheta2Sq;\n		if ( cosTheta2Sq < 0.0 ) {\n			return vec3( 1.0 );\n		}\n		float cosTheta2 = sqrt( cosTheta2Sq );\n		float R0 = IorToFresnel0( iridescenceIOR, outsideIOR );\n		float R12 = F_Schlick( R0, 1.0, cosTheta1 );\n		float T121 = 1.0 - R12;\n		float phi12 = 0.0;\n		if ( iridescenceIOR < outsideIOR ) phi12 = PI;\n		float phi21 = PI - phi12;\n		vec3 baseIOR = Fresnel0ToIor( clamp( baseF0, 0.0, 0.9999 ) );		vec3 R1 = IorToFresnel0( baseIOR, iridescenceIOR );\n		vec3 R23 = F_Schlick( R1, 1.0, cosTheta2 );\n		vec3 phi23 = vec3( 0.0 );\n		if ( baseIOR[ 0 ] < iridescenceIOR ) phi23[ 0 ] = PI;\n		if ( baseIOR[ 1 ] < iridescenceIOR ) phi23[ 1 ] = PI;\n		if ( baseIOR[ 2 ] < iridescenceIOR ) phi23[ 2 ] = PI;\n		float OPD = 2.0 * iridescenceIOR * thinFilmThickness * cosTheta2;\n		vec3 phi = vec3( phi21 ) + phi23;\n		vec3 R123 = clamp( R12 * R23, 1e-5, 0.9999 );\n		vec3 r123 = sqrt( R123 );\n		vec3 Rs = pow2( T121 ) * R23 / ( vec3( 1.0 ) - R123 );\n		vec3 C0 = R12 + Rs;\n		I = C0;\n		vec3 Cm = Rs - T121;\n		for ( int m = 1; m <= 2; ++ m ) {\n			Cm *= r123;\n			vec3 Sm = 2.0 * evalSensitivity( float( m ) * OPD, float( m ) * phi );\n			I += Cm * Sm;\n		}\n		return max( I, vec3( 0.0 ) );\n	}\n#endif",
+	bumpmap_pars_fragment: "#ifdef USE_BUMPMAP\n	uniform sampler2D bumpMap;\n	uniform float bumpScale;\n	vec2 dHdxy_fwd() {\n		vec2 dSTdx = dFdx( vBumpMapUv );\n		vec2 dSTdy = dFdy( vBumpMapUv );\n		float Hll = bumpScale * texture2D( bumpMap, vBumpMapUv ).x;\n		float dBx = bumpScale * texture2D( bumpMap, vBumpMapUv + dSTdx ).x - Hll;\n		float dBy = bumpScale * texture2D( bumpMap, vBumpMapUv + dSTdy ).x - Hll;\n		return vec2( dBx, dBy );\n	}\n	vec3 perturbNormalArb( vec3 surf_pos, vec3 surf_norm, vec2 dHdxy, float faceDirection ) {\n		vec3 vSigmaX = normalize( dFdx( surf_pos.xyz ) );\n		vec3 vSigmaY = normalize( dFdy( surf_pos.xyz ) );\n		vec3 vN = surf_norm;\n		vec3 R1 = cross( vSigmaY, vN );\n		vec3 R2 = cross( vN, vSigmaX );\n		float fDet = dot( vSigmaX, R1 ) * faceDirection;\n		vec3 vGrad = sign( fDet ) * ( dHdxy.x * R1 + dHdxy.y * R2 );\n		return normalize( abs( fDet ) * surf_norm - vGrad );\n	}\n#endif",
+	clipping_planes_fragment: "#if NUM_CLIPPING_PLANES > 0\n	vec4 plane;\n	#ifdef ALPHA_TO_COVERAGE\n		float distanceToPlane, distanceGradient;\n		float clipOpacity = 1.0;\n		#pragma unroll_loop_start\n		for ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {\n			plane = clippingPlanes[ i ];\n			distanceToPlane = - dot( vClipPosition, plane.xyz ) + plane.w;\n			distanceGradient = fwidth( distanceToPlane ) / 2.0;\n			clipOpacity *= smoothstep( - distanceGradient, distanceGradient, distanceToPlane );\n			if ( clipOpacity == 0.0 ) discard;\n		}\n		#pragma unroll_loop_end\n		#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES\n			float unionClipOpacity = 1.0;\n			#pragma unroll_loop_start\n			for ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {\n				plane = clippingPlanes[ i ];\n				distanceToPlane = - dot( vClipPosition, plane.xyz ) + plane.w;\n				distanceGradient = fwidth( distanceToPlane ) / 2.0;\n				unionClipOpacity *= 1.0 - smoothstep( - distanceGradient, distanceGradient, distanceToPlane );\n			}\n			#pragma unroll_loop_end\n			clipOpacity *= 1.0 - unionClipOpacity;\n		#endif\n		diffuseColor.a *= clipOpacity;\n		if ( diffuseColor.a == 0.0 ) discard;\n	#else\n		#pragma unroll_loop_start\n		for ( int i = 0; i < UNION_CLIPPING_PLANES; i ++ ) {\n			plane = clippingPlanes[ i ];\n			if ( dot( vClipPosition, plane.xyz ) > plane.w ) discard;\n		}\n		#pragma unroll_loop_end\n		#if UNION_CLIPPING_PLANES < NUM_CLIPPING_PLANES\n			bool clipped = true;\n			#pragma unroll_loop_start\n			for ( int i = UNION_CLIPPING_PLANES; i < NUM_CLIPPING_PLANES; i ++ ) {\n				plane = clippingPlanes[ i ];\n				clipped = ( dot( vClipPosition, plane.xyz ) > plane.w ) && clipped;\n			}\n			#pragma unroll_loop_end\n			if ( clipped ) discard;\n		#endif\n	#endif\n#endif",
+	clipping_planes_pars_fragment: "#if NUM_CLIPPING_PLANES > 0\n	varying vec3 vClipPosition;\n	uniform vec4 clippingPlanes[ NUM_CLIPPING_PLANES ];\n#endif",
+	clipping_planes_pars_vertex: "#if NUM_CLIPPING_PLANES > 0\n	varying vec3 vClipPosition;\n#endif",
+	clipping_planes_vertex: "#if NUM_CLIPPING_PLANES > 0\n	vClipPosition = - mvPosition.xyz;\n#endif",
+	color_fragment: "#if defined( USE_COLOR ) || defined( USE_COLOR_ALPHA )\n	diffuseColor *= vColor;\n#endif",
+	color_pars_fragment: "#if defined( USE_COLOR ) || defined( USE_COLOR_ALPHA )\n	varying vec4 vColor;\n#endif",
+	color_pars_vertex: "#if defined( USE_COLOR ) || defined( USE_COLOR_ALPHA ) || defined( USE_INSTANCING_COLOR ) || defined( USE_BATCHING_COLOR )\n	varying vec4 vColor;\n#endif",
+	color_vertex: "#if defined( USE_COLOR ) || defined( USE_COLOR_ALPHA ) || defined( USE_INSTANCING_COLOR ) || defined( USE_BATCHING_COLOR )\n	vColor = vec4( 1.0 );\n#endif\n#ifdef USE_COLOR_ALPHA\n	vColor *= color;\n#elif defined( USE_COLOR )\n	vColor.rgb *= color;\n#endif\n#ifdef USE_INSTANCING_COLOR\n	vColor.rgb *= instanceColor.rgb;\n#endif\n#ifdef USE_BATCHING_COLOR\n	vColor *= getBatchingColor( getIndirectIndex( gl_DrawID ) );\n#endif",
+	common: "#define PI 3.141592653589793\n#define PI2 6.283185307179586\n#define PI_HALF 1.5707963267948966\n#define RECIPROCAL_PI 0.3183098861837907\n#define RECIPROCAL_PI2 0.15915494309189535\n#define EPSILON 1e-6\n#ifndef saturate\n#define saturate( a ) clamp( a, 0.0, 1.0 )\n#endif\n#define whiteComplement( a ) ( 1.0 - saturate( a ) )\nfloat pow2( const in float x ) { return x*x; }\nvec3 pow2( const in vec3 x ) { return x*x; }\nfloat pow3( const in float x ) { return x*x*x; }\nfloat pow4( const in float x ) { float x2 = x*x; return x2*x2; }\nfloat max3( const in vec3 v ) { return max( max( v.x, v.y ), v.z ); }\nfloat average( const in vec3 v ) { return dot( v, vec3( 0.3333333 ) ); }\nhighp float rand( const in vec2 uv ) {\n	const highp float a = 12.9898, b = 78.233, c = 43758.5453;\n	highp float dt = dot( uv.xy, vec2( a,b ) ), sn = mod( dt, PI );\n	return fract( sin( sn ) * c );\n}\n#ifdef HIGH_PRECISION\n	float precisionSafeLength( vec3 v ) { return length( v ); }\n#else\n	float precisionSafeLength( vec3 v ) {\n		float maxComponent = max3( abs( v ) );\n		return length( v / maxComponent ) * maxComponent;\n	}\n#endif\nstruct IncidentLight {\n	vec3 color;\n	vec3 direction;\n	bool visible;\n};\nstruct ReflectedLight {\n	vec3 directDiffuse;\n	vec3 directSpecular;\n	vec3 indirectDiffuse;\n	vec3 indirectSpecular;\n};\n#ifdef USE_ALPHAHASH\n	varying vec3 vPosition;\n#endif\nvec3 transformDirection( in vec3 dir, in mat4 matrix ) {\n	return normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );\n}\n#define inverseTransformDirection transformDirectionByInverseViewMatrix\nvec3 transformNormalByInverseViewMatrix( in vec3 normal, in mat4 viewMatrix ) {\n	return normalize( ( vec4( normal, 0.0 ) * viewMatrix ).xyz );\n}\nvec3 transformDirectionByInverseViewMatrix( in vec3 dir, in mat4 viewMatrix ) {\n	return normalize( ( vec4( dir, 0.0 ) * viewMatrix ).xyz );\n}\nbool isPerspectiveMatrix( mat4 m ) {\n	return m[ 2 ][ 3 ] == - 1.0;\n}\nvec2 equirectUv( in vec3 dir ) {\n	float u = atan( dir.z, dir.x ) * RECIPROCAL_PI2 + 0.5;\n	float v = asin( clamp( dir.y, - 1.0, 1.0 ) ) * RECIPROCAL_PI + 0.5;\n	return vec2( u, v );\n}\nvec3 BRDF_Lambert( const in vec3 diffuseColor ) {\n	return RECIPROCAL_PI * diffuseColor;\n}\nvec3 F_Schlick( const in vec3 f0, const in float f90, const in float dotVH ) {\n	float fresnel = exp2( ( - 5.55473 * dotVH - 6.98316 ) * dotVH );\n	return f0 * ( 1.0 - fresnel ) + ( f90 * fresnel );\n}\nfloat F_Schlick( const in float f0, const in float f90, const in float dotVH ) {\n	float fresnel = exp2( ( - 5.55473 * dotVH - 6.98316 ) * dotVH );\n	return f0 * ( 1.0 - fresnel ) + ( f90 * fresnel );\n} // validated",
+	cube_uv_reflection_fragment: "#ifdef ENVMAP_TYPE_CUBE_UV\n	#define cubeUV_minMipLevel 4.0\n	#define cubeUV_minTileSize 16.0\n	float getFace( vec3 direction ) {\n		vec3 absDirection = abs( direction );\n		float face = - 1.0;\n		if ( absDirection.x > absDirection.z ) {\n			if ( absDirection.x > absDirection.y )\n				face = direction.x > 0.0 ? 0.0 : 3.0;\n			else\n				face = direction.y > 0.0 ? 1.0 : 4.0;\n		} else {\n			if ( absDirection.z > absDirection.y )\n				face = direction.z > 0.0 ? 2.0 : 5.0;\n			else\n				face = direction.y > 0.0 ? 1.0 : 4.0;\n		}\n		return face;\n	}\n	vec2 getUV( vec3 direction, float face ) {\n		vec2 uv;\n		if ( face == 0.0 ) {\n			uv = vec2( direction.z, direction.y ) / abs( direction.x );\n		} else if ( face == 1.0 ) {\n			uv = vec2( - direction.x, - direction.z ) / abs( direction.y );\n		} else if ( face == 2.0 ) {\n			uv = vec2( - direction.x, direction.y ) / abs( direction.z );\n		} else if ( face == 3.0 ) {\n			uv = vec2( - direction.z, direction.y ) / abs( direction.x );\n		} else if ( face == 4.0 ) {\n			uv = vec2( - direction.x, direction.z ) / abs( direction.y );\n		} else {\n			uv = vec2( direction.x, direction.y ) / abs( direction.z );\n		}\n		return 0.5 * ( uv + 1.0 );\n	}\n	vec3 bilinearCubeUV( sampler2D envMap, vec3 direction, float mipInt ) {\n		float face = getFace( direction );\n		float filterInt = max( cubeUV_minMipLevel - mipInt, 0.0 );\n		mipInt = max( mipInt, cubeUV_minMipLevel );\n		float faceSize = exp2( mipInt );\n		highp vec2 uv = getUV( direction, face ) * ( faceSize - 2.0 ) + 1.0;\n		if ( face > 2.0 ) {\n			uv.y += faceSize;\n			face -= 3.0;\n		}\n		uv.x += face * faceSize;\n		uv.x += filterInt * 3.0 * cubeUV_minTileSize;\n		uv.y += 4.0 * ( exp2( CUBEUV_MAX_MIP ) - faceSize );\n		uv.x *= CUBEUV_TEXEL_WIDTH;\n		uv.y *= CUBEUV_TEXEL_HEIGHT;\n		#ifdef texture2DGradEXT\n			return texture2DGradEXT( envMap, uv, vec2( 0.0 ), vec2( 0.0 ) ).rgb;\n		#else\n			return texture2D( envMap, uv ).rgb;\n		#endif\n	}\n	#define cubeUV_r0 1.0\n	#define cubeUV_m0 - 2.0\n	#define cubeUV_r1 0.8\n	#define cubeUV_m1 - 1.0\n	#define cubeUV_r4 0.4\n	#define cubeUV_m4 2.0\n	#define cubeUV_r5 0.305\n	#define cubeUV_m5 3.0\n	#define cubeUV_r6 0.21\n	#define cubeUV_m6 4.0\n	float roughnessToMip( float roughness ) {\n		float mip = 0.0;\n		if ( roughness >= cubeUV_r1 ) {\n			mip = ( cubeUV_r0 - roughness ) * ( cubeUV_m1 - cubeUV_m0 ) / ( cubeUV_r0 - cubeUV_r1 ) + cubeUV_m0;\n		} else if ( roughness >= cubeUV_r4 ) {\n			mip = ( cubeUV_r1 - roughness ) * ( cubeUV_m4 - cubeUV_m1 ) / ( cubeUV_r1 - cubeUV_r4 ) + cubeUV_m1;\n		} else if ( roughness >= cubeUV_r5 ) {\n			mip = ( cubeUV_r4 - roughness ) * ( cubeUV_m5 - cubeUV_m4 ) / ( cubeUV_r4 - cubeUV_r5 ) + cubeUV_m4;\n		} else if ( roughness >= cubeUV_r6 ) {\n			mip = ( cubeUV_r5 - roughness ) * ( cubeUV_m6 - cubeUV_m5 ) / ( cubeUV_r5 - cubeUV_r6 ) + cubeUV_m5;\n		} else {\n			mip = - 2.0 * log2( 1.16 * roughness );		}\n		return mip;\n	}\n	vec4 textureCubeUV( sampler2D envMap, vec3 sampleDir, float roughness ) {\n		float mip = clamp( roughnessToMip( roughness ), cubeUV_m0, CUBEUV_MAX_MIP );\n		float mipF = fract( mip );\n		float mipInt = floor( mip );\n		vec3 color0 = bilinearCubeUV( envMap, sampleDir, mipInt );\n		if ( mipF == 0.0 ) {\n			return vec4( color0, 1.0 );\n		} else {\n			vec3 color1 = bilinearCubeUV( envMap, sampleDir, mipInt + 1.0 );\n			return vec4( mix( color0, color1, mipF ), 1.0 );\n		}\n	}\n#endif",
+	defaultnormal_vertex: "vec3 transformedNormal = objectNormal;\n#ifdef USE_TANGENT\n	vec3 transformedTangent = objectTangent;\n#endif\n#ifdef USE_BATCHING\n	mat3 bm = mat3( batchingMatrix );\n	transformedNormal /= vec3( dot( bm[ 0 ], bm[ 0 ] ), dot( bm[ 1 ], bm[ 1 ] ), dot( bm[ 2 ], bm[ 2 ] ) );\n	transformedNormal = bm * transformedNormal;\n	#ifdef USE_TANGENT\n		transformedTangent = bm * transformedTangent;\n	#endif\n#endif\n#ifdef USE_INSTANCING\n	mat3 im = mat3( instanceMatrix );\n	transformedNormal /= vec3( dot( im[ 0 ], im[ 0 ] ), dot( im[ 1 ], im[ 1 ] ), dot( im[ 2 ], im[ 2 ] ) );\n	transformedNormal = im * transformedNormal;\n	#ifdef USE_TANGENT\n		transformedTangent = im * transformedTangent;\n	#endif\n#endif\ntransformedNormal = normalMatrix * transformedNormal;\n#ifdef FLIP_SIDED\n	transformedNormal = - transformedNormal;\n#endif\n#ifdef USE_TANGENT\n	transformedTangent = ( modelViewMatrix * vec4( transformedTangent, 0.0 ) ).xyz;\n#endif",
+	displacementmap_pars_vertex: "#ifdef USE_DISPLACEMENTMAP\n	uniform sampler2D displacementMap;\n	uniform float displacementScale;\n	uniform float displacementBias;\n#endif",
+	displacementmap_vertex: "#ifdef USE_DISPLACEMENTMAP\n	transformed += normalize( objectNormal ) * ( texture2D( displacementMap, vDisplacementMapUv ).x * displacementScale + displacementBias );\n#endif",
+	emissivemap_fragment: "#ifdef USE_EMISSIVEMAP\n	vec4 emissiveColor = texture2D( emissiveMap, vEmissiveMapUv );\n	#ifdef DECODE_VIDEO_TEXTURE_EMISSIVE\n		emissiveColor = sRGBTransferEOTF( emissiveColor );\n	#endif\n	totalEmissiveRadiance *= emissiveColor.rgb;\n#endif",
+	emissivemap_pars_fragment: "#ifdef USE_EMISSIVEMAP\n	uniform sampler2D emissiveMap;\n#endif",
+	colorspace_fragment: "gl_FragColor = linearToOutputTexel( gl_FragColor );",
+	colorspace_pars_fragment: "vec4 LinearTransferOETF( in vec4 value ) {\n	return value;\n}\nvec4 sRGBTransferEOTF( in vec4 value ) {\n	return vec4( mix( pow( value.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), value.rgb * 0.0773993808, vec3( lessThanEqual( value.rgb, vec3( 0.04045 ) ) ) ), value.a );\n}\nvec4 sRGBTransferOETF( in vec4 value ) {\n	return vec4( mix( pow( value.rgb, vec3( 0.41666 ) ) * 1.055 - vec3( 0.055 ), value.rgb * 12.92, vec3( lessThanEqual( value.rgb, vec3( 0.0031308 ) ) ) ), value.a );\n}",
+	envmap_fragment: "#ifdef USE_ENVMAP\n	#ifdef ENV_WORLDPOS\n		vec3 cameraToFrag;\n		if ( isOrthographic ) {\n			cameraToFrag = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n		} else {\n			cameraToFrag = normalize( vWorldPosition - cameraPosition );\n		}\n		vec3 worldNormal = transformNormalByInverseViewMatrix( normal, viewMatrix );\n		#ifdef ENVMAP_MODE_REFLECTION\n			vec3 reflectVec = reflect( cameraToFrag, worldNormal );\n		#else\n			vec3 reflectVec = refract( cameraToFrag, worldNormal, refractionRatio );\n		#endif\n	#else\n		vec3 reflectVec = vReflect;\n	#endif\n	#ifdef ENVMAP_TYPE_CUBE\n		vec4 envColor = textureCube( envMap, envMapRotation * reflectVec );\n		#ifdef ENVMAP_BLENDING_MULTIPLY\n			outgoingLight = mix( outgoingLight, outgoingLight * envColor.xyz, specularStrength * reflectivity );\n		#elif defined( ENVMAP_BLENDING_MIX )\n			outgoingLight = mix( outgoingLight, envColor.xyz, specularStrength * reflectivity );\n		#elif defined( ENVMAP_BLENDING_ADD )\n			outgoingLight += envColor.xyz * specularStrength * reflectivity;\n		#endif\n	#endif\n#endif",
+	envmap_common_pars_fragment: "#ifdef USE_ENVMAP\n	uniform float envMapIntensity;\n	uniform mat3 envMapRotation;\n	#ifdef ENVMAP_TYPE_CUBE\n		uniform samplerCube envMap;\n	#else\n		uniform sampler2D envMap;\n	#endif\n#endif",
+	envmap_pars_fragment: "#ifdef USE_ENVMAP\n	uniform float reflectivity;\n	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( LAMBERT )\n		#define ENV_WORLDPOS\n	#endif\n	#ifdef ENV_WORLDPOS\n		varying vec3 vWorldPosition;\n		uniform float refractionRatio;\n	#else\n		varying vec3 vReflect;\n	#endif\n#endif",
+	envmap_pars_vertex: "#ifdef USE_ENVMAP\n	#if defined( USE_BUMPMAP ) || defined( USE_NORMALMAP ) || defined( PHONG ) || defined( LAMBERT )\n		#define ENV_WORLDPOS\n	#endif\n	#ifdef ENV_WORLDPOS\n		\n		varying vec3 vWorldPosition;\n	#else\n		varying vec3 vReflect;\n		uniform float refractionRatio;\n	#endif\n#endif",
+	envmap_physical_pars_fragment: "#ifdef USE_ENVMAP\n	vec3 getIBLIrradiance( const in vec3 normal ) {\n		#ifdef ENVMAP_TYPE_CUBE_UV\n			vec3 worldNormal = transformNormalByInverseViewMatrix( normal, viewMatrix );\n			vec4 envMapColor = textureCubeUV( envMap, envMapRotation * worldNormal, 1.0 );\n			return PI * envMapColor.rgb * envMapIntensity;\n		#else\n			return vec3( 0.0 );\n		#endif\n	}\n	vec3 getIBLRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness ) {\n		#ifdef ENVMAP_TYPE_CUBE_UV\n			vec3 reflectVec = reflect( - viewDir, normal );\n			reflectVec = normalize( mix( reflectVec, normal, pow4( roughness ) ) );\n			reflectVec = transformDirectionByInverseViewMatrix( reflectVec, viewMatrix );\n			vec4 envMapColor = textureCubeUV( envMap, envMapRotation * reflectVec, roughness );\n			return envMapColor.rgb * envMapIntensity;\n		#else\n			return vec3( 0.0 );\n		#endif\n	}\n	#ifdef USE_ANISOTROPY\n		vec3 getIBLAnisotropyRadiance( const in vec3 viewDir, const in vec3 normal, const in float roughness, const in vec3 bitangent, const in float anisotropy ) {\n			#ifdef ENVMAP_TYPE_CUBE_UV\n				vec3 bentNormal = cross( bitangent, viewDir );\n				bentNormal = normalize( cross( bentNormal, bitangent ) );\n				bentNormal = normalize( mix( bentNormal, normal, pow2( pow2( 1.0 - anisotropy * ( 1.0 - roughness ) ) ) ) );\n				return getIBLRadiance( viewDir, bentNormal, roughness );\n			#else\n				return vec3( 0.0 );\n			#endif\n		}\n	#endif\n#endif",
+	envmap_vertex: "#ifdef USE_ENVMAP\n	#ifdef ENV_WORLDPOS\n		vWorldPosition = worldPosition.xyz;\n	#else\n		vec3 cameraToVertex;\n		if ( isOrthographic ) {\n			cameraToVertex = normalize( vec3( - viewMatrix[ 0 ][ 2 ], - viewMatrix[ 1 ][ 2 ], - viewMatrix[ 2 ][ 2 ] ) );\n		} else {\n			cameraToVertex = normalize( worldPosition.xyz - cameraPosition );\n		}\n		vec3 worldNormal = transformNormalByInverseViewMatrix( transformedNormal, viewMatrix );\n		#ifdef ENVMAP_MODE_REFLECTION\n			vReflect = reflect( cameraToVertex, worldNormal );\n		#else\n			vReflect = refract( cameraToVertex, worldNormal, refractionRatio );\n		#endif\n	#endif\n#endif",
+	fog_vertex: "#ifdef USE_FOG\n	vFogDepth = - mvPosition.z;\n#endif",
+	fog_pars_vertex: "#ifdef USE_FOG\n	varying float vFogDepth;\n#endif",
+	fog_fragment: "#ifdef USE_FOG\n	#ifdef FOG_EXP2\n		float fogFactor = 1.0 - exp( - fogDensity * fogDensity * vFogDepth * vFogDepth );\n	#else\n		float fogFactor = smoothstep( fogNear, fogFar, vFogDepth );\n	#endif\n	gl_FragColor.rgb = mix( gl_FragColor.rgb, fogColor, fogFactor );\n#endif",
+	fog_pars_fragment: "#ifdef USE_FOG\n	uniform vec3 fogColor;\n	varying float vFogDepth;\n	#ifdef FOG_EXP2\n		uniform float fogDensity;\n	#else\n		uniform float fogNear;\n		uniform float fogFar;\n	#endif\n#endif",
+	gradientmap_pars_fragment: "#ifdef USE_GRADIENTMAP\n	uniform sampler2D gradientMap;\n#endif\nvec3 getGradientIrradiance( vec3 normal, vec3 lightDirection ) {\n	float dotNL = dot( normal, lightDirection );\n	vec2 coord = vec2( dotNL * 0.5 + 0.5, 0.0 );\n	#ifdef USE_GRADIENTMAP\n		return vec3( texture2D( gradientMap, coord ).r );\n	#else\n		vec2 fw = fwidth( coord ) * 0.5;\n		return mix( vec3( 0.7 ), vec3( 1.0 ), smoothstep( 0.7 - fw.x, 0.7 + fw.x, coord.x ) );\n	#endif\n}",
+	lightmap_pars_fragment: "#ifdef USE_LIGHTMAP\n	uniform sampler2D lightMap;\n	uniform float lightMapIntensity;\n#endif",
+	lights_lambert_fragment: "LambertMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularStrength = specularStrength;",
+	lights_lambert_pars_fragment: "varying vec3 vViewPosition;\nstruct LambertMaterial {\n	vec3 diffuseColor;\n	float specularStrength;\n};\nvoid RE_Direct_Lambert( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {\n	float dotNL = saturate( dot( geometryNormal, directLight.direction ) );\n	vec3 irradiance = dotNL * directLight.color;\n	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );\n}\nvoid RE_IndirectDiffuse_Lambert( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in LambertMaterial material, inout ReflectedLight reflectedLight ) {\n	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );\n}\n#define RE_Direct				RE_Direct_Lambert\n#define RE_IndirectDiffuse		RE_IndirectDiffuse_Lambert",
+	lights_pars_begin: "uniform bool receiveShadow;\nuniform vec3 ambientLightColor;\n#if defined( USE_LIGHT_PROBES )\n	uniform vec3 lightProbe[ 9 ];\n#endif\nvec3 shGetIrradianceAt( in vec3 normal, in vec3 shCoefficients[ 9 ] ) {\n	float x = normal.x, y = normal.y, z = normal.z;\n	vec3 result = shCoefficients[ 0 ] * 0.886227;\n	result += shCoefficients[ 1 ] * 2.0 * 0.511664 * y;\n	result += shCoefficients[ 2 ] * 2.0 * 0.511664 * z;\n	result += shCoefficients[ 3 ] * 2.0 * 0.511664 * x;\n	result += shCoefficients[ 4 ] * 2.0 * 0.429043 * x * y;\n	result += shCoefficients[ 5 ] * 2.0 * 0.429043 * y * z;\n	result += shCoefficients[ 6 ] * ( 0.743125 * z * z - 0.247708 );\n	result += shCoefficients[ 7 ] * 2.0 * 0.429043 * x * z;\n	result += shCoefficients[ 8 ] * 0.429043 * ( x * x - y * y );\n	return result;\n}\nvec3 getLightProbeIrradiance( const in vec3 lightProbe[ 9 ], const in vec3 normal ) {\n	vec3 worldNormal = transformNormalByInverseViewMatrix( normal, viewMatrix );\n	vec3 irradiance = shGetIrradianceAt( worldNormal, lightProbe );\n	return irradiance;\n}\nvec3 getAmbientLightIrradiance( const in vec3 ambientLightColor ) {\n	vec3 irradiance = ambientLightColor;\n	return irradiance;\n}\nfloat getDistanceAttenuation( const in float lightDistance, const in float cutoffDistance, const in float decayExponent ) {\n	float distanceFalloff = 1.0 / max( pow( lightDistance, decayExponent ), 0.01 );\n	if ( cutoffDistance > 0.0 ) {\n		distanceFalloff *= pow2( saturate( 1.0 - pow4( lightDistance / cutoffDistance ) ) );\n	}\n	return distanceFalloff;\n}\nfloat getSpotAttenuation( const in float coneCosine, const in float penumbraCosine, const in float angleCosine ) {\n	return smoothstep( coneCosine, penumbraCosine, angleCosine );\n}\n#if NUM_DIR_LIGHTS > 0\n	struct DirectionalLight {\n		vec3 direction;\n		vec3 color;\n	};\n	uniform DirectionalLight directionalLights[ NUM_DIR_LIGHTS ];\n	void getDirectionalLightInfo( const in DirectionalLight directionalLight, out IncidentLight light ) {\n		light.color = directionalLight.color;\n		light.direction = directionalLight.direction;\n		light.visible = true;\n	}\n#endif\n#if NUM_POINT_LIGHTS > 0\n	struct PointLight {\n		vec3 position;\n		vec3 color;\n		float distance;\n		float decay;\n	};\n	uniform PointLight pointLights[ NUM_POINT_LIGHTS ];\n	void getPointLightInfo( const in PointLight pointLight, const in vec3 geometryPosition, out IncidentLight light ) {\n		vec3 lVector = pointLight.position - geometryPosition;\n		light.direction = normalize( lVector );\n		float lightDistance = length( lVector );\n		light.color = pointLight.color;\n		light.color *= getDistanceAttenuation( lightDistance, pointLight.distance, pointLight.decay );\n		light.visible = ( light.color != vec3( 0.0 ) );\n	}\n#endif\n#if NUM_SPOT_LIGHTS > 0\n	struct SpotLight {\n		vec3 position;\n		vec3 direction;\n		vec3 color;\n		float distance;\n		float decay;\n		float coneCos;\n		float penumbraCos;\n	};\n	uniform SpotLight spotLights[ NUM_SPOT_LIGHTS ];\n	void getSpotLightInfo( const in SpotLight spotLight, const in vec3 geometryPosition, out IncidentLight light ) {\n		vec3 lVector = spotLight.position - geometryPosition;\n		light.direction = normalize( lVector );\n		float angleCos = dot( light.direction, spotLight.direction );\n		float spotAttenuation = getSpotAttenuation( spotLight.coneCos, spotLight.penumbraCos, angleCos );\n		if ( spotAttenuation > 0.0 ) {\n			float lightDistance = length( lVector );\n			light.color = spotLight.color * spotAttenuation;\n			light.color *= getDistanceAttenuation( lightDistance, spotLight.distance, spotLight.decay );\n			light.visible = ( light.color != vec3( 0.0 ) );\n		} else {\n			light.color = vec3( 0.0 );\n			light.visible = false;\n		}\n	}\n#endif\n#if NUM_RECT_AREA_LIGHTS > 0\n	struct RectAreaLight {\n		vec3 color;\n		vec3 position;\n		vec3 halfWidth;\n		vec3 halfHeight;\n	};\n	uniform sampler2D ltc_1;	uniform sampler2D ltc_2;\n	uniform RectAreaLight rectAreaLights[ NUM_RECT_AREA_LIGHTS ];\n#endif\n#if NUM_HEMI_LIGHTS > 0\n	struct HemisphereLight {\n		vec3 direction;\n		vec3 skyColor;\n		vec3 groundColor;\n	};\n	uniform HemisphereLight hemisphereLights[ NUM_HEMI_LIGHTS ];\n	vec3 getHemisphereLightIrradiance( const in HemisphereLight hemiLight, const in vec3 normal ) {\n		float dotNL = dot( normal, hemiLight.direction );\n		float hemiDiffuseWeight = 0.5 * dotNL + 0.5;\n		vec3 irradiance = mix( hemiLight.groundColor, hemiLight.skyColor, hemiDiffuseWeight );\n		return irradiance;\n	}\n#endif\n#include <lightprobes_pars_fragment>",
+	lights_toon_fragment: "ToonMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;",
+	lights_toon_pars_fragment: "varying vec3 vViewPosition;\nstruct ToonMaterial {\n	vec3 diffuseColor;\n};\nvoid RE_Direct_Toon( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {\n	vec3 irradiance = getGradientIrradiance( geometryNormal, directLight.direction ) * directLight.color;\n	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );\n}\nvoid RE_IndirectDiffuse_Toon( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in ToonMaterial material, inout ReflectedLight reflectedLight ) {\n	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );\n}\n#define RE_Direct				RE_Direct_Toon\n#define RE_IndirectDiffuse		RE_IndirectDiffuse_Toon",
+	lights_phong_fragment: "BlinnPhongMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.specularColor = specular;\nmaterial.specularShininess = shininess;\nmaterial.specularStrength = specularStrength;",
+	lights_phong_pars_fragment: "varying vec3 vViewPosition;\nstruct BlinnPhongMaterial {\n	vec3 diffuseColor;\n	vec3 specularColor;\n	float specularShininess;\n	float specularStrength;\n};\nvoid RE_Direct_BlinnPhong( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n	float dotNL = saturate( dot( geometryNormal, directLight.direction ) );\n	vec3 irradiance = dotNL * directLight.color;\n	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );\n	reflectedLight.directSpecular += irradiance * BRDF_BlinnPhong( directLight.direction, geometryViewDir, geometryNormal, material.specularColor, material.specularShininess ) * material.specularStrength;\n}\nvoid RE_IndirectDiffuse_BlinnPhong( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in BlinnPhongMaterial material, inout ReflectedLight reflectedLight ) {\n	reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );\n}\n#define RE_Direct				RE_Direct_BlinnPhong\n#define RE_IndirectDiffuse		RE_IndirectDiffuse_BlinnPhong",
+	lights_physical_fragment: "PhysicalMaterial material;\nmaterial.diffuseColor = diffuseColor.rgb;\nmaterial.diffuseContribution = diffuseColor.rgb * ( 1.0 - metalnessFactor );\nmaterial.metalness = metalnessFactor;\nvec3 dxy = max( abs( dFdx( nonPerturbedNormal ) ), abs( dFdy( nonPerturbedNormal ) ) );\nfloat geometryRoughness = max( max( dxy.x, dxy.y ), dxy.z );\nmaterial.roughness = max( roughnessFactor, 0.0525 );material.roughness += geometryRoughness;\nmaterial.roughness = min( material.roughness, 1.0 );\n#ifdef IOR\n	material.ior = ior;\n	#ifdef USE_SPECULAR\n		float specularIntensityFactor = specularIntensity;\n		vec3 specularColorFactor = specularColor;\n		#ifdef USE_SPECULAR_COLORMAP\n			specularColorFactor *= texture2D( specularColorMap, vSpecularColorMapUv ).rgb;\n		#endif\n		#ifdef USE_SPECULAR_INTENSITYMAP\n			specularIntensityFactor *= texture2D( specularIntensityMap, vSpecularIntensityMapUv ).a;\n		#endif\n		material.specularF90 = mix( specularIntensityFactor, 1.0, metalnessFactor );\n	#else\n		float specularIntensityFactor = 1.0;\n		vec3 specularColorFactor = vec3( 1.0 );\n		material.specularF90 = 1.0;\n	#endif\n	material.specularColor = min( pow2( ( material.ior - 1.0 ) / ( material.ior + 1.0 ) ) * specularColorFactor, vec3( 1.0 ) ) * specularIntensityFactor;\n	material.specularColorBlended = mix( material.specularColor, diffuseColor.rgb, metalnessFactor );\n#else\n	material.specularColor = vec3( 0.04 );\n	material.specularColorBlended = mix( material.specularColor, diffuseColor.rgb, metalnessFactor );\n	material.specularF90 = 1.0;\n#endif\n#ifdef USE_CLEARCOAT\n	material.clearcoat = clearcoat;\n	material.clearcoatRoughness = clearcoatRoughness;\n	material.clearcoatF0 = vec3( 0.04 );\n	material.clearcoatF90 = 1.0;\n	#ifdef USE_CLEARCOATMAP\n		material.clearcoat *= texture2D( clearcoatMap, vClearcoatMapUv ).x;\n	#endif\n	#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n		material.clearcoatRoughness *= texture2D( clearcoatRoughnessMap, vClearcoatRoughnessMapUv ).y;\n	#endif\n	material.clearcoat = saturate( material.clearcoat );	material.clearcoatRoughness = max( material.clearcoatRoughness, 0.0525 );\n	material.clearcoatRoughness += geometryRoughness;\n	material.clearcoatRoughness = min( material.clearcoatRoughness, 1.0 );\n#endif\n#ifdef USE_DISPERSION\n	material.dispersion = dispersion;\n#endif\n#ifdef USE_IRIDESCENCE\n	material.iridescence = iridescence;\n	material.iridescenceIOR = iridescenceIOR;\n	#ifdef USE_IRIDESCENCEMAP\n		material.iridescence *= texture2D( iridescenceMap, vIridescenceMapUv ).r;\n	#endif\n	#ifdef USE_IRIDESCENCE_THICKNESSMAP\n		material.iridescenceThickness = (iridescenceThicknessMaximum - iridescenceThicknessMinimum) * texture2D( iridescenceThicknessMap, vIridescenceThicknessMapUv ).g + iridescenceThicknessMinimum;\n	#else\n		material.iridescenceThickness = iridescenceThicknessMaximum;\n	#endif\n#endif\n#ifdef USE_SHEEN\n	material.sheenColor = sheenColor;\n	#ifdef USE_SHEEN_COLORMAP\n		material.sheenColor *= texture2D( sheenColorMap, vSheenColorMapUv ).rgb;\n	#endif\n	material.sheenRoughness = clamp( sheenRoughness, 0.0001, 1.0 );\n	#ifdef USE_SHEEN_ROUGHNESSMAP\n		material.sheenRoughness *= texture2D( sheenRoughnessMap, vSheenRoughnessMapUv ).a;\n	#endif\n#endif\n#ifdef USE_ANISOTROPY\n	#ifdef USE_ANISOTROPYMAP\n		mat2 anisotropyMat = mat2( anisotropyVector.x, anisotropyVector.y, - anisotropyVector.y, anisotropyVector.x );\n		vec3 anisotropyPolar = texture2D( anisotropyMap, vAnisotropyMapUv ).rgb;\n		vec2 anisotropyV = anisotropyMat * normalize( 2.0 * anisotropyPolar.rg - vec2( 1.0 ) ) * anisotropyPolar.b;\n	#else\n		vec2 anisotropyV = anisotropyVector;\n	#endif\n	material.anisotropy = length( anisotropyV );\n	if( material.anisotropy == 0.0 ) {\n		anisotropyV = vec2( 1.0, 0.0 );\n	} else {\n		anisotropyV /= material.anisotropy;\n		material.anisotropy = saturate( material.anisotropy );\n	}\n	material.alphaT = mix( pow2( material.roughness ), 1.0, pow2( material.anisotropy ) );\n	material.anisotropyT = tbn[ 0 ] * anisotropyV.x + tbn[ 1 ] * anisotropyV.y;\n	material.anisotropyB = tbn[ 1 ] * anisotropyV.x - tbn[ 0 ] * anisotropyV.y;\n#endif",
+	lights_physical_pars_fragment: "uniform sampler2D dfgLUT;\nstruct PhysicalMaterial {\n	vec3 diffuseColor;\n	vec3 diffuseContribution;\n	vec3 specularColor;\n	vec3 specularColorBlended;\n	float roughness;\n	float metalness;\n	float specularF90;\n	float dispersion;\n	#ifdef USE_CLEARCOAT\n		float clearcoat;\n		float clearcoatRoughness;\n		vec3 clearcoatF0;\n		float clearcoatF90;\n	#endif\n	#ifdef USE_IRIDESCENCE\n		float iridescence;\n		float iridescenceIOR;\n		float iridescenceThickness;\n		vec3 iridescenceFresnel;\n		vec3 iridescenceF0;\n		vec3 iridescenceFresnelDielectric;\n		vec3 iridescenceFresnelMetallic;\n	#endif\n	#ifdef USE_SHEEN\n		vec3 sheenColor;\n		float sheenRoughness;\n	#endif\n	#ifdef IOR\n		float ior;\n	#endif\n	#ifdef USE_TRANSMISSION\n		float transmission;\n		float transmissionAlpha;\n		float thickness;\n		float attenuationDistance;\n		vec3 attenuationColor;\n	#endif\n	#ifdef USE_ANISOTROPY\n		float anisotropy;\n		float alphaT;\n		vec3 anisotropyT;\n		vec3 anisotropyB;\n	#endif\n};\nvec3 clearcoatSpecularDirect = vec3( 0.0 );\nvec3 clearcoatSpecularIndirect = vec3( 0.0 );\nvec3 sheenSpecularDirect = vec3( 0.0 );\nvec3 sheenSpecularIndirect = vec3(0.0 );\nvec3 Schlick_to_F0( const in vec3 f, const in float f90, const in float dotVH ) {\n    float x = clamp( 1.0 - dotVH, 0.0, 1.0 );\n    float x2 = x * x;\n    float x5 = clamp( x * x2 * x2, 0.0, 0.9999 );\n    return ( f - vec3( f90 ) * x5 ) / ( 1.0 - x5 );\n}\nfloat V_GGX_SmithCorrelated( const in float alpha, const in float dotNL, const in float dotNV ) {\n	float a2 = pow2( alpha );\n	float gv = dotNL * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNV ) );\n	float gl = dotNV * sqrt( a2 + ( 1.0 - a2 ) * pow2( dotNL ) );\n	return 0.5 / max( gv + gl, EPSILON );\n}\nfloat D_GGX( const in float alpha, const in float dotNH ) {\n	float a2 = pow2( alpha );\n	float denom = pow2( dotNH ) * ( a2 - 1.0 ) + 1.0;\n	return RECIPROCAL_PI * a2 / pow2( denom );\n}\n#ifdef USE_ANISOTROPY\n	float V_GGX_SmithCorrelated_Anisotropic( const in float alphaT, const in float alphaB, const in float dotTV, const in float dotBV, const in float dotTL, const in float dotBL, const in float dotNV, const in float dotNL ) {\n		float gv = dotNL * length( vec3( alphaT * dotTV, alphaB * dotBV, dotNV ) );\n		float gl = dotNV * length( vec3( alphaT * dotTL, alphaB * dotBL, dotNL ) );\n		return 0.5 / max( gv + gl, EPSILON );\n	}\n	float D_GGX_Anisotropic( const in float alphaT, const in float alphaB, const in float dotNH, const in float dotTH, const in float dotBH ) {\n		float a2 = alphaT * alphaB;\n		highp vec3 v = vec3( alphaB * dotTH, alphaT * dotBH, a2 * dotNH );\n		highp float v2 = dot( v, v );\n		float w2 = a2 / v2;\n		return RECIPROCAL_PI * a2 * pow2 ( w2 );\n	}\n#endif\n#ifdef USE_CLEARCOAT\n	vec3 BRDF_GGX_Clearcoat( const in vec3 lightDir, const in vec3 viewDir, const in vec3 normal, const in PhysicalMaterial material) {\n		vec3 f0 = material.clearcoatF0;\n		float f90 = material.clearcoatF90;\n		float roughness = material.clearcoatRoughness;\n		float alpha = pow2( roughness );\n		vec3 halfDir = normalize( lightDir + viewDir );\n		float dotNL = saturate( dot( normal, lightDir ) );\n		float dotNV = saturate( dot( normal, viewDir ) );\n		float dotNH = saturate( dot( normal, halfDir ) );\n		float dotVH = saturate( dot( viewDir, halfDir ) );\n		vec3 F = F_Schlick( f0, f90, dotVH );\n		float V = V_GGX_SmithCorrelated( alpha, dotNL, dotNV );\n		float D = D_GGX( alpha, dotNH );\n		return F * ( V * D );\n	}\n#endif\nvec3 BRDF_GGX( const in vec3 lightDir, const in vec3 viewDir, const in vec3 normal, const in PhysicalMaterial material ) {\n	vec3 f0 = material.specularColorBlended;\n	float f90 = material.specularF90;\n	float roughness = material.roughness;\n	float alpha = pow2( roughness );\n	vec3 halfDir = normalize( lightDir + viewDir );\n	float dotNL = saturate( dot( normal, lightDir ) );\n	float dotNV = saturate( dot( normal, viewDir ) );\n	float dotNH = saturate( dot( normal, halfDir ) );\n	float dotVH = saturate( dot( viewDir, halfDir ) );\n	vec3 F = F_Schlick( f0, f90, dotVH );\n	#ifdef USE_IRIDESCENCE\n		F = mix( F, material.iridescenceFresnel, material.iridescence );\n	#endif\n	#ifdef USE_ANISOTROPY\n		float dotTL = dot( material.anisotropyT, lightDir );\n		float dotTV = dot( material.anisotropyT, viewDir );\n		float dotTH = dot( material.anisotropyT, halfDir );\n		float dotBL = dot( material.anisotropyB, lightDir );\n		float dotBV = dot( material.anisotropyB, viewDir );\n		float dotBH = dot( material.anisotropyB, halfDir );\n		float V = V_GGX_SmithCorrelated_Anisotropic( material.alphaT, alpha, dotTV, dotBV, dotTL, dotBL, dotNV, dotNL );\n		float D = D_GGX_Anisotropic( material.alphaT, alpha, dotNH, dotTH, dotBH );\n	#else\n		float V = V_GGX_SmithCorrelated( alpha, dotNL, dotNV );\n		float D = D_GGX( alpha, dotNH );\n	#endif\n	return F * ( V * D );\n}\nvec2 LTC_Uv( const in vec3 N, const in vec3 V, const in float roughness ) {\n	const float LUT_SIZE = 64.0;\n	const float LUT_SCALE = ( LUT_SIZE - 1.0 ) / LUT_SIZE;\n	const float LUT_BIAS = 0.5 / LUT_SIZE;\n	float dotNV = saturate( dot( N, V ) );\n	vec2 uv = vec2( roughness, sqrt( 1.0 - dotNV ) );\n	uv = uv * LUT_SCALE + LUT_BIAS;\n	return uv;\n}\nfloat LTC_ClippedSphereFormFactor( const in vec3 f ) {\n	float l = length( f );\n	return max( ( l * l + f.z ) / ( l + 1.0 ), 0.0 );\n}\nvec3 LTC_EdgeVectorFormFactor( const in vec3 v1, const in vec3 v2 ) {\n	float x = dot( v1, v2 );\n	float y = abs( x );\n	float a = 0.8543985 + ( 0.4965155 + 0.0145206 * y ) * y;\n	float b = 3.4175940 + ( 4.1616724 + y ) * y;\n	float v = a / b;\n	float theta_sintheta = ( x > 0.0 ) ? v : 0.5 * inversesqrt( max( 1.0 - x * x, 1e-7 ) ) - v;\n	return cross( v1, v2 ) * theta_sintheta;\n}\nvec3 LTC_Evaluate( const in vec3 N, const in vec3 V, const in vec3 P, const in mat3 mInv, const in vec3 rectCoords[ 4 ] ) {\n	vec3 v1 = rectCoords[ 1 ] - rectCoords[ 0 ];\n	vec3 v2 = rectCoords[ 3 ] - rectCoords[ 0 ];\n	vec3 lightNormal = cross( v1, v2 );\n	if( dot( lightNormal, P - rectCoords[ 0 ] ) < 0.0 ) return vec3( 0.0 );\n	vec3 T1, T2;\n	T1 = normalize( V - N * dot( V, N ) );\n	T2 = - cross( N, T1 );\n	mat3 mat = mInv * transpose( mat3( T1, T2, N ) );\n	vec3 coords[ 4 ];\n	coords[ 0 ] = mat * ( rectCoords[ 0 ] - P );\n	coords[ 1 ] = mat * ( rectCoords[ 1 ] - P );\n	coords[ 2 ] = mat * ( rectCoords[ 2 ] - P );\n	coords[ 3 ] = mat * ( rectCoords[ 3 ] - P );\n	coords[ 0 ] = normalize( coords[ 0 ] );\n	coords[ 1 ] = normalize( coords[ 1 ] );\n	coords[ 2 ] = normalize( coords[ 2 ] );\n	coords[ 3 ] = normalize( coords[ 3 ] );\n	vec3 vectorFormFactor = vec3( 0.0 );\n	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 0 ], coords[ 1 ] );\n	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 1 ], coords[ 2 ] );\n	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 2 ], coords[ 3 ] );\n	vectorFormFactor += LTC_EdgeVectorFormFactor( coords[ 3 ], coords[ 0 ] );\n	float result = LTC_ClippedSphereFormFactor( vectorFormFactor );\n	return vec3( result );\n}\n#if defined( USE_SHEEN )\nfloat D_Charlie( float roughness, float dotNH ) {\n	float alpha = pow2( roughness );\n	float invAlpha = 1.0 / alpha;\n	float cos2h = dotNH * dotNH;\n	float sin2h = max( 1.0 - cos2h, 0.0078125 );\n	return ( 2.0 + invAlpha ) * pow( sin2h, invAlpha * 0.5 ) / ( 2.0 * PI );\n}\nfloat V_Neubelt( float dotNV, float dotNL ) {\n	return saturate( 1.0 / ( 4.0 * ( dotNL + dotNV - dotNL * dotNV ) ) );\n}\nvec3 BRDF_Sheen( const in vec3 lightDir, const in vec3 viewDir, const in vec3 normal, vec3 sheenColor, const in float sheenRoughness ) {\n	vec3 halfDir = normalize( lightDir + viewDir );\n	float dotNL = saturate( dot( normal, lightDir ) );\n	float dotNV = saturate( dot( normal, viewDir ) );\n	float dotNH = saturate( dot( normal, halfDir ) );\n	float D = D_Charlie( sheenRoughness, dotNH );\n	float V = V_Neubelt( dotNV, dotNL );\n	return sheenColor * ( D * V );\n}\n#endif\nfloat IBLSheenBRDF( const in vec3 normal, const in vec3 viewDir, const in float roughness ) {\n	float dotNV = saturate( dot( normal, viewDir ) );\n	float r2 = roughness * roughness;\n	float rInv = 1.0 / ( roughness + 0.1 );\n	float a = -1.9362 + 1.0678 * roughness + 0.4573 * r2 - 0.8469 * rInv;\n	float b = -0.6014 + 0.5538 * roughness - 0.4670 * r2 - 0.1255 * rInv;\n	float DG = exp( a * dotNV + b );\n	return saturate( DG );\n}\nvec3 EnvironmentBRDF( const in vec3 normal, const in vec3 viewDir, const in vec3 specularColor, const in float specularF90, const in float roughness ) {\n	float dotNV = saturate( dot( normal, viewDir ) );\n	vec2 fab = texture2D( dfgLUT, vec2( roughness, dotNV ) ).rg;\n	return specularColor * fab.x + specularF90 * fab.y;\n}\n#ifdef USE_IRIDESCENCE\nvoid computeMultiscatteringIridescence( const in vec3 normal, const in vec3 viewDir, const in vec3 specularColor, const in float specularF90, const in float iridescence, const in vec3 iridescenceF0, const in float roughness, inout vec3 singleScatter, inout vec3 multiScatter ) {\n#else\nvoid computeMultiscattering( const in vec3 normal, const in vec3 viewDir, const in vec3 specularColor, const in float specularF90, const in float roughness, inout vec3 singleScatter, inout vec3 multiScatter ) {\n#endif\n	float dotNV = saturate( dot( normal, viewDir ) );\n	vec2 fab = texture2D( dfgLUT, vec2( roughness, dotNV ) ).rg;\n	#ifdef USE_IRIDESCENCE\n		vec3 Fr = mix( specularColor, iridescenceF0, iridescence );\n	#else\n		vec3 Fr = specularColor;\n	#endif\n	vec3 FssEss = Fr * fab.x + specularF90 * fab.y;\n	float Ess = fab.x + fab.y;\n	float Ems = 1.0 - Ess;\n	vec3 Favg = Fr + ( 1.0 - Fr ) * 0.047619;	vec3 Fms = FssEss * Favg / ( 1.0 - Ems * Favg );\n	singleScatter += FssEss;\n	multiScatter += Fms * Ems;\n}\nvec3 BRDF_GGX_Multiscatter( const in vec3 lightDir, const in vec3 viewDir, const in vec3 normal, const in PhysicalMaterial material ) {\n	vec3 singleScatter = BRDF_GGX( lightDir, viewDir, normal, material );\n	float dotNL = saturate( dot( normal, lightDir ) );\n	float dotNV = saturate( dot( normal, viewDir ) );\n	vec2 dfgV = texture2D( dfgLUT, vec2( material.roughness, dotNV ) ).rg;\n	vec2 dfgL = texture2D( dfgLUT, vec2( material.roughness, dotNL ) ).rg;\n	vec3 FssEss_V = material.specularColorBlended * dfgV.x + material.specularF90 * dfgV.y;\n	vec3 FssEss_L = material.specularColorBlended * dfgL.x + material.specularF90 * dfgL.y;\n	float Ess_V = dfgV.x + dfgV.y;\n	float Ess_L = dfgL.x + dfgL.y;\n	float Ems_V = 1.0 - Ess_V;\n	float Ems_L = 1.0 - Ess_L;\n	vec3 Favg = material.specularColorBlended + ( 1.0 - material.specularColorBlended ) * 0.047619;\n	vec3 Fms = FssEss_V * FssEss_L * Favg / ( 1.0 - Ems_V * Ems_L * Favg + EPSILON );\n	float compensationFactor = Ems_V * Ems_L;\n	vec3 multiScatter = Fms * compensationFactor;\n	return singleScatter + multiScatter;\n}\n#if NUM_RECT_AREA_LIGHTS > 0\n	void RE_Direct_RectArea_Physical( const in RectAreaLight rectAreaLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n		vec3 normal = geometryNormal;\n		vec3 viewDir = geometryViewDir;\n		vec3 position = geometryPosition;\n		vec3 lightPos = rectAreaLight.position;\n		vec3 halfWidth = rectAreaLight.halfWidth;\n		vec3 halfHeight = rectAreaLight.halfHeight;\n		vec3 lightColor = rectAreaLight.color;\n		float roughness = material.roughness;\n		vec3 rectCoords[ 4 ];\n		rectCoords[ 0 ] = lightPos + halfWidth - halfHeight;		rectCoords[ 1 ] = lightPos - halfWidth - halfHeight;\n		rectCoords[ 2 ] = lightPos - halfWidth + halfHeight;\n		rectCoords[ 3 ] = lightPos + halfWidth + halfHeight;\n		vec2 uv = LTC_Uv( normal, viewDir, roughness );\n		vec4 t1 = texture2D( ltc_1, uv );\n		vec4 t2 = texture2D( ltc_2, uv );\n		mat3 mInv = mat3(\n			vec3( t1.x, 0, t1.y ),\n			vec3(    0, 1,    0 ),\n			vec3( t1.z, 0, t1.w )\n		);\n		vec3 fresnel = ( material.specularColorBlended * t2.x + ( material.specularF90 - material.specularColorBlended ) * t2.y );\n		reflectedLight.directSpecular += lightColor * fresnel * LTC_Evaluate( normal, viewDir, position, mInv, rectCoords );\n		reflectedLight.directDiffuse += lightColor * material.diffuseContribution * LTC_Evaluate( normal, viewDir, position, mat3( 1.0 ), rectCoords );\n		#ifdef USE_CLEARCOAT\n			vec3 Ncc = geometryClearcoatNormal;\n			vec2 uvClearcoat = LTC_Uv( Ncc, viewDir, material.clearcoatRoughness );\n			vec4 t1Clearcoat = texture2D( ltc_1, uvClearcoat );\n			vec4 t2Clearcoat = texture2D( ltc_2, uvClearcoat );\n			mat3 mInvClearcoat = mat3(\n				vec3( t1Clearcoat.x, 0, t1Clearcoat.y ),\n				vec3(             0, 1,             0 ),\n				vec3( t1Clearcoat.z, 0, t1Clearcoat.w )\n			);\n			vec3 fresnelClearcoat = material.clearcoatF0 * t2Clearcoat.x + ( material.clearcoatF90 - material.clearcoatF0 ) * t2Clearcoat.y;\n			clearcoatSpecularDirect += lightColor * fresnelClearcoat * LTC_Evaluate( Ncc, viewDir, position, mInvClearcoat, rectCoords );\n		#endif\n	}\n#endif\nvoid RE_Direct_Physical( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n	float dotNL = saturate( dot( geometryNormal, directLight.direction ) );\n	vec3 irradiance = dotNL * directLight.color;\n	#ifdef USE_CLEARCOAT\n		float dotNLcc = saturate( dot( geometryClearcoatNormal, directLight.direction ) );\n		vec3 ccIrradiance = dotNLcc * directLight.color;\n		clearcoatSpecularDirect += ccIrradiance * BRDF_GGX_Clearcoat( directLight.direction, geometryViewDir, geometryClearcoatNormal, material );\n	#endif\n	#ifdef USE_SHEEN\n \n 		sheenSpecularDirect += irradiance * BRDF_Sheen( directLight.direction, geometryViewDir, geometryNormal, material.sheenColor, material.sheenRoughness );\n \n 		float sheenAlbedoV = IBLSheenBRDF( geometryNormal, geometryViewDir, material.sheenRoughness );\n 		float sheenAlbedoL = IBLSheenBRDF( geometryNormal, directLight.direction, material.sheenRoughness );\n \n 		float sheenEnergyComp = 1.0 - max3( material.sheenColor ) * max( sheenAlbedoV, sheenAlbedoL );\n \n 		irradiance *= sheenEnergyComp;\n \n 	#endif\n	reflectedLight.directSpecular += irradiance * BRDF_GGX_Multiscatter( directLight.direction, geometryViewDir, geometryNormal, material );\n	reflectedLight.directDiffuse += irradiance * BRDF_Lambert( material.diffuseContribution );\n}\nvoid RE_IndirectDiffuse_Physical( const in vec3 irradiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight ) {\n	vec3 diffuse = irradiance * BRDF_Lambert( material.diffuseContribution );\n	#ifdef USE_SHEEN\n		float sheenAlbedo = IBLSheenBRDF( geometryNormal, geometryViewDir, material.sheenRoughness );\n		float sheenEnergyComp = 1.0 - max3( material.sheenColor ) * sheenAlbedo;\n		diffuse *= sheenEnergyComp;\n	#endif\n	reflectedLight.indirectDiffuse += diffuse;\n}\nvoid RE_IndirectSpecular_Physical( const in vec3 radiance, const in vec3 irradiance, const in vec3 clearcoatRadiance, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in PhysicalMaterial material, inout ReflectedLight reflectedLight) {\n	#ifdef USE_CLEARCOAT\n		clearcoatSpecularIndirect += clearcoatRadiance * EnvironmentBRDF( geometryClearcoatNormal, geometryViewDir, material.clearcoatF0, material.clearcoatF90, material.clearcoatRoughness );\n	#endif\n	#ifdef USE_SHEEN\n		sheenSpecularIndirect += irradiance * material.sheenColor * IBLSheenBRDF( geometryNormal, geometryViewDir, material.sheenRoughness ) * RECIPROCAL_PI;\n 	#endif\n	vec3 singleScatteringDielectric = vec3( 0.0 );\n	vec3 multiScatteringDielectric = vec3( 0.0 );\n	vec3 singleScatteringMetallic = vec3( 0.0 );\n	vec3 multiScatteringMetallic = vec3( 0.0 );\n	#ifdef USE_IRIDESCENCE\n		computeMultiscatteringIridescence( geometryNormal, geometryViewDir, material.specularColor, material.specularF90, material.iridescence, material.iridescenceFresnelDielectric, material.roughness, singleScatteringDielectric, multiScatteringDielectric );\n		computeMultiscatteringIridescence( geometryNormal, geometryViewDir, material.diffuseColor, material.specularF90, material.iridescence, material.iridescenceFresnelMetallic, material.roughness, singleScatteringMetallic, multiScatteringMetallic );\n	#else\n		computeMultiscattering( geometryNormal, geometryViewDir, material.specularColor, material.specularF90, material.roughness, singleScatteringDielectric, multiScatteringDielectric );\n		computeMultiscattering( geometryNormal, geometryViewDir, material.diffuseColor, material.specularF90, material.roughness, singleScatteringMetallic, multiScatteringMetallic );\n	#endif\n	vec3 singleScattering = mix( singleScatteringDielectric, singleScatteringMetallic, material.metalness );\n	vec3 multiScattering = mix( multiScatteringDielectric, multiScatteringMetallic, material.metalness );\n	vec3 totalScatteringDielectric = singleScatteringDielectric + multiScatteringDielectric;\n	vec3 diffuse = material.diffuseContribution * ( 1.0 - totalScatteringDielectric );\n	vec3 cosineWeightedIrradiance = irradiance * RECIPROCAL_PI;\n	vec3 indirectSpecular = radiance * singleScattering;\n	indirectSpecular += multiScattering * cosineWeightedIrradiance;\n	vec3 indirectDiffuse = diffuse * cosineWeightedIrradiance;\n	#ifdef USE_SHEEN\n		float sheenAlbedo = IBLSheenBRDF( geometryNormal, geometryViewDir, material.sheenRoughness );\n		float sheenEnergyComp = 1.0 - max3( material.sheenColor ) * sheenAlbedo;\n		indirectSpecular *= sheenEnergyComp;\n		indirectDiffuse *= sheenEnergyComp;\n	#endif\n	reflectedLight.indirectSpecular += indirectSpecular;\n	reflectedLight.indirectDiffuse += indirectDiffuse;\n}\n#define RE_Direct				RE_Direct_Physical\n#define RE_Direct_RectArea		RE_Direct_RectArea_Physical\n#define RE_IndirectDiffuse		RE_IndirectDiffuse_Physical\n#define RE_IndirectSpecular		RE_IndirectSpecular_Physical\nfloat computeSpecularOcclusion( const in float dotNV, const in float ambientOcclusion, const in float roughness ) {\n	return saturate( pow( dotNV + ambientOcclusion, exp2( - 16.0 * roughness - 1.0 ) ) - 1.0 + ambientOcclusion );\n}",
+	lights_fragment_begin: "\nvec3 geometryPosition = - vViewPosition;\nvec3 geometryNormal = normal;\nvec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );\nvec3 geometryClearcoatNormal = vec3( 0.0 );\n#ifdef USE_CLEARCOAT\n	geometryClearcoatNormal = clearcoatNormal;\n#endif\n#ifdef USE_IRIDESCENCE\n	float dotNVi = saturate( dot( normal, geometryViewDir ) );\n	if ( material.iridescenceThickness == 0.0 ) {\n		material.iridescence = 0.0;\n	} else {\n		material.iridescence = saturate( material.iridescence );\n	}\n	if ( material.iridescence > 0.0 ) {\n		material.iridescenceFresnelDielectric = evalIridescence( 1.0, material.iridescenceIOR, dotNVi, material.iridescenceThickness, material.specularColor );\n		material.iridescenceFresnelMetallic = evalIridescence( 1.0, material.iridescenceIOR, dotNVi, material.iridescenceThickness, material.diffuseColor );\n		material.iridescenceFresnel = mix( material.iridescenceFresnelDielectric, material.iridescenceFresnelMetallic, material.metalness );\n		material.iridescenceF0 = Schlick_to_F0( material.iridescenceFresnel, 1.0, dotNVi );\n	}\n#endif\nIncidentLight directLight;\n#if ( NUM_POINT_LIGHTS > 0 ) && defined( RE_Direct )\n	PointLight pointLight;\n	#if defined( USE_SHADOWMAP ) && NUM_POINT_LIGHT_SHADOWS > 0\n	PointLightShadow pointLightShadow;\n	#endif\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_POINT_LIGHTS; i ++ ) {\n		pointLight = pointLights[ i ];\n		getPointLightInfo( pointLight, geometryPosition, directLight );\n		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS ) && ( defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_BASIC ) )\n		pointLightShadow = pointLightShadows[ i ];\n		directLight.color *= ( directLight.visible && receiveShadow ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowIntensity, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;\n		#endif\n		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );\n	}\n	#pragma unroll_loop_end\n#endif\n#if ( NUM_SPOT_LIGHTS > 0 ) && defined( RE_Direct )\n	SpotLight spotLight;\n	vec4 spotColor;\n	vec3 spotLightCoord;\n	bool inSpotLightMap;\n	#if defined( USE_SHADOWMAP ) && NUM_SPOT_LIGHT_SHADOWS > 0\n	SpotLightShadow spotLightShadow;\n	#endif\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_SPOT_LIGHTS; i ++ ) {\n		spotLight = spotLights[ i ];\n		getSpotLightInfo( spotLight, geometryPosition, directLight );\n		#if ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS )\n		#define SPOT_LIGHT_MAP_INDEX UNROLLED_LOOP_INDEX\n		#elif ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )\n		#define SPOT_LIGHT_MAP_INDEX NUM_SPOT_LIGHT_MAPS\n		#else\n		#define SPOT_LIGHT_MAP_INDEX ( UNROLLED_LOOP_INDEX - NUM_SPOT_LIGHT_SHADOWS + NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS )\n		#endif\n		#if ( SPOT_LIGHT_MAP_INDEX < NUM_SPOT_LIGHT_MAPS )\n			spotLightCoord = vSpotLightCoord[ i ].xyz / vSpotLightCoord[ i ].w;\n			inSpotLightMap = all( lessThan( abs( spotLightCoord * 2. - 1. ), vec3( 1.0 ) ) );\n			spotColor = texture2D( spotLightMap[ SPOT_LIGHT_MAP_INDEX ], spotLightCoord.xy );\n			directLight.color = inSpotLightMap ? directLight.color * spotColor.rgb : directLight.color;\n		#endif\n		#undef SPOT_LIGHT_MAP_INDEX\n		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )\n		spotLightShadow = spotLightShadows[ i ];\n		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowIntensity, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;\n		#endif\n		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );\n	}\n	#pragma unroll_loop_end\n#endif\n#if ( NUM_DIR_LIGHTS > 0 ) && defined( RE_Direct )\n	DirectionalLight directionalLight;\n	#if defined( USE_SHADOWMAP ) && NUM_DIR_LIGHT_SHADOWS > 0\n	DirectionalLightShadow directionalLightShadow;\n	#endif\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_DIR_LIGHTS; i ++ ) {\n		directionalLight = directionalLights[ i ];\n		getDirectionalLightInfo( directionalLight, directLight );\n		#if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )\n		directionalLightShadow = directionalLightShadows[ i ];\n		directLight.color *= ( directLight.visible && receiveShadow ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowIntensity, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n		#endif\n		RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );\n	}\n	#pragma unroll_loop_end\n#endif\n#if ( NUM_RECT_AREA_LIGHTS > 0 ) && defined( RE_Direct_RectArea )\n	RectAreaLight rectAreaLight;\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_RECT_AREA_LIGHTS; i ++ ) {\n		rectAreaLight = rectAreaLights[ i ];\n		RE_Direct_RectArea( rectAreaLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );\n	}\n	#pragma unroll_loop_end\n#endif\n#if defined( RE_IndirectDiffuse )\n	vec3 iblIrradiance = vec3( 0.0 );\n	vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );\n	#if defined( USE_LIGHT_PROBES )\n		irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );\n	#endif\n	#if ( NUM_HEMI_LIGHTS > 0 )\n		#pragma unroll_loop_start\n		for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {\n			irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometryNormal );\n		}\n		#pragma unroll_loop_end\n	#endif\n	#ifdef USE_LIGHT_PROBES_GRID\n		vec3 probeWorldPos = ( ( vec4( geometryPosition, 1.0 ) - viewMatrix[ 3 ] ) * viewMatrix ).xyz;\n		vec3 probeWorldNormal = transformNormalByInverseViewMatrix( geometryNormal, viewMatrix );\n		irradiance += getLightProbeGridIrradiance( probeWorldPos, probeWorldNormal );\n	#endif\n#endif\n#if defined( RE_IndirectSpecular )\n	vec3 radiance = vec3( 0.0 );\n	vec3 clearcoatRadiance = vec3( 0.0 );\n#endif",
+	lights_fragment_maps: "#if defined( RE_IndirectDiffuse )\n	#ifdef USE_LIGHTMAP\n		vec4 lightMapTexel = texture2D( lightMap, vLightMapUv );\n		vec3 lightMapIrradiance = lightMapTexel.rgb * lightMapIntensity;\n		irradiance += lightMapIrradiance;\n	#endif\n	#if defined( USE_ENVMAP ) && defined( ENVMAP_TYPE_CUBE_UV )\n		#if defined( STANDARD ) || defined( LAMBERT ) || defined( PHONG )\n			iblIrradiance += getIBLIrradiance( geometryNormal );\n		#endif\n	#endif\n#endif\n#if defined( USE_ENVMAP ) && defined( RE_IndirectSpecular )\n	#ifdef USE_ANISOTROPY\n		radiance += getIBLAnisotropyRadiance( geometryViewDir, geometryNormal, material.roughness, material.anisotropyB, material.anisotropy );\n	#else\n		radiance += getIBLRadiance( geometryViewDir, geometryNormal, material.roughness );\n	#endif\n	#ifdef USE_CLEARCOAT\n		clearcoatRadiance += getIBLRadiance( geometryViewDir, geometryClearcoatNormal, material.clearcoatRoughness );\n	#endif\n#endif",
+	lights_fragment_end: "#if defined( RE_IndirectDiffuse )\n	#if defined( LAMBERT ) || defined( PHONG )\n		irradiance += iblIrradiance;\n	#endif\n	RE_IndirectDiffuse( irradiance, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );\n#endif\n#if defined( RE_IndirectSpecular )\n	RE_IndirectSpecular( radiance, iblIrradiance, clearcoatRadiance, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, reflectedLight );\n#endif",
+	lightprobes_pars_fragment: "#ifdef USE_LIGHT_PROBES_GRID\nuniform highp sampler3D probesSH;\nuniform vec3 probesMin;\nuniform vec3 probesMax;\nuniform vec3 probesResolution;\nvec3 getLightProbeGridIrradiance( vec3 worldPos, vec3 worldNormal ) {\n	vec3 res = probesResolution;\n	vec3 gridRange = probesMax - probesMin;\n	vec3 resMinusOne = res - 1.0;\n	vec3 probeSpacing = gridRange / resMinusOne;\n	vec3 samplePos = worldPos + worldNormal * probeSpacing * 0.5;\n	vec3 uvw = clamp( ( samplePos - probesMin ) / gridRange, 0.0, 1.0 );\n	uvw = uvw * resMinusOne / res + 0.5 / res;\n	float nz          = res.z;\n	float paddedSlices = nz + 2.0;\n	float atlasDepth  = 7.0 * paddedSlices;\n	float uvZBase     = uvw.z * nz + 1.0;\n	vec4 s0 = texture( probesSH, vec3( uvw.xy, ( uvZBase                       ) / atlasDepth ) );\n	vec4 s1 = texture( probesSH, vec3( uvw.xy, ( uvZBase +       paddedSlices   ) / atlasDepth ) );\n	vec4 s2 = texture( probesSH, vec3( uvw.xy, ( uvZBase + 2.0 * paddedSlices   ) / atlasDepth ) );\n	vec4 s3 = texture( probesSH, vec3( uvw.xy, ( uvZBase + 3.0 * paddedSlices   ) / atlasDepth ) );\n	vec4 s4 = texture( probesSH, vec3( uvw.xy, ( uvZBase + 4.0 * paddedSlices   ) / atlasDepth ) );\n	vec4 s5 = texture( probesSH, vec3( uvw.xy, ( uvZBase + 5.0 * paddedSlices   ) / atlasDepth ) );\n	vec4 s6 = texture( probesSH, vec3( uvw.xy, ( uvZBase + 6.0 * paddedSlices   ) / atlasDepth ) );\n	vec3 c0 = s0.xyz;\n	vec3 c1 = vec3( s0.w, s1.xy );\n	vec3 c2 = vec3( s1.zw, s2.x );\n	vec3 c3 = s2.yzw;\n	vec3 c4 = s3.xyz;\n	vec3 c5 = vec3( s3.w, s4.xy );\n	vec3 c6 = vec3( s4.zw, s5.x );\n	vec3 c7 = s5.yzw;\n	vec3 c8 = s6.xyz;\n	float x = worldNormal.x, y = worldNormal.y, z = worldNormal.z;\n	vec3 result = c0 * 0.886227;\n	result += c1 * 2.0 * 0.511664 * y;\n	result += c2 * 2.0 * 0.511664 * z;\n	result += c3 * 2.0 * 0.511664 * x;\n	result += c4 * 2.0 * 0.429043 * x * y;\n	result += c5 * 2.0 * 0.429043 * y * z;\n	result += c6 * ( 0.743125 * z * z - 0.247708 );\n	result += c7 * 2.0 * 0.429043 * x * z;\n	result += c8 * 0.429043 * ( x * x - y * y );\n	return max( result, vec3( 0.0 ) );\n}\n#endif",
+	logdepthbuf_fragment: "#if defined( USE_LOGARITHMIC_DEPTH_BUFFER )\n	gl_FragDepth = vIsPerspective == 0.0 ? gl_FragCoord.z : log2( vFragDepth ) * logDepthBufFC * 0.5;\n#endif",
+	logdepthbuf_pars_fragment: "#if defined( USE_LOGARITHMIC_DEPTH_BUFFER )\n	uniform float logDepthBufFC;\n	varying float vFragDepth;\n	varying float vIsPerspective;\n#endif",
+	logdepthbuf_pars_vertex: "#ifdef USE_LOGARITHMIC_DEPTH_BUFFER\n	varying float vFragDepth;\n	varying float vIsPerspective;\n#endif",
+	logdepthbuf_vertex: "#ifdef USE_LOGARITHMIC_DEPTH_BUFFER\n	vFragDepth = 1.0 + gl_Position.w;\n	vIsPerspective = float( isPerspectiveMatrix( projectionMatrix ) );\n#endif",
+	map_fragment: "#ifdef USE_MAP\n	vec4 sampledDiffuseColor = texture2D( map, vMapUv );\n	#ifdef DECODE_VIDEO_TEXTURE\n		sampledDiffuseColor = sRGBTransferEOTF( sampledDiffuseColor );\n	#endif\n	diffuseColor *= sampledDiffuseColor;\n#endif",
+	map_pars_fragment: "#ifdef USE_MAP\n	uniform sampler2D map;\n#endif",
+	map_particle_fragment: "#if defined( USE_MAP ) || defined( USE_ALPHAMAP )\n	#if defined( USE_POINTS_UV )\n		vec2 uv = vUv;\n	#else\n		vec2 uv = ( uvTransform * vec3( gl_PointCoord.x, 1.0 - gl_PointCoord.y, 1 ) ).xy;\n	#endif\n#endif\n#ifdef USE_MAP\n	diffuseColor *= texture2D( map, uv );\n#endif\n#ifdef USE_ALPHAMAP\n	diffuseColor.a *= texture2D( alphaMap, uv ).g;\n#endif",
+	map_particle_pars_fragment: "#if defined( USE_POINTS_UV )\n	varying vec2 vUv;\n#else\n	#if defined( USE_MAP ) || defined( USE_ALPHAMAP )\n		uniform mat3 uvTransform;\n	#endif\n#endif\n#ifdef USE_MAP\n	uniform sampler2D map;\n#endif\n#ifdef USE_ALPHAMAP\n	uniform sampler2D alphaMap;\n#endif",
+	metalnessmap_fragment: "float metalnessFactor = metalness;\n#ifdef USE_METALNESSMAP\n	vec4 texelMetalness = texture2D( metalnessMap, vMetalnessMapUv );\n	metalnessFactor *= texelMetalness.b;\n#endif",
+	metalnessmap_pars_fragment: "#ifdef USE_METALNESSMAP\n	uniform sampler2D metalnessMap;\n#endif",
+	morphinstance_vertex: "#ifdef USE_INSTANCING_MORPH\n	float morphTargetInfluences[ MORPHTARGETS_COUNT ];\n	float morphTargetBaseInfluence = texelFetch( morphTexture, ivec2( 0, gl_InstanceID ), 0 ).r;\n	for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {\n		morphTargetInfluences[i] =  texelFetch( morphTexture, ivec2( i + 1, gl_InstanceID ), 0 ).r;\n	}\n#endif",
+	morphcolor_vertex: "#if defined( USE_MORPHCOLORS )\n	vColor *= morphTargetBaseInfluence;\n	for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {\n		#if defined( USE_COLOR_ALPHA )\n			if ( morphTargetInfluences[ i ] != 0.0 ) vColor += getMorph( gl_VertexID, i, 2 ) * morphTargetInfluences[ i ];\n		#elif defined( USE_COLOR )\n			if ( morphTargetInfluences[ i ] != 0.0 ) vColor += getMorph( gl_VertexID, i, 2 ).rgb * morphTargetInfluences[ i ];\n		#endif\n	}\n#endif",
+	morphnormal_vertex: "#ifdef USE_MORPHNORMALS\n	objectNormal *= morphTargetBaseInfluence;\n	for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {\n		if ( morphTargetInfluences[ i ] != 0.0 ) objectNormal += getMorph( gl_VertexID, i, 1 ).xyz * morphTargetInfluences[ i ];\n	}\n#endif",
+	morphtarget_pars_vertex: "#ifdef USE_MORPHTARGETS\n	#ifndef USE_INSTANCING_MORPH\n		uniform float morphTargetBaseInfluence;\n		uniform float morphTargetInfluences[ MORPHTARGETS_COUNT ];\n	#endif\n	uniform sampler2DArray morphTargetsTexture;\n	uniform ivec2 morphTargetsTextureSize;\n	vec4 getMorph( const in int vertexIndex, const in int morphTargetIndex, const in int offset ) {\n		int texelIndex = vertexIndex * MORPHTARGETS_TEXTURE_STRIDE + offset;\n		int y = texelIndex / morphTargetsTextureSize.x;\n		int x = texelIndex - y * morphTargetsTextureSize.x;\n		ivec3 morphUV = ivec3( x, y, morphTargetIndex );\n		return texelFetch( morphTargetsTexture, morphUV, 0 );\n	}\n#endif",
+	morphtarget_vertex: "#ifdef USE_MORPHTARGETS\n	transformed *= morphTargetBaseInfluence;\n	for ( int i = 0; i < MORPHTARGETS_COUNT; i ++ ) {\n		if ( morphTargetInfluences[ i ] != 0.0 ) transformed += getMorph( gl_VertexID, i, 0 ).xyz * morphTargetInfluences[ i ];\n	}\n#endif",
+	normal_fragment_begin: "float faceDirection = gl_FrontFacing ? 1.0 : - 1.0;\n#ifdef FLAT_SHADED\n	vec3 fdx = dFdx( vViewPosition );\n	vec3 fdy = dFdy( vViewPosition );\n	vec3 normal = normalize( cross( fdx, fdy ) );\n#else\n	vec3 normal = normalize( vNormal );\n	#ifdef DOUBLE_SIDED\n		normal *= faceDirection;\n	#endif\n#endif\n#if defined( USE_NORMALMAP_TANGENTSPACE ) || defined( USE_CLEARCOAT_NORMALMAP ) || defined( USE_ANISOTROPY )\n	#ifdef USE_TANGENT\n		mat3 tbn = mat3( normalize( vTangent ), normalize( vBitangent ), normal );\n	#else\n		mat3 tbn = getTangentFrame( - vViewPosition, normal,\n		#if defined( USE_NORMALMAP )\n			vNormalMapUv\n		#elif defined( USE_CLEARCOAT_NORMALMAP )\n			vClearcoatNormalMapUv\n		#else\n			vUv\n		#endif\n		);\n	#endif\n	#ifdef DOUBLE_SIDED\n		tbn[0] *= faceDirection;\n		tbn[1] *= faceDirection;\n	#endif\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n	#ifdef USE_TANGENT\n		mat3 tbn2 = mat3( normalize( vTangent ), normalize( vBitangent ), normal );\n	#else\n		mat3 tbn2 = getTangentFrame( - vViewPosition, normal, vClearcoatNormalMapUv );\n	#endif\n	#ifdef DOUBLE_SIDED\n		tbn2[0] *= faceDirection;\n		tbn2[1] *= faceDirection;\n	#endif\n#endif\nvec3 nonPerturbedNormal = normal;",
+	normal_fragment_maps: "#ifdef USE_NORMALMAP_OBJECTSPACE\n	normal = texture2D( normalMap, vNormalMapUv ).xyz * 2.0 - 1.0;\n	#ifdef FLIP_SIDED\n		normal = - normal;\n	#endif\n	#ifdef DOUBLE_SIDED\n		normal = normal * faceDirection;\n	#endif\n	normal = normalize( normalMatrix * normal );\n#elif defined( USE_NORMALMAP_TANGENTSPACE )\n	vec3 mapN = texture2D( normalMap, vNormalMapUv ).xyz * 2.0 - 1.0;\n	#if defined( USE_PACKED_NORMALMAP )\n		mapN = vec3( mapN.xy, sqrt( saturate( 1.0 - dot( mapN.xy, mapN.xy ) ) ) );\n	#endif\n	mapN.xy *= normalScale;\n	normal = normalize( tbn * mapN );\n#elif defined( USE_BUMPMAP )\n	normal = perturbNormalArb( - vViewPosition, normal, dHdxy_fwd(), faceDirection );\n#endif",
+	normal_pars_fragment: "#ifndef FLAT_SHADED\n	varying vec3 vNormal;\n	#ifdef USE_TANGENT\n		varying vec3 vTangent;\n		varying vec3 vBitangent;\n	#endif\n#endif",
+	normal_pars_vertex: "#ifndef FLAT_SHADED\n	varying vec3 vNormal;\n	#ifdef USE_TANGENT\n		varying vec3 vTangent;\n		varying vec3 vBitangent;\n	#endif\n#endif",
+	normal_vertex: "#ifndef FLAT_SHADED\n	vNormal = normalize( transformedNormal );\n	#ifdef USE_TANGENT\n		vTangent = normalize( transformedTangent );\n		vBitangent = normalize( cross( vNormal, vTangent ) * tangent.w );\n		#ifdef FLIP_SIDED\n			vBitangent = - vBitangent;\n		#endif\n	#endif\n#endif",
+	normalmap_pars_fragment: "#ifdef USE_NORMALMAP\n	uniform sampler2D normalMap;\n	uniform vec2 normalScale;\n#endif\n#ifdef USE_NORMALMAP_OBJECTSPACE\n	uniform mat3 normalMatrix;\n#endif\n#if ! defined ( USE_TANGENT ) && ( defined ( USE_NORMALMAP_TANGENTSPACE ) || defined ( USE_CLEARCOAT_NORMALMAP ) || defined( USE_ANISOTROPY ) )\n	mat3 getTangentFrame( vec3 eye_pos, vec3 surf_norm, vec2 uv ) {\n		vec3 q0 = dFdx( eye_pos.xyz );\n		vec3 q1 = dFdy( eye_pos.xyz );\n		vec2 st0 = dFdx( uv.st );\n		vec2 st1 = dFdy( uv.st );\n		vec3 N = surf_norm;\n		vec3 q1perp = cross( q1, N );\n		vec3 q0perp = cross( N, q0 );\n		vec3 T = q1perp * st0.x + q0perp * st1.x;\n		vec3 B = q1perp * st0.y + q0perp * st1.y;\n		float det = max( dot( T, T ), dot( B, B ) );\n		float scale = ( det == 0.0 ) ? 0.0 : inversesqrt( det );\n		return mat3( T * scale, B * scale, N );\n	}\n#endif",
+	clearcoat_normal_fragment_begin: "#ifdef USE_CLEARCOAT\n	vec3 clearcoatNormal = nonPerturbedNormal;\n#endif",
+	clearcoat_normal_fragment_maps: "#ifdef USE_CLEARCOAT_NORMALMAP\n	vec3 clearcoatMapN = texture2D( clearcoatNormalMap, vClearcoatNormalMapUv ).xyz * 2.0 - 1.0;\n	clearcoatMapN.xy *= clearcoatNormalScale;\n	clearcoatNormal = normalize( tbn2 * clearcoatMapN );\n#endif",
+	clearcoat_pars_fragment: "#ifdef USE_CLEARCOATMAP\n	uniform sampler2D clearcoatMap;\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n	uniform sampler2D clearcoatNormalMap;\n	uniform vec2 clearcoatNormalScale;\n#endif\n#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n	uniform sampler2D clearcoatRoughnessMap;\n#endif",
+	iridescence_pars_fragment: "#ifdef USE_IRIDESCENCEMAP\n	uniform sampler2D iridescenceMap;\n#endif\n#ifdef USE_IRIDESCENCE_THICKNESSMAP\n	uniform sampler2D iridescenceThicknessMap;\n#endif",
+	opaque_fragment: "#ifdef OPAQUE\ndiffuseColor.a = 1.0;\n#endif\n#ifdef USE_TRANSMISSION\ndiffuseColor.a *= material.transmissionAlpha;\n#endif\ngl_FragColor = vec4( outgoingLight, diffuseColor.a );",
+	packing: "vec3 packNormalToRGB( const in vec3 normal ) {\n	return normalize( normal ) * 0.5 + 0.5;\n}\nvec3 unpackRGBToNormal( const in vec3 rgb ) {\n	return 2.0 * rgb.xyz - 1.0;\n}\nconst float PackUpscale = 256. / 255.;const float UnpackDownscale = 255. / 256.;const float ShiftRight8 = 1. / 256.;\nconst float Inv255 = 1. / 255.;\nconst vec4 PackFactors = vec4( 1.0, 256.0, 256.0 * 256.0, 256.0 * 256.0 * 256.0 );\nconst vec2 UnpackFactors2 = vec2( UnpackDownscale, 1.0 / PackFactors.g );\nconst vec3 UnpackFactors3 = vec3( UnpackDownscale / PackFactors.rg, 1.0 / PackFactors.b );\nconst vec4 UnpackFactors4 = vec4( UnpackDownscale / PackFactors.rgb, 1.0 / PackFactors.a );\nvec4 packDepthToRGBA( const in float v ) {\n	if( v <= 0.0 )\n		return vec4( 0., 0., 0., 0. );\n	if( v >= 1.0 )\n		return vec4( 1., 1., 1., 1. );\n	float vuf;\n	float af = modf( v * PackFactors.a, vuf );\n	float bf = modf( vuf * ShiftRight8, vuf );\n	float gf = modf( vuf * ShiftRight8, vuf );\n	return vec4( vuf * Inv255, gf * PackUpscale, bf * PackUpscale, af );\n}\nvec3 packDepthToRGB( const in float v ) {\n	if( v <= 0.0 )\n		return vec3( 0., 0., 0. );\n	if( v >= 1.0 )\n		return vec3( 1., 1., 1. );\n	float vuf;\n	float bf = modf( v * PackFactors.b, vuf );\n	float gf = modf( vuf * ShiftRight8, vuf );\n	return vec3( vuf * Inv255, gf * PackUpscale, bf );\n}\nvec2 packDepthToRG( const in float v ) {\n	if( v <= 0.0 )\n		return vec2( 0., 0. );\n	if( v >= 1.0 )\n		return vec2( 1., 1. );\n	float vuf;\n	float gf = modf( v * 256., vuf );\n	return vec2( vuf * Inv255, gf );\n}\nfloat unpackRGBAToDepth( const in vec4 v ) {\n	return dot( v, UnpackFactors4 );\n}\nfloat unpackRGBToDepth( const in vec3 v ) {\n	return dot( v, UnpackFactors3 );\n}\nfloat unpackRGToDepth( const in vec2 v ) {\n	return v.r * UnpackFactors2.r + v.g * UnpackFactors2.g;\n}\nvec4 pack2HalfToRGBA( const in vec2 v ) {\n	vec4 r = vec4( v.x, fract( v.x * 255.0 ), v.y, fract( v.y * 255.0 ) );\n	return vec4( r.x - r.y / 255.0, r.y, r.z - r.w / 255.0, r.w );\n}\nvec2 unpackRGBATo2Half( const in vec4 v ) {\n	return vec2( v.x + ( v.y / 255.0 ), v.z + ( v.w / 255.0 ) );\n}\nfloat viewZToOrthographicDepth( const in float viewZ, const in float near, const in float far ) {\n	return ( viewZ + near ) / ( near - far );\n}\nfloat orthographicDepthToViewZ( const in float depth, const in float near, const in float far ) {\n	#ifdef USE_REVERSED_DEPTH_BUFFER\n	\n		return depth * ( far - near ) - far;\n	#else\n		return depth * ( near - far ) - near;\n	#endif\n}\nfloat viewZToPerspectiveDepth( const in float viewZ, const in float near, const in float far ) {\n	return ( ( near + viewZ ) * far ) / ( ( far - near ) * viewZ );\n}\nfloat perspectiveDepthToViewZ( const in float depth, const in float near, const in float far ) {\n	\n	#ifdef USE_REVERSED_DEPTH_BUFFER\n		return ( near * far ) / ( ( near - far ) * depth - near );\n	#else\n		return ( near * far ) / ( ( far - near ) * depth - far );\n	#endif\n}",
+	premultiplied_alpha_fragment: "#ifdef PREMULTIPLIED_ALPHA\n	gl_FragColor.rgb *= gl_FragColor.a;\n#endif",
+	project_vertex: "vec4 mvPosition = vec4( transformed, 1.0 );\n#ifdef USE_BATCHING\n	mvPosition = batchingMatrix * mvPosition;\n#endif\n#ifdef USE_INSTANCING\n	mvPosition = instanceMatrix * mvPosition;\n#endif\nmvPosition = modelViewMatrix * mvPosition;\ngl_Position = projectionMatrix * mvPosition;",
+	dithering_fragment: "#ifdef DITHERING\n	gl_FragColor.rgb = dithering( gl_FragColor.rgb );\n#endif",
+	dithering_pars_fragment: "#ifdef DITHERING\n	vec3 dithering( vec3 color ) {\n		float grid_position = rand( gl_FragCoord.xy );\n		vec3 dither_shift_RGB = vec3( 0.25 / 255.0, -0.25 / 255.0, 0.25 / 255.0 );\n		dither_shift_RGB = mix( 2.0 * dither_shift_RGB, -2.0 * dither_shift_RGB, grid_position );\n		return color + dither_shift_RGB;\n	}\n#endif",
+	roughnessmap_fragment: "float roughnessFactor = roughness;\n#ifdef USE_ROUGHNESSMAP\n	vec4 texelRoughness = texture2D( roughnessMap, vRoughnessMapUv );\n	roughnessFactor *= texelRoughness.g;\n#endif",
+	roughnessmap_pars_fragment: "#ifdef USE_ROUGHNESSMAP\n	uniform sampler2D roughnessMap;\n#endif",
+	shadowmap_pars_fragment: "#if NUM_SPOT_LIGHT_COORDS > 0\n	varying vec4 vSpotLightCoord[ NUM_SPOT_LIGHT_COORDS ];\n#endif\n#if NUM_SPOT_LIGHT_MAPS > 0\n	uniform sampler2D spotLightMap[ NUM_SPOT_LIGHT_MAPS ];\n#endif\n#ifdef USE_SHADOWMAP\n	#if NUM_DIR_LIGHT_SHADOWS > 0\n		#if defined( SHADOWMAP_TYPE_PCF )\n			uniform sampler2DShadow directionalShadowMap[ NUM_DIR_LIGHT_SHADOWS ];\n		#else\n			uniform sampler2D directionalShadowMap[ NUM_DIR_LIGHT_SHADOWS ];\n		#endif\n		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHT_SHADOWS ];\n		struct DirectionalLightShadow {\n			float shadowIntensity;\n			float shadowBias;\n			float shadowNormalBias;\n			float shadowRadius;\n			vec2 shadowMapSize;\n		};\n		uniform DirectionalLightShadow directionalLightShadows[ NUM_DIR_LIGHT_SHADOWS ];\n	#endif\n	#if NUM_SPOT_LIGHT_SHADOWS > 0\n		#if defined( SHADOWMAP_TYPE_PCF )\n			uniform sampler2DShadow spotShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];\n		#else\n			uniform sampler2D spotShadowMap[ NUM_SPOT_LIGHT_SHADOWS ];\n		#endif\n		struct SpotLightShadow {\n			float shadowIntensity;\n			float shadowBias;\n			float shadowNormalBias;\n			float shadowRadius;\n			vec2 shadowMapSize;\n		};\n		uniform SpotLightShadow spotLightShadows[ NUM_SPOT_LIGHT_SHADOWS ];\n	#endif\n	#if NUM_POINT_LIGHT_SHADOWS > 0\n		#if defined( SHADOWMAP_TYPE_PCF )\n			uniform samplerCubeShadow pointShadowMap[ NUM_POINT_LIGHT_SHADOWS ];\n		#elif defined( SHADOWMAP_TYPE_BASIC )\n			uniform samplerCube pointShadowMap[ NUM_POINT_LIGHT_SHADOWS ];\n		#endif\n		varying vec4 vPointShadowCoord[ NUM_POINT_LIGHT_SHADOWS ];\n		struct PointLightShadow {\n			float shadowIntensity;\n			float shadowBias;\n			float shadowNormalBias;\n			float shadowRadius;\n			vec2 shadowMapSize;\n			float shadowCameraNear;\n			float shadowCameraFar;\n		};\n		uniform PointLightShadow pointLightShadows[ NUM_POINT_LIGHT_SHADOWS ];\n	#endif\n	#if defined( SHADOWMAP_TYPE_PCF )\n		float interleavedGradientNoise( vec2 position ) {\n			return fract( 52.9829189 * fract( dot( position, vec2( 0.06711056, 0.00583715 ) ) ) );\n		}\n		vec2 vogelDiskSample( int sampleIndex, int samplesCount, float phi ) {\n			const float goldenAngle = 2.399963229728653;\n			float r = sqrt( ( float( sampleIndex ) + 0.5 ) / float( samplesCount ) );\n			float theta = float( sampleIndex ) * goldenAngle + phi;\n			return vec2( cos( theta ), sin( theta ) ) * r;\n		}\n	#endif\n	#if defined( SHADOWMAP_TYPE_PCF )\n		float getShadow( sampler2DShadow shadowMap, vec2 shadowMapSize, float shadowIntensity, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n			float shadow = 1.0;\n			shadowCoord.xyz /= shadowCoord.w;\n			shadowCoord.z += shadowBias;\n			bool inFrustum = shadowCoord.x >= 0.0 && shadowCoord.x <= 1.0 && shadowCoord.y >= 0.0 && shadowCoord.y <= 1.0;\n			bool frustumTest = inFrustum && shadowCoord.z <= 1.0;\n			if ( frustumTest ) {\n				vec2 texelSize = vec2( 1.0 ) / shadowMapSize;\n				float radius = shadowRadius * texelSize.x;\n				float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;\n				shadow = (\n					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 0, 5, phi ) * radius, shadowCoord.z ) ) +\n					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 1, 5, phi ) * radius, shadowCoord.z ) ) +\n					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 2, 5, phi ) * radius, shadowCoord.z ) ) +\n					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 3, 5, phi ) * radius, shadowCoord.z ) ) +\n					texture( shadowMap, vec3( shadowCoord.xy + vogelDiskSample( 4, 5, phi ) * radius, shadowCoord.z ) )\n				) * 0.2;\n			}\n			return mix( 1.0, shadow, shadowIntensity );\n		}\n	#elif defined( SHADOWMAP_TYPE_VSM )\n		float getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowIntensity, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n			float shadow = 1.0;\n			shadowCoord.xyz /= shadowCoord.w;\n			#ifdef USE_REVERSED_DEPTH_BUFFER\n				shadowCoord.z -= shadowBias;\n			#else\n				shadowCoord.z += shadowBias;\n			#endif\n			bool inFrustum = shadowCoord.x >= 0.0 && shadowCoord.x <= 1.0 && shadowCoord.y >= 0.0 && shadowCoord.y <= 1.0;\n			bool frustumTest = inFrustum && shadowCoord.z <= 1.0;\n			if ( frustumTest ) {\n				vec2 distribution = texture2D( shadowMap, shadowCoord.xy ).rg;\n				float mean = distribution.x;\n				float variance = distribution.y * distribution.y;\n				#ifdef USE_REVERSED_DEPTH_BUFFER\n					float hard_shadow = step( mean, shadowCoord.z );\n				#else\n					float hard_shadow = step( shadowCoord.z, mean );\n				#endif\n				\n				if ( hard_shadow == 1.0 ) {\n					shadow = 1.0;\n				} else {\n					variance = max( variance, 0.0000001 );\n					float d = shadowCoord.z - mean;\n					float p_max = variance / ( variance + d * d );\n					p_max = clamp( ( p_max - 0.3 ) / 0.65, 0.0, 1.0 );\n					shadow = max( hard_shadow, p_max );\n				}\n			}\n			return mix( 1.0, shadow, shadowIntensity );\n		}\n	#else\n		float getShadow( sampler2D shadowMap, vec2 shadowMapSize, float shadowIntensity, float shadowBias, float shadowRadius, vec4 shadowCoord ) {\n			float shadow = 1.0;\n			shadowCoord.xyz /= shadowCoord.w;\n			#ifdef USE_REVERSED_DEPTH_BUFFER\n				shadowCoord.z -= shadowBias;\n			#else\n				shadowCoord.z += shadowBias;\n			#endif\n			bool inFrustum = shadowCoord.x >= 0.0 && shadowCoord.x <= 1.0 && shadowCoord.y >= 0.0 && shadowCoord.y <= 1.0;\n			bool frustumTest = inFrustum && shadowCoord.z <= 1.0;\n			if ( frustumTest ) {\n				float depth = texture2D( shadowMap, shadowCoord.xy ).r;\n				#ifdef USE_REVERSED_DEPTH_BUFFER\n					shadow = step( depth, shadowCoord.z );\n				#else\n					shadow = step( shadowCoord.z, depth );\n				#endif\n			}\n			return mix( 1.0, shadow, shadowIntensity );\n		}\n	#endif\n	#if NUM_POINT_LIGHT_SHADOWS > 0\n	#if defined( SHADOWMAP_TYPE_PCF )\n	float getPointShadow( samplerCubeShadow shadowMap, vec2 shadowMapSize, float shadowIntensity, float shadowBias, float shadowRadius, vec4 shadowCoord, float shadowCameraNear, float shadowCameraFar ) {\n		float shadow = 1.0;\n		vec3 lightToPosition = shadowCoord.xyz;\n		vec3 bd3D = normalize( lightToPosition );\n		vec3 absVec = abs( lightToPosition );\n		float viewSpaceZ = max( max( absVec.x, absVec.y ), absVec.z );\n		if ( viewSpaceZ - shadowCameraFar <= 0.0 && viewSpaceZ - shadowCameraNear >= 0.0 ) {\n			#ifdef USE_REVERSED_DEPTH_BUFFER\n				float dp = ( shadowCameraNear * ( shadowCameraFar - viewSpaceZ ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );\n				dp -= shadowBias;\n			#else\n				float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );\n				dp += shadowBias;\n			#endif\n			float texelSize = shadowRadius / shadowMapSize.x;\n			vec3 absDir = abs( bd3D );\n			vec3 tangent = absDir.x > absDir.z ? vec3( 0.0, 1.0, 0.0 ) : vec3( 1.0, 0.0, 0.0 );\n			tangent = normalize( cross( bd3D, tangent ) );\n			vec3 bitangent = cross( bd3D, tangent );\n			float phi = interleavedGradientNoise( gl_FragCoord.xy ) * PI2;\n			vec2 sample0 = vogelDiskSample( 0, 5, phi );\n			vec2 sample1 = vogelDiskSample( 1, 5, phi );\n			vec2 sample2 = vogelDiskSample( 2, 5, phi );\n			vec2 sample3 = vogelDiskSample( 3, 5, phi );\n			vec2 sample4 = vogelDiskSample( 4, 5, phi );\n			shadow = (\n				texture( shadowMap, vec4( bd3D + ( tangent * sample0.x + bitangent * sample0.y ) * texelSize, dp ) ) +\n				texture( shadowMap, vec4( bd3D + ( tangent * sample1.x + bitangent * sample1.y ) * texelSize, dp ) ) +\n				texture( shadowMap, vec4( bd3D + ( tangent * sample2.x + bitangent * sample2.y ) * texelSize, dp ) ) +\n				texture( shadowMap, vec4( bd3D + ( tangent * sample3.x + bitangent * sample3.y ) * texelSize, dp ) ) +\n				texture( shadowMap, vec4( bd3D + ( tangent * sample4.x + bitangent * sample4.y ) * texelSize, dp ) )\n			) * 0.2;\n		}\n		return mix( 1.0, shadow, shadowIntensity );\n	}\n	#elif defined( SHADOWMAP_TYPE_BASIC )\n	float getPointShadow( samplerCube shadowMap, vec2 shadowMapSize, float shadowIntensity, float shadowBias, float shadowRadius, vec4 shadowCoord, float shadowCameraNear, float shadowCameraFar ) {\n		float shadow = 1.0;\n		vec3 lightToPosition = shadowCoord.xyz;\n		vec3 absVec = abs( lightToPosition );\n		float viewSpaceZ = max( max( absVec.x, absVec.y ), absVec.z );\n		if ( viewSpaceZ - shadowCameraFar <= 0.0 && viewSpaceZ - shadowCameraNear >= 0.0 ) {\n			float dp = ( shadowCameraFar * ( viewSpaceZ - shadowCameraNear ) ) / ( viewSpaceZ * ( shadowCameraFar - shadowCameraNear ) );\n			dp += shadowBias;\n			vec3 bd3D = normalize( lightToPosition );\n			float depth = textureCube( shadowMap, bd3D ).r;\n			#ifdef USE_REVERSED_DEPTH_BUFFER\n				depth = 1.0 - depth;\n			#endif\n			shadow = step( dp, depth );\n		}\n		return mix( 1.0, shadow, shadowIntensity );\n	}\n	#endif\n	#endif\n#endif",
+	shadowmap_pars_vertex: "#if NUM_SPOT_LIGHT_COORDS > 0\n	uniform mat4 spotLightMatrix[ NUM_SPOT_LIGHT_COORDS ];\n	varying vec4 vSpotLightCoord[ NUM_SPOT_LIGHT_COORDS ];\n#endif\n#ifdef USE_SHADOWMAP\n	#if NUM_DIR_LIGHT_SHADOWS > 0\n		uniform mat4 directionalShadowMatrix[ NUM_DIR_LIGHT_SHADOWS ];\n		varying vec4 vDirectionalShadowCoord[ NUM_DIR_LIGHT_SHADOWS ];\n		struct DirectionalLightShadow {\n			float shadowIntensity;\n			float shadowBias;\n			float shadowNormalBias;\n			float shadowRadius;\n			vec2 shadowMapSize;\n		};\n		uniform DirectionalLightShadow directionalLightShadows[ NUM_DIR_LIGHT_SHADOWS ];\n	#endif\n	#if NUM_SPOT_LIGHT_SHADOWS > 0\n		struct SpotLightShadow {\n			float shadowIntensity;\n			float shadowBias;\n			float shadowNormalBias;\n			float shadowRadius;\n			vec2 shadowMapSize;\n		};\n		uniform SpotLightShadow spotLightShadows[ NUM_SPOT_LIGHT_SHADOWS ];\n	#endif\n	#if NUM_POINT_LIGHT_SHADOWS > 0\n		uniform mat4 pointShadowMatrix[ NUM_POINT_LIGHT_SHADOWS ];\n		varying vec4 vPointShadowCoord[ NUM_POINT_LIGHT_SHADOWS ];\n		struct PointLightShadow {\n			float shadowIntensity;\n			float shadowBias;\n			float shadowNormalBias;\n			float shadowRadius;\n			vec2 shadowMapSize;\n			float shadowCameraNear;\n			float shadowCameraFar;\n		};\n		uniform PointLightShadow pointLightShadows[ NUM_POINT_LIGHT_SHADOWS ];\n	#endif\n#endif",
+	shadowmap_vertex: "#if ( defined( USE_SHADOWMAP ) && ( NUM_DIR_LIGHT_SHADOWS > 0 || NUM_POINT_LIGHT_SHADOWS > 0 ) ) || ( NUM_SPOT_LIGHT_COORDS > 0 )\n	#ifdef HAS_NORMAL\n		vec3 shadowWorldNormal = transformNormalByInverseViewMatrix( transformedNormal, viewMatrix );\n	#else\n		vec3 shadowWorldNormal = vec3( 0.0 );\n	#endif\n	vec4 shadowWorldPosition;\n#endif\n#if defined( USE_SHADOWMAP )\n	#if NUM_DIR_LIGHT_SHADOWS > 0\n		#pragma unroll_loop_start\n		for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {\n			shadowWorldPosition = worldPosition + vec4( shadowWorldNormal * directionalLightShadows[ i ].shadowNormalBias, 0 );\n			vDirectionalShadowCoord[ i ] = directionalShadowMatrix[ i ] * shadowWorldPosition;\n		}\n		#pragma unroll_loop_end\n	#endif\n	#if NUM_POINT_LIGHT_SHADOWS > 0\n		#pragma unroll_loop_start\n		for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {\n			shadowWorldPosition = worldPosition + vec4( shadowWorldNormal * pointLightShadows[ i ].shadowNormalBias, 0 );\n			vPointShadowCoord[ i ] = pointShadowMatrix[ i ] * shadowWorldPosition;\n		}\n		#pragma unroll_loop_end\n	#endif\n#endif\n#if NUM_SPOT_LIGHT_COORDS > 0\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_SPOT_LIGHT_COORDS; i ++ ) {\n		shadowWorldPosition = worldPosition;\n		#if ( defined( USE_SHADOWMAP ) && UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )\n			shadowWorldPosition.xyz += shadowWorldNormal * spotLightShadows[ i ].shadowNormalBias;\n		#endif\n		vSpotLightCoord[ i ] = spotLightMatrix[ i ] * shadowWorldPosition;\n	}\n	#pragma unroll_loop_end\n#endif",
+	shadowmask_pars_fragment: "float getShadowMask() {\n	float shadow = 1.0;\n	#ifdef USE_SHADOWMAP\n	#if NUM_DIR_LIGHT_SHADOWS > 0\n	DirectionalLightShadow directionalLight;\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_DIR_LIGHT_SHADOWS; i ++ ) {\n		directionalLight = directionalLightShadows[ i ];\n		shadow *= receiveShadow ? getShadow( directionalShadowMap[ i ], directionalLight.shadowMapSize, directionalLight.shadowIntensity, directionalLight.shadowBias, directionalLight.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;\n	}\n	#pragma unroll_loop_end\n	#endif\n	#if NUM_SPOT_LIGHT_SHADOWS > 0\n	SpotLightShadow spotLight;\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_SPOT_LIGHT_SHADOWS; i ++ ) {\n		spotLight = spotLightShadows[ i ];\n		shadow *= receiveShadow ? getShadow( spotShadowMap[ i ], spotLight.shadowMapSize, spotLight.shadowIntensity, spotLight.shadowBias, spotLight.shadowRadius, vSpotLightCoord[ i ] ) : 1.0;\n	}\n	#pragma unroll_loop_end\n	#endif\n	#if NUM_POINT_LIGHT_SHADOWS > 0 && ( defined( SHADOWMAP_TYPE_PCF ) || defined( SHADOWMAP_TYPE_BASIC ) )\n	PointLightShadow pointLight;\n	#pragma unroll_loop_start\n	for ( int i = 0; i < NUM_POINT_LIGHT_SHADOWS; i ++ ) {\n		pointLight = pointLightShadows[ i ];\n		shadow *= receiveShadow ? getPointShadow( pointShadowMap[ i ], pointLight.shadowMapSize, pointLight.shadowIntensity, pointLight.shadowBias, pointLight.shadowRadius, vPointShadowCoord[ i ], pointLight.shadowCameraNear, pointLight.shadowCameraFar ) : 1.0;\n	}\n	#pragma unroll_loop_end\n	#endif\n	#endif\n	return shadow;\n}",
+	skinbase_vertex: "#ifdef USE_SKINNING\n	mat4 boneMatX = getBoneMatrix( skinIndex.x );\n	mat4 boneMatY = getBoneMatrix( skinIndex.y );\n	mat4 boneMatZ = getBoneMatrix( skinIndex.z );\n	mat4 boneMatW = getBoneMatrix( skinIndex.w );\n#endif",
+	skinning_pars_vertex: "#ifdef USE_SKINNING\n	uniform mat4 bindMatrix;\n	uniform mat4 bindMatrixInverse;\n	uniform highp sampler2D boneTexture;\n	mat4 getBoneMatrix( const in float i ) {\n		int size = textureSize( boneTexture, 0 ).x;\n		int j = int( i ) * 4;\n		int x = j % size;\n		int y = j / size;\n		vec4 v1 = texelFetch( boneTexture, ivec2( x, y ), 0 );\n		vec4 v2 = texelFetch( boneTexture, ivec2( x + 1, y ), 0 );\n		vec4 v3 = texelFetch( boneTexture, ivec2( x + 2, y ), 0 );\n		vec4 v4 = texelFetch( boneTexture, ivec2( x + 3, y ), 0 );\n		return mat4( v1, v2, v3, v4 );\n	}\n#endif",
+	skinning_vertex: "#ifdef USE_SKINNING\n	vec4 skinVertex = bindMatrix * vec4( transformed, 1.0 );\n	vec4 skinned = vec4( 0.0 );\n	skinned += boneMatX * skinVertex * skinWeight.x;\n	skinned += boneMatY * skinVertex * skinWeight.y;\n	skinned += boneMatZ * skinVertex * skinWeight.z;\n	skinned += boneMatW * skinVertex * skinWeight.w;\n	transformed = ( bindMatrixInverse * skinned ).xyz;\n#endif",
+	skinnormal_vertex: "#ifdef USE_SKINNING\n	mat4 skinMatrix = mat4( 0.0 );\n	skinMatrix += skinWeight.x * boneMatX;\n	skinMatrix += skinWeight.y * boneMatY;\n	skinMatrix += skinWeight.z * boneMatZ;\n	skinMatrix += skinWeight.w * boneMatW;\n	skinMatrix = bindMatrixInverse * skinMatrix * bindMatrix;\n	objectNormal = vec4( skinMatrix * vec4( objectNormal, 0.0 ) ).xyz;\n	#ifdef USE_TANGENT\n		objectTangent = vec4( skinMatrix * vec4( objectTangent, 0.0 ) ).xyz;\n	#endif\n#endif",
+	specularmap_fragment: "float specularStrength;\n#ifdef USE_SPECULARMAP\n	vec4 texelSpecular = texture2D( specularMap, vSpecularMapUv );\n	specularStrength = texelSpecular.r;\n#else\n	specularStrength = 1.0;\n#endif",
+	specularmap_pars_fragment: "#ifdef USE_SPECULARMAP\n	uniform sampler2D specularMap;\n#endif",
+	tonemapping_fragment: "#if defined( TONE_MAPPING )\n	gl_FragColor.rgb = toneMapping( gl_FragColor.rgb );\n#endif",
+	tonemapping_pars_fragment: "#ifndef saturate\n#define saturate( a ) clamp( a, 0.0, 1.0 )\n#endif\nuniform float toneMappingExposure;\nvec3 LinearToneMapping( vec3 color ) {\n	return saturate( toneMappingExposure * color );\n}\nvec3 ReinhardToneMapping( vec3 color ) {\n	color *= toneMappingExposure;\n	return saturate( color / ( vec3( 1.0 ) + color ) );\n}\nvec3 CineonToneMapping( vec3 color ) {\n	color *= toneMappingExposure;\n	color = max( vec3( 0.0 ), color - 0.004 );\n	return pow( ( color * ( 6.2 * color + 0.5 ) ) / ( color * ( 6.2 * color + 1.7 ) + 0.06 ), vec3( 2.2 ) );\n}\nvec3 RRTAndODTFit( vec3 v ) {\n	vec3 a = v * ( v + 0.0245786 ) - 0.000090537;\n	vec3 b = v * ( 0.983729 * v + 0.4329510 ) + 0.238081;\n	return a / b;\n}\nvec3 ACESFilmicToneMapping( vec3 color ) {\n	const mat3 ACESInputMat = mat3(\n		vec3( 0.59719, 0.07600, 0.02840 ),		vec3( 0.35458, 0.90834, 0.13383 ),\n		vec3( 0.04823, 0.01566, 0.83777 )\n	);\n	const mat3 ACESOutputMat = mat3(\n		vec3(  1.60475, -0.10208, -0.00327 ),		vec3( -0.53108,  1.10813, -0.07276 ),\n		vec3( -0.07367, -0.00605,  1.07602 )\n	);\n	color *= toneMappingExposure / 0.6;\n	color = ACESInputMat * color;\n	color = RRTAndODTFit( color );\n	color = ACESOutputMat * color;\n	return saturate( color );\n}\nconst mat3 LINEAR_REC2020_TO_LINEAR_SRGB = mat3(\n	vec3( 1.6605, - 0.1246, - 0.0182 ),\n	vec3( - 0.5876, 1.1329, - 0.1006 ),\n	vec3( - 0.0728, - 0.0083, 1.1187 )\n);\nconst mat3 LINEAR_SRGB_TO_LINEAR_REC2020 = mat3(\n	vec3( 0.6274, 0.0691, 0.0164 ),\n	vec3( 0.3293, 0.9195, 0.0880 ),\n	vec3( 0.0433, 0.0113, 0.8956 )\n);\nvec3 agxDefaultContrastApprox( vec3 x ) {\n	vec3 x2 = x * x;\n	vec3 x4 = x2 * x2;\n	return + 15.5 * x4 * x2\n		- 40.14 * x4 * x\n		+ 31.96 * x4\n		- 6.868 * x2 * x\n		+ 0.4298 * x2\n		+ 0.1191 * x\n		- 0.00232;\n}\nvec3 AgXToneMapping( vec3 color ) {\n	const mat3 AgXInsetMatrix = mat3(\n		vec3( 0.856627153315983, 0.137318972929847, 0.11189821299995 ),\n		vec3( 0.0951212405381588, 0.761241990602591, 0.0767994186031903 ),\n		vec3( 0.0482516061458583, 0.101439036467562, 0.811302368396859 )\n	);\n	const mat3 AgXOutsetMatrix = mat3(\n		vec3( 1.1271005818144368, - 0.1413297634984383, - 0.14132976349843826 ),\n		vec3( - 0.11060664309660323, 1.157823702216272, - 0.11060664309660294 ),\n		vec3( - 0.016493938717834573, - 0.016493938717834257, 1.2519364065950405 )\n	);\n	const float AgxMinEv = - 12.47393;	const float AgxMaxEv = 4.026069;\n	color *= toneMappingExposure;\n	color = LINEAR_SRGB_TO_LINEAR_REC2020 * color;\n	color = AgXInsetMatrix * color;\n	color = max( color, 1e-10 );	color = log2( color );\n	color = ( color - AgxMinEv ) / ( AgxMaxEv - AgxMinEv );\n	color = clamp( color, 0.0, 1.0 );\n	color = agxDefaultContrastApprox( color );\n	color = AgXOutsetMatrix * color;\n	color = pow( max( vec3( 0.0 ), color ), vec3( 2.2 ) );\n	color = LINEAR_REC2020_TO_LINEAR_SRGB * color;\n	color = clamp( color, 0.0, 1.0 );\n	return color;\n}\nvec3 NeutralToneMapping( vec3 color ) {\n	const float StartCompression = 0.8 - 0.04;\n	const float Desaturation = 0.15;\n	color *= toneMappingExposure;\n	float x = min( color.r, min( color.g, color.b ) );\n	float offset = x < 0.08 ? x - 6.25 * x * x : 0.04;\n	color -= offset;\n	float peak = max( color.r, max( color.g, color.b ) );\n	if ( peak < StartCompression ) return color;\n	float d = 1. - StartCompression;\n	float newPeak = 1. - d * d / ( peak + d - StartCompression );\n	color *= newPeak / peak;\n	float g = 1. - 1. / ( Desaturation * ( peak - newPeak ) + 1. );\n	return mix( color, vec3( newPeak ), g );\n}\nvec3 CustomToneMapping( vec3 color ) { return color; }",
+	transmission_fragment: "#ifdef USE_TRANSMISSION\n	material.transmission = transmission;\n	material.transmissionAlpha = 1.0;\n	material.thickness = thickness;\n	material.attenuationDistance = attenuationDistance;\n	material.attenuationColor = attenuationColor;\n	#ifdef USE_TRANSMISSIONMAP\n		material.transmission *= texture2D( transmissionMap, vTransmissionMapUv ).r;\n	#endif\n	#ifdef USE_THICKNESSMAP\n		material.thickness *= texture2D( thicknessMap, vThicknessMapUv ).g;\n	#endif\n	vec3 pos = vWorldPosition;\n	vec3 v = normalize( cameraPosition - pos );\n	vec3 n = transformNormalByInverseViewMatrix( normal, viewMatrix );\n	vec4 transmitted = getIBLVolumeRefraction(\n		n, v, material.roughness, material.diffuseContribution, material.specularColorBlended, material.specularF90,\n		pos, modelMatrix, viewMatrix, projectionMatrix, material.dispersion, material.ior, material.thickness,\n		material.attenuationColor, material.attenuationDistance );\n	material.transmissionAlpha = mix( material.transmissionAlpha, transmitted.a, material.transmission );\n	totalDiffuse = mix( totalDiffuse, transmitted.rgb, material.transmission );\n#endif",
+	transmission_pars_fragment: "#ifdef USE_TRANSMISSION\n	uniform float transmission;\n	uniform float thickness;\n	uniform float attenuationDistance;\n	uniform vec3 attenuationColor;\n	#ifdef USE_TRANSMISSIONMAP\n		uniform sampler2D transmissionMap;\n	#endif\n	#ifdef USE_THICKNESSMAP\n		uniform sampler2D thicknessMap;\n	#endif\n	uniform vec2 transmissionSamplerSize;\n	uniform sampler2D transmissionSamplerMap;\n	uniform mat4 modelMatrix;\n	uniform mat4 projectionMatrix;\n	varying vec3 vWorldPosition;\n	float w0( float a ) {\n		return ( 1.0 / 6.0 ) * ( a * ( a * ( - a + 3.0 ) - 3.0 ) + 1.0 );\n	}\n	float w1( float a ) {\n		return ( 1.0 / 6.0 ) * ( a *  a * ( 3.0 * a - 6.0 ) + 4.0 );\n	}\n	float w2( float a ){\n		return ( 1.0 / 6.0 ) * ( a * ( a * ( - 3.0 * a + 3.0 ) + 3.0 ) + 1.0 );\n	}\n	float w3( float a ) {\n		return ( 1.0 / 6.0 ) * ( a * a * a );\n	}\n	float g0( float a ) {\n		return w0( a ) + w1( a );\n	}\n	float g1( float a ) {\n		return w2( a ) + w3( a );\n	}\n	float h0( float a ) {\n		return - 1.0 + w1( a ) / ( w0( a ) + w1( a ) );\n	}\n	float h1( float a ) {\n		return 1.0 + w3( a ) / ( w2( a ) + w3( a ) );\n	}\n	vec4 bicubic( sampler2D tex, vec2 uv, vec4 texelSize, float lod ) {\n		uv = uv * texelSize.zw + 0.5;\n		vec2 iuv = floor( uv );\n		vec2 fuv = fract( uv );\n		float g0x = g0( fuv.x );\n		float g1x = g1( fuv.x );\n		float h0x = h0( fuv.x );\n		float h1x = h1( fuv.x );\n		float h0y = h0( fuv.y );\n		float h1y = h1( fuv.y );\n		vec2 p0 = ( vec2( iuv.x + h0x, iuv.y + h0y ) - 0.5 ) * texelSize.xy;\n		vec2 p1 = ( vec2( iuv.x + h1x, iuv.y + h0y ) - 0.5 ) * texelSize.xy;\n		vec2 p2 = ( vec2( iuv.x + h0x, iuv.y + h1y ) - 0.5 ) * texelSize.xy;\n		vec2 p3 = ( vec2( iuv.x + h1x, iuv.y + h1y ) - 0.5 ) * texelSize.xy;\n		return g0( fuv.y ) * ( g0x * textureLod( tex, p0, lod ) + g1x * textureLod( tex, p1, lod ) ) +\n			g1( fuv.y ) * ( g0x * textureLod( tex, p2, lod ) + g1x * textureLod( tex, p3, lod ) );\n	}\n	vec4 textureBicubic( sampler2D sampler, vec2 uv, float lod ) {\n		vec2 fLodSize = vec2( textureSize( sampler, int( lod ) ) );\n		vec2 cLodSize = vec2( textureSize( sampler, int( lod + 1.0 ) ) );\n		vec2 fLodSizeInv = 1.0 / fLodSize;\n		vec2 cLodSizeInv = 1.0 / cLodSize;\n		vec4 fSample = bicubic( sampler, uv, vec4( fLodSizeInv, fLodSize ), floor( lod ) );\n		vec4 cSample = bicubic( sampler, uv, vec4( cLodSizeInv, cLodSize ), ceil( lod ) );\n		return mix( fSample, cSample, fract( lod ) );\n	}\n	vec3 getVolumeTransmissionRay( const in vec3 n, const in vec3 v, const in float thickness, const in float ior, const in mat4 modelMatrix ) {\n		vec3 refractionVector = refract( - v, normalize( n ), 1.0 / ior );\n		vec3 modelScale;\n		modelScale.x = length( vec3( modelMatrix[ 0 ].xyz ) );\n		modelScale.y = length( vec3( modelMatrix[ 1 ].xyz ) );\n		modelScale.z = length( vec3( modelMatrix[ 2 ].xyz ) );\n		return normalize( refractionVector ) * thickness * modelScale;\n	}\n	float applyIorToRoughness( const in float roughness, const in float ior ) {\n		return roughness * clamp( ior * 2.0 - 2.0, 0.0, 1.0 );\n	}\n	vec4 getTransmissionSample( const in vec2 fragCoord, const in float roughness, const in float ior ) {\n		float lod = log2( transmissionSamplerSize.x ) * applyIorToRoughness( roughness, ior );\n		return textureBicubic( transmissionSamplerMap, fragCoord.xy, lod );\n	}\n	vec3 volumeAttenuation( const in float transmissionDistance, const in vec3 attenuationColor, const in float attenuationDistance ) {\n		if ( isinf( attenuationDistance ) ) {\n			return vec3( 1.0 );\n		} else {\n			vec3 attenuationCoefficient = -log( attenuationColor ) / attenuationDistance;\n			vec3 transmittance = exp( - attenuationCoefficient * transmissionDistance );			return transmittance;\n		}\n	}\n	vec4 getIBLVolumeRefraction( const in vec3 n, const in vec3 v, const in float roughness, const in vec3 diffuseColor,\n		const in vec3 specularColor, const in float specularF90, const in vec3 position, const in mat4 modelMatrix,\n		const in mat4 viewMatrix, const in mat4 projMatrix, const in float dispersion, const in float ior, const in float thickness,\n		const in vec3 attenuationColor, const in float attenuationDistance ) {\n		vec4 transmittedLight;\n		vec3 transmittance;\n		#ifdef USE_DISPERSION\n			float halfSpread = ( ior - 1.0 ) * 0.025 * dispersion;\n			vec3 iors = vec3( ior - halfSpread, ior, ior + halfSpread );\n			for ( int i = 0; i < 3; i ++ ) {\n				vec3 transmissionRay = getVolumeTransmissionRay( n, v, thickness, iors[ i ], modelMatrix );\n				vec3 refractedRayExit = position + transmissionRay;\n				vec4 ndcPos = projMatrix * viewMatrix * vec4( refractedRayExit, 1.0 );\n				vec2 refractionCoords = ndcPos.xy / ndcPos.w;\n				refractionCoords += 1.0;\n				refractionCoords /= 2.0;\n				vec4 transmissionSample = getTransmissionSample( refractionCoords, roughness, iors[ i ] );\n				transmittedLight[ i ] = transmissionSample[ i ];\n				transmittedLight.a += transmissionSample.a;\n				transmittance[ i ] = diffuseColor[ i ] * volumeAttenuation( length( transmissionRay ), attenuationColor, attenuationDistance )[ i ];\n			}\n			transmittedLight.a /= 3.0;\n		#else\n			vec3 transmissionRay = getVolumeTransmissionRay( n, v, thickness, ior, modelMatrix );\n			vec3 refractedRayExit = position + transmissionRay;\n			vec4 ndcPos = projMatrix * viewMatrix * vec4( refractedRayExit, 1.0 );\n			vec2 refractionCoords = ndcPos.xy / ndcPos.w;\n			refractionCoords += 1.0;\n			refractionCoords /= 2.0;\n			transmittedLight = getTransmissionSample( refractionCoords, roughness, ior );\n			transmittance = diffuseColor * volumeAttenuation( length( transmissionRay ), attenuationColor, attenuationDistance );\n		#endif\n		vec3 attenuatedColor = transmittance * transmittedLight.rgb;\n		vec3 F = EnvironmentBRDF( n, v, specularColor, specularF90, roughness );\n		float transmittanceFactor = ( transmittance.r + transmittance.g + transmittance.b ) / 3.0;\n		return vec4( ( 1.0 - F ) * attenuatedColor, 1.0 - ( 1.0 - transmittedLight.a ) * transmittanceFactor );\n	}\n#endif",
+	uv_pars_fragment: "#if defined( USE_UV ) || defined( USE_ANISOTROPY )\n	varying vec2 vUv;\n#endif\n#ifdef USE_MAP\n	varying vec2 vMapUv;\n#endif\n#ifdef USE_ALPHAMAP\n	varying vec2 vAlphaMapUv;\n#endif\n#ifdef USE_LIGHTMAP\n	varying vec2 vLightMapUv;\n#endif\n#ifdef USE_AOMAP\n	varying vec2 vAoMapUv;\n#endif\n#ifdef USE_BUMPMAP\n	varying vec2 vBumpMapUv;\n#endif\n#ifdef USE_NORMALMAP\n	varying vec2 vNormalMapUv;\n#endif\n#ifdef USE_EMISSIVEMAP\n	varying vec2 vEmissiveMapUv;\n#endif\n#ifdef USE_METALNESSMAP\n	varying vec2 vMetalnessMapUv;\n#endif\n#ifdef USE_ROUGHNESSMAP\n	varying vec2 vRoughnessMapUv;\n#endif\n#ifdef USE_ANISOTROPYMAP\n	varying vec2 vAnisotropyMapUv;\n#endif\n#ifdef USE_CLEARCOATMAP\n	varying vec2 vClearcoatMapUv;\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n	varying vec2 vClearcoatNormalMapUv;\n#endif\n#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n	varying vec2 vClearcoatRoughnessMapUv;\n#endif\n#ifdef USE_IRIDESCENCEMAP\n	varying vec2 vIridescenceMapUv;\n#endif\n#ifdef USE_IRIDESCENCE_THICKNESSMAP\n	varying vec2 vIridescenceThicknessMapUv;\n#endif\n#ifdef USE_SHEEN_COLORMAP\n	varying vec2 vSheenColorMapUv;\n#endif\n#ifdef USE_SHEEN_ROUGHNESSMAP\n	varying vec2 vSheenRoughnessMapUv;\n#endif\n#ifdef USE_SPECULARMAP\n	varying vec2 vSpecularMapUv;\n#endif\n#ifdef USE_SPECULAR_COLORMAP\n	varying vec2 vSpecularColorMapUv;\n#endif\n#ifdef USE_SPECULAR_INTENSITYMAP\n	varying vec2 vSpecularIntensityMapUv;\n#endif\n#ifdef USE_TRANSMISSIONMAP\n	uniform mat3 transmissionMapTransform;\n	varying vec2 vTransmissionMapUv;\n#endif\n#ifdef USE_THICKNESSMAP\n	uniform mat3 thicknessMapTransform;\n	varying vec2 vThicknessMapUv;\n#endif",
+	uv_pars_vertex: "#if defined( USE_UV ) || defined( USE_ANISOTROPY )\n	varying vec2 vUv;\n#endif\n#ifdef USE_MAP\n	uniform mat3 mapTransform;\n	varying vec2 vMapUv;\n#endif\n#ifdef USE_ALPHAMAP\n	uniform mat3 alphaMapTransform;\n	varying vec2 vAlphaMapUv;\n#endif\n#ifdef USE_LIGHTMAP\n	uniform mat3 lightMapTransform;\n	varying vec2 vLightMapUv;\n#endif\n#ifdef USE_AOMAP\n	uniform mat3 aoMapTransform;\n	varying vec2 vAoMapUv;\n#endif\n#ifdef USE_BUMPMAP\n	uniform mat3 bumpMapTransform;\n	varying vec2 vBumpMapUv;\n#endif\n#ifdef USE_NORMALMAP\n	uniform mat3 normalMapTransform;\n	varying vec2 vNormalMapUv;\n#endif\n#ifdef USE_DISPLACEMENTMAP\n	uniform mat3 displacementMapTransform;\n	varying vec2 vDisplacementMapUv;\n#endif\n#ifdef USE_EMISSIVEMAP\n	uniform mat3 emissiveMapTransform;\n	varying vec2 vEmissiveMapUv;\n#endif\n#ifdef USE_METALNESSMAP\n	uniform mat3 metalnessMapTransform;\n	varying vec2 vMetalnessMapUv;\n#endif\n#ifdef USE_ROUGHNESSMAP\n	uniform mat3 roughnessMapTransform;\n	varying vec2 vRoughnessMapUv;\n#endif\n#ifdef USE_ANISOTROPYMAP\n	uniform mat3 anisotropyMapTransform;\n	varying vec2 vAnisotropyMapUv;\n#endif\n#ifdef USE_CLEARCOATMAP\n	uniform mat3 clearcoatMapTransform;\n	varying vec2 vClearcoatMapUv;\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n	uniform mat3 clearcoatNormalMapTransform;\n	varying vec2 vClearcoatNormalMapUv;\n#endif\n#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n	uniform mat3 clearcoatRoughnessMapTransform;\n	varying vec2 vClearcoatRoughnessMapUv;\n#endif\n#ifdef USE_SHEEN_COLORMAP\n	uniform mat3 sheenColorMapTransform;\n	varying vec2 vSheenColorMapUv;\n#endif\n#ifdef USE_SHEEN_ROUGHNESSMAP\n	uniform mat3 sheenRoughnessMapTransform;\n	varying vec2 vSheenRoughnessMapUv;\n#endif\n#ifdef USE_IRIDESCENCEMAP\n	uniform mat3 iridescenceMapTransform;\n	varying vec2 vIridescenceMapUv;\n#endif\n#ifdef USE_IRIDESCENCE_THICKNESSMAP\n	uniform mat3 iridescenceThicknessMapTransform;\n	varying vec2 vIridescenceThicknessMapUv;\n#endif\n#ifdef USE_SPECULARMAP\n	uniform mat3 specularMapTransform;\n	varying vec2 vSpecularMapUv;\n#endif\n#ifdef USE_SPECULAR_COLORMAP\n	uniform mat3 specularColorMapTransform;\n	varying vec2 vSpecularColorMapUv;\n#endif\n#ifdef USE_SPECULAR_INTENSITYMAP\n	uniform mat3 specularIntensityMapTransform;\n	varying vec2 vSpecularIntensityMapUv;\n#endif\n#ifdef USE_TRANSMISSIONMAP\n	uniform mat3 transmissionMapTransform;\n	varying vec2 vTransmissionMapUv;\n#endif\n#ifdef USE_THICKNESSMAP\n	uniform mat3 thicknessMapTransform;\n	varying vec2 vThicknessMapUv;\n#endif",
+	uv_vertex: "#if defined( USE_UV ) || defined( USE_ANISOTROPY )\n	vUv = vec3( uv, 1 ).xy;\n#endif\n#ifdef USE_MAP\n	vMapUv = ( mapTransform * vec3( MAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_ALPHAMAP\n	vAlphaMapUv = ( alphaMapTransform * vec3( ALPHAMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_LIGHTMAP\n	vLightMapUv = ( lightMapTransform * vec3( LIGHTMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_AOMAP\n	vAoMapUv = ( aoMapTransform * vec3( AOMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_BUMPMAP\n	vBumpMapUv = ( bumpMapTransform * vec3( BUMPMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_NORMALMAP\n	vNormalMapUv = ( normalMapTransform * vec3( NORMALMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_DISPLACEMENTMAP\n	vDisplacementMapUv = ( displacementMapTransform * vec3( DISPLACEMENTMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_EMISSIVEMAP\n	vEmissiveMapUv = ( emissiveMapTransform * vec3( EMISSIVEMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_METALNESSMAP\n	vMetalnessMapUv = ( metalnessMapTransform * vec3( METALNESSMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_ROUGHNESSMAP\n	vRoughnessMapUv = ( roughnessMapTransform * vec3( ROUGHNESSMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_ANISOTROPYMAP\n	vAnisotropyMapUv = ( anisotropyMapTransform * vec3( ANISOTROPYMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_CLEARCOATMAP\n	vClearcoatMapUv = ( clearcoatMapTransform * vec3( CLEARCOATMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_CLEARCOAT_NORMALMAP\n	vClearcoatNormalMapUv = ( clearcoatNormalMapTransform * vec3( CLEARCOAT_NORMALMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_CLEARCOAT_ROUGHNESSMAP\n	vClearcoatRoughnessMapUv = ( clearcoatRoughnessMapTransform * vec3( CLEARCOAT_ROUGHNESSMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_IRIDESCENCEMAP\n	vIridescenceMapUv = ( iridescenceMapTransform * vec3( IRIDESCENCEMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_IRIDESCENCE_THICKNESSMAP\n	vIridescenceThicknessMapUv = ( iridescenceThicknessMapTransform * vec3( IRIDESCENCE_THICKNESSMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_SHEEN_COLORMAP\n	vSheenColorMapUv = ( sheenColorMapTransform * vec3( SHEEN_COLORMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_SHEEN_ROUGHNESSMAP\n	vSheenRoughnessMapUv = ( sheenRoughnessMapTransform * vec3( SHEEN_ROUGHNESSMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_SPECULARMAP\n	vSpecularMapUv = ( specularMapTransform * vec3( SPECULARMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_SPECULAR_COLORMAP\n	vSpecularColorMapUv = ( specularColorMapTransform * vec3( SPECULAR_COLORMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_SPECULAR_INTENSITYMAP\n	vSpecularIntensityMapUv = ( specularIntensityMapTransform * vec3( SPECULAR_INTENSITYMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_TRANSMISSIONMAP\n	vTransmissionMapUv = ( transmissionMapTransform * vec3( TRANSMISSIONMAP_UV, 1 ) ).xy;\n#endif\n#ifdef USE_THICKNESSMAP\n	vThicknessMapUv = ( thicknessMapTransform * vec3( THICKNESSMAP_UV, 1 ) ).xy;\n#endif",
+	worldpos_vertex: "#if defined( USE_ENVMAP ) || defined( DISTANCE ) || defined ( USE_SHADOWMAP ) || defined ( USE_TRANSMISSION ) || NUM_SPOT_LIGHT_COORDS > 0\n	vec4 worldPosition = vec4( transformed, 1.0 );\n	#ifdef USE_BATCHING\n		worldPosition = batchingMatrix * worldPosition;\n	#endif\n	#ifdef USE_INSTANCING\n		worldPosition = instanceMatrix * worldPosition;\n	#endif\n	worldPosition = modelMatrix * worldPosition;\n#endif",
+	background_vert: "varying vec2 vUv;\nuniform mat3 uvTransform;\nvoid main() {\n	vUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n	gl_Position = vec4( position.xy, 1.0, 1.0 );\n}",
+	background_frag: "uniform sampler2D t2D;\nuniform float backgroundIntensity;\nvarying vec2 vUv;\nvoid main() {\n	vec4 texColor = texture2D( t2D, vUv );\n	#ifdef DECODE_VIDEO_TEXTURE\n		texColor = vec4( mix( pow( texColor.rgb * 0.9478672986 + vec3( 0.0521327014 ), vec3( 2.4 ) ), texColor.rgb * 0.0773993808, vec3( lessThanEqual( texColor.rgb, vec3( 0.04045 ) ) ) ), texColor.w );\n	#endif\n	texColor.rgb *= backgroundIntensity;\n	gl_FragColor = texColor;\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n}",
+	backgroundCube_vert: "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n	vWorldDirection = transformDirection( position, modelMatrix );\n	#include <begin_vertex>\n	#include <project_vertex>\n	gl_Position.z = gl_Position.w;\n}",
+	backgroundCube_frag: "#ifdef ENVMAP_TYPE_CUBE\n	uniform samplerCube envMap;\n#elif defined( ENVMAP_TYPE_CUBE_UV )\n	uniform sampler2D envMap;\n#endif\nuniform float backgroundBlurriness;\nuniform float backgroundIntensity;\nuniform mat3 backgroundRotation;\nvarying vec3 vWorldDirection;\n#include <cube_uv_reflection_fragment>\nvoid main() {\n	#ifdef ENVMAP_TYPE_CUBE\n		vec4 texColor = textureCube( envMap, backgroundRotation * vWorldDirection );\n	#elif defined( ENVMAP_TYPE_CUBE_UV )\n		vec4 texColor = textureCubeUV( envMap, backgroundRotation * vWorldDirection, backgroundBlurriness );\n	#else\n		vec4 texColor = vec4( 0.0, 0.0, 0.0, 1.0 );\n	#endif\n	texColor.rgb *= backgroundIntensity;\n	gl_FragColor = texColor;\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n}",
+	cube_vert: "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n	vWorldDirection = transformDirection( position, modelMatrix );\n	#include <begin_vertex>\n	#include <project_vertex>\n	gl_Position.z = gl_Position.w;\n}",
+	cube_frag: "uniform samplerCube tCube;\nuniform float tFlip;\nuniform float opacity;\nvarying vec3 vWorldDirection;\nvoid main() {\n	vec4 texColor = textureCube( tCube, vec3( tFlip * vWorldDirection.x, vWorldDirection.yz ) );\n	gl_FragColor = texColor;\n	gl_FragColor.a *= opacity;\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n}",
+	depth_vert: "#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvarying vec2 vHighPrecisionZW;\nvoid main() {\n	#include <uv_vertex>\n	#include <batching_vertex>\n	#include <skinbase_vertex>\n	#include <morphinstance_vertex>\n	#ifdef USE_DISPLACEMENTMAP\n		#include <beginnormal_vertex>\n		#include <morphnormal_vertex>\n		#include <skinnormal_vertex>\n	#endif\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	vHighPrecisionZW = gl_Position.zw;\n}",
+	depth_frag: "#if DEPTH_PACKING == 3200\n	uniform float opacity;\n#endif\n#include <common>\n#include <packing>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvarying vec2 vHighPrecisionZW;\nvoid main() {\n	vec4 diffuseColor = vec4( 1.0 );\n	#include <clipping_planes_fragment>\n	#if DEPTH_PACKING == 3200\n		diffuseColor.a = opacity;\n	#endif\n	#include <map_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <logdepthbuf_fragment>\n	#ifdef USE_REVERSED_DEPTH_BUFFER\n		float fragCoordZ = vHighPrecisionZW[ 0 ] / vHighPrecisionZW[ 1 ];\n	#else\n		float fragCoordZ = 0.5 * vHighPrecisionZW[ 0 ] / vHighPrecisionZW[ 1 ] + 0.5;\n	#endif\n	#if DEPTH_PACKING == 3200\n		gl_FragColor = vec4( vec3( 1.0 - fragCoordZ ), opacity );\n	#elif DEPTH_PACKING == 3201\n		gl_FragColor = packDepthToRGBA( fragCoordZ );\n	#elif DEPTH_PACKING == 3202\n		gl_FragColor = vec4( packDepthToRGB( fragCoordZ ), 1.0 );\n	#elif DEPTH_PACKING == 3203\n		gl_FragColor = vec4( packDepthToRG( fragCoordZ ), 0.0, 1.0 );\n	#endif\n}",
+	distance_vert: "#define DISTANCE\nvarying vec3 vWorldPosition;\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <batching_vertex>\n	#include <skinbase_vertex>\n	#include <morphinstance_vertex>\n	#ifdef USE_DISPLACEMENTMAP\n		#include <beginnormal_vertex>\n		#include <morphnormal_vertex>\n		#include <skinnormal_vertex>\n	#endif\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <worldpos_vertex>\n	#include <clipping_planes_vertex>\n	vWorldPosition = worldPosition.xyz;\n}",
+	distance_frag: "#define DISTANCE\nuniform vec3 referencePosition;\nuniform float nearDistance;\nuniform float farDistance;\nvarying vec3 vWorldPosition;\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( 1.0 );\n	#include <clipping_planes_fragment>\n	#include <map_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	float dist = length( vWorldPosition - referencePosition );\n	dist = ( dist - nearDistance ) / ( farDistance - nearDistance );\n	dist = saturate( dist );\n	gl_FragColor = vec4( dist, 0.0, 0.0, 1.0 );\n}",
+	equirect_vert: "varying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n	vWorldDirection = transformDirection( position, modelMatrix );\n	#include <begin_vertex>\n	#include <project_vertex>\n}",
+	equirect_frag: "uniform sampler2D tEquirect;\nvarying vec3 vWorldDirection;\n#include <common>\nvoid main() {\n	vec3 direction = normalize( vWorldDirection );\n	vec2 sampleUV = equirectUv( direction );\n	gl_FragColor = texture2D( tEquirect, sampleUV );\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n}",
+	linedashed_vert: "uniform float scale;\nattribute float lineDistance;\nvarying float vLineDistance;\n#include <common>\n#include <uv_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	vLineDistance = scale * lineDistance;\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	#include <fog_vertex>\n}",
+	linedashed_frag: "uniform vec3 diffuse;\nuniform float opacity;\nuniform float dashSize;\nuniform float totalSize;\nvarying float vLineDistance;\n#include <common>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	if ( mod( vLineDistance, totalSize ) > dashSize ) {\n		discard;\n	}\n	vec3 outgoingLight = vec3( 0.0 );\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	outgoingLight = diffuseColor.rgb;\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n}",
+	meshbasic_vert: "#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <batching_vertex>\n	#if defined ( USE_ENVMAP ) || defined ( USE_SKINNING )\n		#include <beginnormal_vertex>\n		#include <morphnormal_vertex>\n		#include <skinbase_vertex>\n		#include <skinnormal_vertex>\n		#include <defaultnormal_vertex>\n	#endif\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	#include <worldpos_vertex>\n	#include <envmap_vertex>\n	#include <fog_vertex>\n}",
+	meshbasic_frag: "uniform vec3 diffuse;\nuniform float opacity;\n#ifndef FLAT_SHADED\n	varying vec3 vNormal;\n#endif\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <specularmap_fragment>\n	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n	#ifdef USE_LIGHTMAP\n		vec4 lightMapTexel = texture2D( lightMap, vLightMapUv );\n		reflectedLight.indirectDiffuse += lightMapTexel.rgb * lightMapIntensity * RECIPROCAL_PI;\n	#else\n		reflectedLight.indirectDiffuse += vec3( 1.0 );\n	#endif\n	#include <aomap_fragment>\n	reflectedLight.indirectDiffuse *= diffuseColor.rgb;\n	vec3 outgoingLight = reflectedLight.indirectDiffuse;\n	#include <envmap_fragment>\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n	#include <dithering_fragment>\n}",
+	meshlambert_vert: "#define LAMBERT\nvarying vec3 vViewPosition;\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <normal_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <normal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	vViewPosition = - mvPosition.xyz;\n	#include <worldpos_vertex>\n	#include <envmap_vertex>\n	#include <shadowmap_vertex>\n	#include <fog_vertex>\n}",
+	meshlambert_frag: "#define LAMBERT\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float opacity;\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <normal_pars_fragment>\n#include <lights_lambert_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n	vec3 totalEmissiveRadiance = emissive;\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <specularmap_fragment>\n	#include <normal_fragment_begin>\n	#include <normal_fragment_maps>\n	#include <emissivemap_fragment>\n	#include <lights_lambert_fragment>\n	#include <lights_fragment_begin>\n	#include <lights_fragment_maps>\n	#include <lights_fragment_end>\n	#include <aomap_fragment>\n	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;\n	#include <envmap_fragment>\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n	#include <dithering_fragment>\n}",
+	meshmatcap_vert: "#define MATCAP\nvarying vec3 vViewPosition;\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <color_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <fog_pars_vertex>\n#include <normal_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <normal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	#include <fog_vertex>\n	vViewPosition = - mvPosition.xyz;\n}",
+	meshmatcap_frag: "#define MATCAP\nuniform vec3 diffuse;\nuniform float opacity;\nuniform sampler2D matcap;\nvarying vec3 vViewPosition;\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <fog_pars_fragment>\n#include <normal_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <normal_fragment_begin>\n	#include <normal_fragment_maps>\n	vec3 viewDir = normalize( vViewPosition );\n	vec3 x = normalize( vec3( viewDir.z, 0.0, - viewDir.x ) );\n	vec3 y = cross( viewDir, x );\n	vec2 uv = vec2( dot( x, normal ), dot( y, normal ) ) * 0.495 + 0.5;\n	#ifdef USE_MATCAP\n		vec4 matcapColor = texture2D( matcap, uv );\n	#else\n		vec4 matcapColor = vec4( vec3( mix( 0.2, 0.8, uv.y ) ), 1.0 );\n	#endif\n	vec3 outgoingLight = diffuseColor.rgb * matcapColor.rgb;\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n	#include <dithering_fragment>\n}",
+	meshnormal_vert: "#define NORMAL\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP_TANGENTSPACE )\n	varying vec3 vViewPosition;\n#endif\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <normal_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphinstance_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <normal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP_TANGENTSPACE )\n	vViewPosition = - mvPosition.xyz;\n#endif\n}",
+	meshnormal_frag: "#define NORMAL\nuniform float opacity;\n#if defined( FLAT_SHADED ) || defined( USE_BUMPMAP ) || defined( USE_NORMALMAP_TANGENTSPACE )\n	varying vec3 vViewPosition;\n#endif\n#include <uv_pars_fragment>\n#include <normal_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( 0.0, 0.0, 0.0, opacity );\n	#include <clipping_planes_fragment>\n	#include <logdepthbuf_fragment>\n	#include <normal_fragment_begin>\n	#include <normal_fragment_maps>\n	gl_FragColor = vec4( normalize( normal ) * 0.5 + 0.5, diffuseColor.a );\n	#ifdef OPAQUE\n		gl_FragColor.a = 1.0;\n	#endif\n}",
+	meshphong_vert: "#define PHONG\nvarying vec3 vViewPosition;\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <envmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <normal_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphcolor_vertex>\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphinstance_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <normal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	vViewPosition = - mvPosition.xyz;\n	#include <worldpos_vertex>\n	#include <envmap_vertex>\n	#include <shadowmap_vertex>\n	#include <fog_vertex>\n}",
+	meshphong_frag: "#define PHONG\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform vec3 specular;\nuniform float shininess;\nuniform float opacity;\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <cube_uv_reflection_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <normal_pars_fragment>\n#include <lights_phong_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <specularmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n	vec3 totalEmissiveRadiance = emissive;\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <specularmap_fragment>\n	#include <normal_fragment_begin>\n	#include <normal_fragment_maps>\n	#include <emissivemap_fragment>\n	#include <lights_phong_fragment>\n	#include <lights_fragment_begin>\n	#include <lights_fragment_maps>\n	#include <lights_fragment_end>\n	#include <aomap_fragment>\n	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + reflectedLight.directSpecular + reflectedLight.indirectSpecular + totalEmissiveRadiance;\n	#include <envmap_fragment>\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n	#include <dithering_fragment>\n}",
+	meshphysical_vert: "#define STANDARD\nvarying vec3 vViewPosition;\n#ifdef USE_TRANSMISSION\n	varying vec3 vWorldPosition;\n#endif\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <normal_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <normal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	vViewPosition = - mvPosition.xyz;\n	#include <worldpos_vertex>\n	#include <shadowmap_vertex>\n	#include <fog_vertex>\n#ifdef USE_TRANSMISSION\n	vWorldPosition = worldPosition.xyz;\n#endif\n}",
+	meshphysical_frag: "#define STANDARD\n#ifdef PHYSICAL\n	#define IOR\n	#define USE_SPECULAR\n#endif\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float roughness;\nuniform float metalness;\nuniform float opacity;\n#ifdef IOR\n	uniform float ior;\n#endif\n#ifdef USE_SPECULAR\n	uniform float specularIntensity;\n	uniform vec3 specularColor;\n	#ifdef USE_SPECULAR_COLORMAP\n		uniform sampler2D specularColorMap;\n	#endif\n	#ifdef USE_SPECULAR_INTENSITYMAP\n		uniform sampler2D specularIntensityMap;\n	#endif\n#endif\n#ifdef USE_CLEARCOAT\n	uniform float clearcoat;\n	uniform float clearcoatRoughness;\n#endif\n#ifdef USE_DISPERSION\n	uniform float dispersion;\n#endif\n#ifdef USE_IRIDESCENCE\n	uniform float iridescence;\n	uniform float iridescenceIOR;\n	uniform float iridescenceThicknessMinimum;\n	uniform float iridescenceThicknessMaximum;\n#endif\n#ifdef USE_SHEEN\n	uniform vec3 sheenColor;\n	uniform float sheenRoughness;\n	#ifdef USE_SHEEN_COLORMAP\n		uniform sampler2D sheenColorMap;\n	#endif\n	#ifdef USE_SHEEN_ROUGHNESSMAP\n		uniform sampler2D sheenRoughnessMap;\n	#endif\n#endif\n#ifdef USE_ANISOTROPY\n	uniform vec2 anisotropyVector;\n	#ifdef USE_ANISOTROPYMAP\n		uniform sampler2D anisotropyMap;\n	#endif\n#endif\nvarying vec3 vViewPosition;\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <iridescence_fragment>\n#include <cube_uv_reflection_fragment>\n#include <envmap_common_pars_fragment>\n#include <envmap_physical_pars_fragment>\n#include <fog_pars_fragment>\n#include <lights_pars_begin>\n#include <normal_pars_fragment>\n#include <lights_physical_pars_fragment>\n#include <transmission_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <clearcoat_pars_fragment>\n#include <iridescence_pars_fragment>\n#include <roughnessmap_pars_fragment>\n#include <metalnessmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n	vec3 totalEmissiveRadiance = emissive;\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <roughnessmap_fragment>\n	#include <metalnessmap_fragment>\n	#include <normal_fragment_begin>\n	#include <normal_fragment_maps>\n	#include <clearcoat_normal_fragment_begin>\n	#include <clearcoat_normal_fragment_maps>\n	#include <emissivemap_fragment>\n	#include <lights_physical_fragment>\n	#include <lights_fragment_begin>\n	#include <lights_fragment_maps>\n	#include <lights_fragment_end>\n	#include <aomap_fragment>\n	vec3 totalDiffuse = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse;\n	vec3 totalSpecular = reflectedLight.directSpecular + reflectedLight.indirectSpecular;\n	#include <transmission_fragment>\n	vec3 outgoingLight = totalDiffuse + totalSpecular + totalEmissiveRadiance;\n	#ifdef USE_SHEEN\n \n		outgoingLight = outgoingLight + sheenSpecularDirect + sheenSpecularIndirect;\n \n 	#endif\n	#ifdef USE_CLEARCOAT\n		float dotNVcc = saturate( dot( geometryClearcoatNormal, geometryViewDir ) );\n		vec3 Fcc = F_Schlick( material.clearcoatF0, material.clearcoatF90, dotNVcc );\n		outgoingLight = outgoingLight * ( 1.0 - material.clearcoat * Fcc ) + ( clearcoatSpecularDirect + clearcoatSpecularIndirect ) * material.clearcoat;\n	#endif\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n	#include <dithering_fragment>\n}",
+	meshtoon_vert: "#define TOON\nvarying vec3 vViewPosition;\n#include <common>\n#include <batching_pars_vertex>\n#include <uv_pars_vertex>\n#include <displacementmap_pars_vertex>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <normal_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <shadowmap_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <normal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <displacementmap_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	vViewPosition = - mvPosition.xyz;\n	#include <worldpos_vertex>\n	#include <shadowmap_vertex>\n	#include <fog_vertex>\n}",
+	meshtoon_frag: "#define TOON\nuniform vec3 diffuse;\nuniform vec3 emissive;\nuniform float opacity;\n#include <common>\n#include <dithering_pars_fragment>\n#include <color_pars_fragment>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <aomap_pars_fragment>\n#include <lightmap_pars_fragment>\n#include <emissivemap_pars_fragment>\n#include <gradientmap_pars_fragment>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <normal_pars_fragment>\n#include <lights_toon_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <bumpmap_pars_fragment>\n#include <normalmap_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	ReflectedLight reflectedLight = ReflectedLight( vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ), vec3( 0.0 ) );\n	vec3 totalEmissiveRadiance = emissive;\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <color_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	#include <normal_fragment_begin>\n	#include <normal_fragment_maps>\n	#include <emissivemap_fragment>\n	#include <lights_toon_fragment>\n	#include <lights_fragment_begin>\n	#include <lights_fragment_maps>\n	#include <lights_fragment_end>\n	#include <aomap_fragment>\n	vec3 outgoingLight = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse + totalEmissiveRadiance;\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n	#include <dithering_fragment>\n}",
+	points_vert: "uniform float size;\nuniform float scale;\n#include <common>\n#include <color_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\n#ifdef USE_POINTS_UV\n	varying vec2 vUv;\n	uniform mat3 uvTransform;\n#endif\nvoid main() {\n	#ifdef USE_POINTS_UV\n		vUv = ( uvTransform * vec3( uv, 1 ) ).xy;\n	#endif\n	#include <color_vertex>\n	#include <morphinstance_vertex>\n	#include <morphcolor_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <project_vertex>\n	gl_PointSize = size;\n	#ifdef USE_SIZEATTENUATION\n		bool isPerspective = isPerspectiveMatrix( projectionMatrix );\n		if ( isPerspective ) gl_PointSize *= ( scale / - mvPosition.z );\n	#endif\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	#include <worldpos_vertex>\n	#include <fog_vertex>\n}",
+	points_frag: "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <color_pars_fragment>\n#include <map_particle_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	vec3 outgoingLight = vec3( 0.0 );\n	#include <logdepthbuf_fragment>\n	#include <map_particle_fragment>\n	#include <color_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	outgoingLight = diffuseColor.rgb;\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n}",
+	shadow_vert: "#include <common>\n#include <batching_pars_vertex>\n#include <fog_pars_vertex>\n#include <morphtarget_pars_vertex>\n#include <skinning_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <shadowmap_pars_vertex>\nvoid main() {\n	#include <batching_vertex>\n	#include <beginnormal_vertex>\n	#include <morphinstance_vertex>\n	#include <morphnormal_vertex>\n	#include <skinbase_vertex>\n	#include <skinnormal_vertex>\n	#include <defaultnormal_vertex>\n	#include <begin_vertex>\n	#include <morphtarget_vertex>\n	#include <skinning_vertex>\n	#include <project_vertex>\n	#include <logdepthbuf_vertex>\n	#include <worldpos_vertex>\n	#include <shadowmap_vertex>\n	#include <fog_vertex>\n}",
+	shadow_frag: "uniform vec3 color;\nuniform float opacity;\n#include <common>\n#include <fog_pars_fragment>\n#include <bsdfs>\n#include <lights_pars_begin>\n#include <logdepthbuf_pars_fragment>\n#include <shadowmap_pars_fragment>\n#include <shadowmask_pars_fragment>\nvoid main() {\n	#include <logdepthbuf_fragment>\n	gl_FragColor = vec4( color, opacity * ( 1.0 - getShadowMask() ) );\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n	#include <premultiplied_alpha_fragment>\n}",
+	sprite_vert: "uniform float rotation;\nuniform vec2 center;\n#include <common>\n#include <uv_pars_vertex>\n#include <fog_pars_vertex>\n#include <logdepthbuf_pars_vertex>\n#include <clipping_planes_pars_vertex>\nvoid main() {\n	#include <uv_vertex>\n	vec4 mvPosition = modelViewMatrix[ 3 ];\n	vec2 scale = vec2( length( modelMatrix[ 0 ].xyz ), length( modelMatrix[ 1 ].xyz ) );\n	#ifndef USE_SIZEATTENUATION\n		bool isPerspective = isPerspectiveMatrix( projectionMatrix );\n		if ( isPerspective ) scale *= - mvPosition.z;\n	#endif\n	vec2 alignedPosition = ( position.xy - ( center - vec2( 0.5 ) ) ) * scale;\n	vec2 rotatedPosition;\n	rotatedPosition.x = cos( rotation ) * alignedPosition.x - sin( rotation ) * alignedPosition.y;\n	rotatedPosition.y = sin( rotation ) * alignedPosition.x + cos( rotation ) * alignedPosition.y;\n	mvPosition.xy += rotatedPosition;\n	gl_Position = projectionMatrix * mvPosition;\n	#include <logdepthbuf_vertex>\n	#include <clipping_planes_vertex>\n	#include <fog_vertex>\n}",
+	sprite_frag: "uniform vec3 diffuse;\nuniform float opacity;\n#include <common>\n#include <uv_pars_fragment>\n#include <map_pars_fragment>\n#include <alphamap_pars_fragment>\n#include <alphatest_pars_fragment>\n#include <alphahash_pars_fragment>\n#include <fog_pars_fragment>\n#include <logdepthbuf_pars_fragment>\n#include <clipping_planes_pars_fragment>\nvoid main() {\n	vec4 diffuseColor = vec4( diffuse, opacity );\n	#include <clipping_planes_fragment>\n	vec3 outgoingLight = vec3( 0.0 );\n	#include <logdepthbuf_fragment>\n	#include <map_fragment>\n	#include <alphamap_fragment>\n	#include <alphatest_fragment>\n	#include <alphahash_fragment>\n	outgoingLight = diffuseColor.rgb;\n	#include <opaque_fragment>\n	#include <tonemapping_fragment>\n	#include <colorspace_fragment>\n	#include <fog_fragment>\n}"
+}, $ = {
+	common: {
+		diffuse: { value: /*@__PURE__*/ new Z(16777215) },
+		opacity: { value: 1 },
+		map: { value: null },
+		mapTransform: { value: /*@__PURE__*/ new G() },
+		alphaMap: { value: null },
+		alphaMapTransform: { value: /*@__PURE__*/ new G() },
+		alphaTest: { value: 0 }
+	},
+	specularmap: {
+		specularMap: { value: null },
+		specularMapTransform: { value: /*@__PURE__*/ new G() }
+	},
+	envmap: {
+		envMap: { value: null },
+		envMapRotation: { value: /*@__PURE__*/ new G() },
+		reflectivity: { value: 1 },
+		ior: { value: 1.5 },
+		refractionRatio: { value: .98 },
+		dfgLUT: { value: null }
+	},
+	aomap: {
+		aoMap: { value: null },
+		aoMapIntensity: { value: 1 },
+		aoMapTransform: { value: /*@__PURE__*/ new G() }
+	},
+	lightmap: {
+		lightMap: { value: null },
+		lightMapIntensity: { value: 1 },
+		lightMapTransform: { value: /*@__PURE__*/ new G() }
+	},
+	bumpmap: {
+		bumpMap: { value: null },
+		bumpMapTransform: { value: /*@__PURE__*/ new G() },
+		bumpScale: { value: 1 }
+	},
+	normalmap: {
+		normalMap: { value: null },
+		normalMapTransform: { value: /*@__PURE__*/ new G() },
+		normalScale: { value: /*@__PURE__*/ new U(1, 1) }
+	},
+	displacementmap: {
+		displacementMap: { value: null },
+		displacementMapTransform: { value: /*@__PURE__*/ new G() },
+		displacementScale: { value: 1 },
+		displacementBias: { value: 0 }
+	},
+	emissivemap: {
+		emissiveMap: { value: null },
+		emissiveMapTransform: { value: /*@__PURE__*/ new G() }
+	},
+	metalnessmap: {
+		metalnessMap: { value: null },
+		metalnessMapTransform: { value: /*@__PURE__*/ new G() }
+	},
+	roughnessmap: {
+		roughnessMap: { value: null },
+		roughnessMapTransform: { value: /*@__PURE__*/ new G() }
+	},
+	gradientmap: { gradientMap: { value: null } },
+	fog: {
+		fogDensity: { value: 25e-5 },
+		fogNear: { value: 1 },
+		fogFar: { value: 2e3 },
+		fogColor: { value: /*@__PURE__*/ new Z(16777215) }
+	},
+	lights: {
+		ambientLightColor: { value: [] },
+		lightProbe: { value: [] },
+		directionalLights: {
+			value: [],
+			properties: {
+				direction: {},
+				color: {}
+			}
+		},
+		directionalLightShadows: {
+			value: [],
+			properties: {
+				shadowIntensity: 1,
+				shadowBias: {},
+				shadowNormalBias: {},
+				shadowRadius: {},
+				shadowMapSize: {}
+			}
+		},
+		directionalShadowMatrix: { value: [] },
+		spotLights: {
+			value: [],
+			properties: {
+				color: {},
+				position: {},
+				direction: {},
+				distance: {},
+				coneCos: {},
+				penumbraCos: {},
+				decay: {}
+			}
+		},
+		spotLightShadows: {
+			value: [],
+			properties: {
+				shadowIntensity: 1,
+				shadowBias: {},
+				shadowNormalBias: {},
+				shadowRadius: {},
+				shadowMapSize: {}
+			}
+		},
+		spotLightMap: { value: [] },
+		spotLightMatrix: { value: [] },
+		pointLights: {
+			value: [],
+			properties: {
+				color: {},
+				position: {},
+				decay: {},
+				distance: {}
+			}
+		},
+		pointLightShadows: {
+			value: [],
+			properties: {
+				shadowIntensity: 1,
+				shadowBias: {},
+				shadowNormalBias: {},
+				shadowRadius: {},
+				shadowMapSize: {},
+				shadowCameraNear: {},
+				shadowCameraFar: {}
+			}
+		},
+		pointShadowMatrix: { value: [] },
+		hemisphereLights: {
+			value: [],
+			properties: {
+				direction: {},
+				skyColor: {},
+				groundColor: {}
+			}
+		},
+		rectAreaLights: {
+			value: [],
+			properties: {
+				color: {},
+				position: {},
+				width: {},
+				height: {}
+			}
+		},
+		ltc_1: { value: null },
+		ltc_2: { value: null },
+		probesSH: { value: null },
+		probesMin: { value: /*@__PURE__*/ new W() },
+		probesMax: { value: /*@__PURE__*/ new W() },
+		probesResolution: { value: /*@__PURE__*/ new W() }
+	},
+	points: {
+		diffuse: { value: /*@__PURE__*/ new Z(16777215) },
+		opacity: { value: 1 },
+		size: { value: 1 },
+		scale: { value: 1 },
+		map: { value: null },
+		alphaMap: { value: null },
+		alphaMapTransform: { value: /*@__PURE__*/ new G() },
+		alphaTest: { value: 0 },
+		uvTransform: { value: /*@__PURE__*/ new G() }
+	},
+	sprite: {
+		diffuse: { value: /*@__PURE__*/ new Z(16777215) },
+		opacity: { value: 1 },
+		center: { value: /*@__PURE__*/ new U(.5, .5) },
+		rotation: { value: 0 },
+		map: { value: null },
+		mapTransform: { value: /*@__PURE__*/ new G() },
+		alphaMap: { value: null },
+		alphaMapTransform: { value: /*@__PURE__*/ new G() },
+		alphaTest: { value: 0 }
+	}
+}, li = {
+	basic: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.specularmap,
+			$.envmap,
+			$.aomap,
+			$.lightmap,
+			$.fog
+		]),
+		vertexShader: Q.meshbasic_vert,
+		fragmentShader: Q.meshbasic_frag
+	},
+	lambert: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.specularmap,
+			$.envmap,
+			$.aomap,
+			$.lightmap,
+			$.emissivemap,
+			$.bumpmap,
+			$.normalmap,
+			$.displacementmap,
+			$.fog,
+			$.lights,
+			{
+				emissive: { value: /*@__PURE__*/ new Z(0) },
+				envMapIntensity: { value: 1 }
+			}
+		]),
+		vertexShader: Q.meshlambert_vert,
+		fragmentShader: Q.meshlambert_frag
+	},
+	phong: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.specularmap,
+			$.envmap,
+			$.aomap,
+			$.lightmap,
+			$.emissivemap,
+			$.bumpmap,
+			$.normalmap,
+			$.displacementmap,
+			$.fog,
+			$.lights,
+			{
+				emissive: { value: /*@__PURE__*/ new Z(0) },
+				specular: { value: /*@__PURE__*/ new Z(1118481) },
+				shininess: { value: 30 },
+				envMapIntensity: { value: 1 }
+			}
+		]),
+		vertexShader: Q.meshphong_vert,
+		fragmentShader: Q.meshphong_frag
+	},
+	standard: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.envmap,
+			$.aomap,
+			$.lightmap,
+			$.emissivemap,
+			$.bumpmap,
+			$.normalmap,
+			$.displacementmap,
+			$.roughnessmap,
+			$.metalnessmap,
+			$.fog,
+			$.lights,
+			{
+				emissive: { value: /*@__PURE__*/ new Z(0) },
+				roughness: { value: 1 },
+				metalness: { value: 0 },
+				envMapIntensity: { value: 1 }
+			}
+		]),
+		vertexShader: Q.meshphysical_vert,
+		fragmentShader: Q.meshphysical_frag
+	},
+	toon: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.aomap,
+			$.lightmap,
+			$.emissivemap,
+			$.bumpmap,
+			$.normalmap,
+			$.displacementmap,
+			$.gradientmap,
+			$.fog,
+			$.lights,
+			{ emissive: { value: /*@__PURE__*/ new Z(0) } }
+		]),
+		vertexShader: Q.meshtoon_vert,
+		fragmentShader: Q.meshtoon_frag
+	},
+	matcap: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.bumpmap,
+			$.normalmap,
+			$.displacementmap,
+			$.fog,
+			{ matcap: { value: null } }
+		]),
+		vertexShader: Q.meshmatcap_vert,
+		fragmentShader: Q.meshmatcap_frag
+	},
+	points: {
+		uniforms: /*@__PURE__*/ sr([$.points, $.fog]),
+		vertexShader: Q.points_vert,
+		fragmentShader: Q.points_frag
+	},
+	dashed: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.fog,
+			{
+				scale: { value: 1 },
+				dashSize: { value: 1 },
+				totalSize: { value: 2 }
+			}
+		]),
+		vertexShader: Q.linedashed_vert,
+		fragmentShader: Q.linedashed_frag
+	},
+	depth: {
+		uniforms: /*@__PURE__*/ sr([$.common, $.displacementmap]),
+		vertexShader: Q.depth_vert,
+		fragmentShader: Q.depth_frag
+	},
+	normal: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.bumpmap,
+			$.normalmap,
+			$.displacementmap,
+			{ opacity: { value: 1 } }
+		]),
+		vertexShader: Q.meshnormal_vert,
+		fragmentShader: Q.meshnormal_frag
+	},
+	sprite: {
+		uniforms: /*@__PURE__*/ sr([$.sprite, $.fog]),
+		vertexShader: Q.sprite_vert,
+		fragmentShader: Q.sprite_frag
+	},
+	background: {
+		uniforms: {
+			uvTransform: { value: /*@__PURE__*/ new G() },
+			t2D: { value: null },
+			backgroundIntensity: { value: 1 }
+		},
+		vertexShader: Q.background_vert,
+		fragmentShader: Q.background_frag
+	},
+	backgroundCube: {
+		uniforms: {
+			envMap: { value: null },
+			backgroundBlurriness: { value: 0 },
+			backgroundIntensity: { value: 1 },
+			backgroundRotation: { value: /*@__PURE__*/ new G() }
+		},
+		vertexShader: Q.backgroundCube_vert,
+		fragmentShader: Q.backgroundCube_frag
+	},
+	cube: {
+		uniforms: {
+			tCube: { value: null },
+			tFlip: { value: -1 },
+			opacity: { value: 1 }
+		},
+		vertexShader: Q.cube_vert,
+		fragmentShader: Q.cube_frag
+	},
+	equirect: {
+		uniforms: { tEquirect: { value: null } },
+		vertexShader: Q.equirect_vert,
+		fragmentShader: Q.equirect_frag
+	},
+	distance: {
+		uniforms: /*@__PURE__*/ sr([
+			$.common,
+			$.displacementmap,
+			{
+				referencePosition: { value: /*@__PURE__*/ new W() },
+				nearDistance: { value: 1 },
+				farDistance: { value: 1e3 }
+			}
+		]),
+		vertexShader: Q.distance_vert,
+		fragmentShader: Q.distance_frag
+	},
+	shadow: {
+		uniforms: /*@__PURE__*/ sr([
+			$.lights,
+			$.fog,
+			{
+				color: { value: /*@__PURE__*/ new Z(0) },
+				opacity: { value: 1 }
+			}
+		]),
+		vertexShader: Q.shadow_vert,
+		fragmentShader: Q.shadow_frag
+	}
+};
+li.physical = {
+	uniforms: /*@__PURE__*/ sr([li.standard.uniforms, {
+		clearcoat: { value: 0 },
+		clearcoatMap: { value: null },
+		clearcoatMapTransform: { value: /*@__PURE__*/ new G() },
+		clearcoatNormalMap: { value: null },
+		clearcoatNormalMapTransform: { value: /*@__PURE__*/ new G() },
+		clearcoatNormalScale: { value: /*@__PURE__*/ new U(1, 1) },
+		clearcoatRoughness: { value: 0 },
+		clearcoatRoughnessMap: { value: null },
+		clearcoatRoughnessMapTransform: { value: /*@__PURE__*/ new G() },
+		dispersion: { value: 0 },
+		iridescence: { value: 0 },
+		iridescenceMap: { value: null },
+		iridescenceMapTransform: { value: /*@__PURE__*/ new G() },
+		iridescenceIOR: { value: 1.3 },
+		iridescenceThicknessMinimum: { value: 100 },
+		iridescenceThicknessMaximum: { value: 400 },
+		iridescenceThicknessMap: { value: null },
+		iridescenceThicknessMapTransform: { value: /*@__PURE__*/ new G() },
+		sheen: { value: 0 },
+		sheenColor: { value: /*@__PURE__*/ new Z(0) },
+		sheenColorMap: { value: null },
+		sheenColorMapTransform: { value: /*@__PURE__*/ new G() },
+		sheenRoughness: { value: 1 },
+		sheenRoughnessMap: { value: null },
+		sheenRoughnessMapTransform: { value: /*@__PURE__*/ new G() },
+		transmission: { value: 0 },
+		transmissionMap: { value: null },
+		transmissionMapTransform: { value: /*@__PURE__*/ new G() },
+		transmissionSamplerSize: { value: /*@__PURE__*/ new U() },
+		transmissionSamplerMap: { value: null },
+		thickness: { value: 0 },
+		thicknessMap: { value: null },
+		thicknessMapTransform: { value: /*@__PURE__*/ new G() },
+		attenuationDistance: { value: 0 },
+		attenuationColor: { value: /*@__PURE__*/ new Z(0) },
+		specularColor: { value: /*@__PURE__*/ new Z(1, 1, 1) },
+		specularColorMap: { value: null },
+		specularColorMapTransform: { value: /*@__PURE__*/ new G() },
+		specularIntensity: { value: 1 },
+		specularIntensityMap: { value: null },
+		specularIntensityMapTransform: { value: /*@__PURE__*/ new G() },
+		anisotropyVector: { value: /*@__PURE__*/ new U() },
+		anisotropyMap: { value: null },
+		anisotropyMapTransform: { value: /*@__PURE__*/ new G() }
+	}]),
+	vertexShader: Q.meshphysical_vert,
+	fragmentShader: Q.meshphysical_frag
+};
+var ui = {
+	r: 0,
+	b: 0,
+	g: 0
+}, di = /*@__PURE__*/ new Fe(), fi = /*@__PURE__*/ new G();
+fi.set(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+function pi(e, t, n, r, i, a) {
+	let o = new Z(0), s = i === !0 ? 0 : 1, c, l, u = null, d = 0, f = null;
+	function p(e) {
+		let n = e.isScene === !0 ? e.background : null;
+		if (n && n.isTexture) {
+			let r = e.backgroundBlurriness > 0;
+			n = t.get(n, r);
+		}
+		return n;
+	}
+	function m(t) {
+		let r = !1, i = p(t);
+		i === null ? g(o, s) : i && i.isColor && (g(i, 1), r = !0);
+		let c = e.xr.getEnvironmentBlendMode();
+		c === "additive" ? n.buffers.color.setClear(0, 0, 0, 1, a) : c === "alpha-blend" && n.buffers.color.setClear(0, 0, 0, 0, a), (e.autoClear || r) && (n.buffers.depth.setTest(!0), n.buffers.depth.setMask(!0), n.buffers.color.setMask(!0), e.clear(e.autoClearColor, e.autoClearDepth, e.autoClearStencil));
+	}
+	function h(t, n) {
+		let i = p(n);
+		i && (i.isCubeTexture || i.mapping === 306) ? (l === void 0 && (l = new Mn(new rr(1, 1, 1), new mr({
+			name: "BackgroundCubeMaterial",
+			uniforms: or(li.backgroundCube.uniforms),
+			vertexShader: li.backgroundCube.vertexShader,
+			fragmentShader: li.backgroundCube.fragmentShader,
+			side: 1,
+			depthTest: !1,
+			depthWrite: !1,
+			fog: !1,
+			allowOverride: !1
+		})), l.geometry.deleteAttribute("normal"), l.geometry.deleteAttribute("uv"), l.onBeforeRender = function(e, t, n) {
+			this.matrixWorld.copyPosition(n.matrixWorld);
+		}, Object.defineProperty(l.material, "envMap", { get: function() {
+			return this.uniforms.envMap.value;
+		} }), r.update(l)), l.material.uniforms.envMap.value = i, l.material.uniforms.backgroundBlurriness.value = n.backgroundBlurriness, l.material.uniforms.backgroundIntensity.value = n.backgroundIntensity, l.material.uniforms.backgroundRotation.value.setFromMatrix4(di.makeRotationFromEuler(n.backgroundRotation)).transpose(), i.isCubeTexture && i.isRenderTargetTexture === !1 && l.material.uniforms.backgroundRotation.value.premultiply(fi), l.material.toneMapped = K.getTransfer(i.colorSpace) !== j, (u !== i || d !== i.version || f !== e.toneMapping) && (l.material.needsUpdate = !0, u = i, d = i.version, f = e.toneMapping), l.layers.enableAll(), t.unshift(l, l.geometry, l.material, 0, 0, null)) : i && i.isTexture && (c === void 0 && (c = new Mn(new ar(2, 2), new mr({
+			name: "BackgroundMaterial",
+			uniforms: or(li.background.uniforms),
+			vertexShader: li.background.vertexShader,
+			fragmentShader: li.background.fragmentShader,
+			side: 0,
+			depthTest: !1,
+			depthWrite: !1,
+			fog: !1,
+			allowOverride: !1
+		})), c.geometry.deleteAttribute("normal"), Object.defineProperty(c.material, "map", { get: function() {
+			return this.uniforms.t2D.value;
+		} }), r.update(c)), c.material.uniforms.t2D.value = i, c.material.uniforms.backgroundIntensity.value = n.backgroundIntensity, c.material.toneMapped = K.getTransfer(i.colorSpace) !== j, i.matrixAutoUpdate === !0 && i.updateMatrix(), c.material.uniforms.uvTransform.value.copy(i.matrix), (u !== i || d !== i.version || f !== e.toneMapping) && (c.material.needsUpdate = !0, u = i, d = i.version, f = e.toneMapping), c.layers.enableAll(), t.unshift(c, c.geometry, c.material, 0, 0, null));
+	}
+	function g(t, r) {
+		t.getRGB(ui, ur(e)), n.buffers.color.setClear(ui.r, ui.g, ui.b, r, a);
+	}
+	function _() {
+		l !== void 0 && (l.geometry.dispose(), l.material.dispose(), l = void 0), c !== void 0 && (c.geometry.dispose(), c.material.dispose(), c = void 0);
+	}
+	return {
+		getClearColor: function() {
+			return o;
+		},
+		setClearColor: function(e, t = 1) {
+			o.set(e), s = t, g(o, s);
+		},
+		getClearAlpha: function() {
+			return s;
+		},
+		setClearAlpha: function(e) {
+			s = e, g(o, s);
+		},
+		render: m,
+		addToRenderList: h,
+		dispose: _
+	};
+}
+function mi(e, t) {
+	let n = e.getParameter(e.MAX_VERTEX_ATTRIBS), r = {}, i = f(null), a = i, o = !1;
+	function s(n, r, i, s, c) {
+		let u = !1, f = d(n, s, i, r);
+		a !== f && (a = f, l(a.object)), u = p(n, s, i, c), u && m(n, s, i, c), c !== null && t.update(c, e.ELEMENT_ARRAY_BUFFER), (u || o) && (o = !1, b(n, r, i, s), c !== null && e.bindBuffer(e.ELEMENT_ARRAY_BUFFER, t.get(c).buffer));
+	}
+	function c() {
+		return e.createVertexArray();
+	}
+	function l(t) {
+		return e.bindVertexArray(t);
+	}
+	function u(t) {
+		return e.deleteVertexArray(t);
+	}
+	function d(e, t, n, i) {
+		let a = i.wireframe === !0, o = r[t.id];
+		o === void 0 && (o = {}, r[t.id] = o);
+		let s = e.isInstancedMesh === !0 ? e.id : 0, l = o[s];
+		l === void 0 && (l = {}, o[s] = l);
+		let u = l[n.id];
+		u === void 0 && (u = {}, l[n.id] = u);
+		let d = u[a];
+		return d === void 0 && (d = f(c()), u[a] = d), d;
+	}
+	function f(e) {
+		let t = [], r = [], i = [];
+		for (let e = 0; e < n; e++) t[e] = 0, r[e] = 0, i[e] = 0;
+		return {
+			geometry: null,
+			program: null,
+			wireframe: !1,
+			newAttributes: t,
+			enabledAttributes: r,
+			attributeDivisors: i,
+			object: e,
+			attributes: {},
+			index: null
+		};
+	}
+	function p(e, t, n, r) {
+		let i = a.attributes, o = t.attributes, s = 0, c = n.getAttributes();
+		for (let t in c) if (c[t].location >= 0) {
+			let n = i[t], r = o[t];
+			if (r === void 0 && (t === "instanceMatrix" && e.instanceMatrix && (r = e.instanceMatrix), t === "instanceColor" && e.instanceColor && (r = e.instanceColor)), n === void 0 || n.attribute !== r || r && n.data !== r.data) return !0;
+			s++;
+		}
+		return a.attributesNum !== s || a.index !== r;
+	}
+	function m(e, t, n, r) {
+		let i = {}, o = t.attributes, s = 0, c = n.getAttributes();
+		for (let t in c) if (c[t].location >= 0) {
+			let n = o[t];
+			n === void 0 && (t === "instanceMatrix" && e.instanceMatrix && (n = e.instanceMatrix), t === "instanceColor" && e.instanceColor && (n = e.instanceColor));
+			let r = {};
+			r.attribute = n, n && n.data && (r.data = n.data), i[t] = r, s++;
+		}
+		a.attributes = i, a.attributesNum = s, a.index = r;
+	}
+	function h() {
+		let e = a.newAttributes;
+		for (let t = 0, n = e.length; t < n; t++) e[t] = 0;
+	}
+	function g(e) {
+		_(e, 0);
+	}
+	function _(t, n) {
+		let r = a.newAttributes, i = a.enabledAttributes, o = a.attributeDivisors;
+		r[t] = 1, i[t] === 0 && (e.enableVertexAttribArray(t), i[t] = 1), o[t] !== n && (e.vertexAttribDivisor(t, n), o[t] = n);
+	}
+	function v() {
+		let t = a.newAttributes, n = a.enabledAttributes;
+		for (let r = 0, i = n.length; r < i; r++) n[r] !== t[r] && (e.disableVertexAttribArray(r), n[r] = 0);
+	}
+	function y(t, n, r, i, a, o, s) {
+		s === !0 ? e.vertexAttribIPointer(t, n, r, a, o) : e.vertexAttribPointer(t, n, r, i, a, o);
+	}
+	function b(n, r, i, a) {
+		h();
+		let o = a.attributes, s = i.getAttributes(), c = r.defaultAttributeValues;
+		for (let r in s) {
+			let i = s[r];
+			if (i.location >= 0) {
+				let s = o[r];
+				if (s === void 0 && (r === "instanceMatrix" && n.instanceMatrix && (s = n.instanceMatrix), r === "instanceColor" && n.instanceColor && (s = n.instanceColor)), s !== void 0) {
+					let r = s.normalized, o = s.itemSize, c = t.get(s);
+					if (c === void 0) continue;
+					let l = c.buffer, u = c.type, d = c.bytesPerElement, f = u === e.INT || u === e.UNSIGNED_INT || s.gpuType === 1013;
+					if (s.isInterleavedBufferAttribute) {
+						let t = s.data, c = t.stride, p = s.offset;
+						if (t.isInstancedInterleavedBuffer) {
+							for (let e = 0; e < i.locationSize; e++) _(i.location + e, t.meshPerAttribute);
+							n.isInstancedMesh !== !0 && a._maxInstanceCount === void 0 && (a._maxInstanceCount = t.meshPerAttribute * t.count);
+						} else for (let e = 0; e < i.locationSize; e++) g(i.location + e);
+						e.bindBuffer(e.ARRAY_BUFFER, l);
+						for (let e = 0; e < i.locationSize; e++) y(i.location + e, o / i.locationSize, u, r, c * d, (p + o / i.locationSize * e) * d, f);
+					} else {
+						if (s.isInstancedBufferAttribute) {
+							for (let e = 0; e < i.locationSize; e++) _(i.location + e, s.meshPerAttribute);
+							n.isInstancedMesh !== !0 && a._maxInstanceCount === void 0 && (a._maxInstanceCount = s.meshPerAttribute * s.count);
+						} else for (let e = 0; e < i.locationSize; e++) g(i.location + e);
+						e.bindBuffer(e.ARRAY_BUFFER, l);
+						for (let e = 0; e < i.locationSize; e++) y(i.location + e, o / i.locationSize, u, r, o * d, o / i.locationSize * e * d, f);
+					}
+				} else if (c !== void 0) {
+					let t = c[r];
+					if (t !== void 0) switch (t.length) {
+						case 2:
+							e.vertexAttrib2fv(i.location, t);
+							break;
+						case 3:
+							e.vertexAttrib3fv(i.location, t);
+							break;
+						case 4:
+							e.vertexAttrib4fv(i.location, t);
+							break;
+						default: e.vertexAttrib1fv(i.location, t);
+					}
+				}
+			}
+		}
+		v();
+	}
+	function x() {
+		T();
+		for (let e in r) {
+			let t = r[e];
+			for (let e in t) {
+				let n = t[e];
+				for (let e in n) {
+					let t = n[e];
+					for (let e in t) u(t[e].object), delete t[e];
+					delete n[e];
+				}
+			}
+			delete r[e];
+		}
+	}
+	function S(e) {
+		if (r[e.id] === void 0) return;
+		let t = r[e.id];
+		for (let e in t) {
+			let n = t[e];
+			for (let e in n) {
+				let t = n[e];
+				for (let e in t) u(t[e].object), delete t[e];
+				delete n[e];
+			}
+		}
+		delete r[e.id];
+	}
+	function C(e) {
+		for (let t in r) {
+			let n = r[t];
+			for (let t in n) {
+				let r = n[t];
+				if (r[e.id] === void 0) continue;
+				let i = r[e.id];
+				for (let e in i) u(i[e].object), delete i[e];
+				delete r[e.id];
+			}
+		}
+	}
+	function w(e) {
+		for (let t in r) {
+			let n = r[t], i = e.isInstancedMesh === !0 ? e.id : 0, a = n[i];
+			if (a !== void 0) {
+				for (let e in a) {
+					let t = a[e];
+					for (let e in t) u(t[e].object), delete t[e];
+					delete a[e];
+				}
+				delete n[i], Object.keys(n).length === 0 && delete r[t];
+			}
+		}
+	}
+	function T() {
+		E(), o = !0, a !== i && (a = i, l(a.object));
+	}
+	function E() {
+		i.geometry = null, i.program = null, i.wireframe = !1;
+	}
+	return {
+		setup: s,
+		reset: T,
+		resetDefaultState: E,
+		dispose: x,
+		releaseStatesOfGeometry: S,
+		releaseStatesOfObject: w,
+		releaseStatesOfProgram: C,
+		initAttributes: h,
+		enableAttribute: g,
+		disableUnusedAttributes: v
+	};
+}
+function hi(e, t, n) {
+	let r;
+	function i(e) {
+		r = e;
+	}
+	function a(t, i) {
+		e.drawArrays(r, t, i), n.update(i, r, 1);
+	}
+	function o(t, i, a) {
+		a !== 0 && (e.drawArraysInstanced(r, t, i, a), n.update(i, r, a));
+	}
+	function s(e, i, a) {
+		if (a === 0) return;
+		t.get("WEBGL_multi_draw").multiDrawArraysWEBGL(r, e, 0, i, 0, a);
+		let o = 0;
+		for (let e = 0; e < a; e++) o += i[e];
+		n.update(o, r, 1);
+	}
+	this.setMode = i, this.render = a, this.renderInstances = o, this.renderMultiDraw = s;
+}
+function gi(e, t, n, r) {
+	let i;
+	function a() {
+		if (i !== void 0) return i;
+		if (t.has("EXT_texture_filter_anisotropic") === !0) {
+			let n = t.get("EXT_texture_filter_anisotropic");
+			i = e.getParameter(n.MAX_TEXTURE_MAX_ANISOTROPY_EXT);
+		} else i = 0;
+		return i;
+	}
+	function o(t) {
+		return !(t !== 1023 && r.convert(t) !== e.getParameter(e.IMPLEMENTATION_COLOR_READ_FORMAT));
+	}
+	function s(n) {
+		let i = n === 1016 && (t.has("EXT_color_buffer_half_float") || t.has("EXT_color_buffer_float"));
+		return !(n !== 1009 && r.convert(n) !== e.getParameter(e.IMPLEMENTATION_COLOR_READ_TYPE) && n !== 1015 && !i);
+	}
+	function c(t) {
+		if (t === "highp") {
+			if (e.getShaderPrecisionFormat(e.VERTEX_SHADER, e.HIGH_FLOAT).precision > 0 && e.getShaderPrecisionFormat(e.FRAGMENT_SHADER, e.HIGH_FLOAT).precision > 0) return "highp";
+			t = "mediump";
+		}
+		return t === "mediump" && e.getShaderPrecisionFormat(e.VERTEX_SHADER, e.MEDIUM_FLOAT).precision > 0 && e.getShaderPrecisionFormat(e.FRAGMENT_SHADER, e.MEDIUM_FLOAT).precision > 0 ? "mediump" : "lowp";
+	}
+	let l = n.precision === void 0 ? "highp" : n.precision, u = c(l);
+	u !== l && (F("WebGLRenderer:", l, "not supported, using", u, "instead."), l = u);
+	let d = n.logarithmicDepthBuffer === !0, f = n.reversedDepthBuffer === !0 && t.has("EXT_clip_control");
+	n.reversedDepthBuffer === !0 && f === !1 && F("WebGLRenderer: Unable to use reversed depth buffer due to missing EXT_clip_control extension. Fallback to default depth buffer.");
+	let p = e.getParameter(e.MAX_TEXTURE_IMAGE_UNITS), m = e.getParameter(e.MAX_VERTEX_TEXTURE_IMAGE_UNITS), h = e.getParameter(e.MAX_TEXTURE_SIZE), g = e.getParameter(e.MAX_CUBE_MAP_TEXTURE_SIZE), _ = e.getParameter(e.MAX_VERTEX_ATTRIBS), v = e.getParameter(e.MAX_VERTEX_UNIFORM_VECTORS), y = e.getParameter(e.MAX_VARYING_VECTORS), b = e.getParameter(e.MAX_FRAGMENT_UNIFORM_VECTORS), x = e.getParameter(e.MAX_SAMPLES), S = e.getParameter(e.SAMPLES);
+	return {
+		isWebGL2: !0,
+		getMaxAnisotropy: a,
+		getMaxPrecision: c,
+		textureFormatReadable: o,
+		textureTypeReadable: s,
+		precision: l,
+		logarithmicDepthBuffer: d,
+		reversedDepthBuffer: f,
+		maxTextures: p,
+		maxVertexTextures: m,
+		maxTextureSize: h,
+		maxCubemapSize: g,
+		maxAttributes: _,
+		maxVertexUniforms: v,
+		maxVaryings: y,
+		maxFragmentUniforms: b,
+		maxSamples: x,
+		samples: S
+	};
+}
+function _i(e) {
+	let t = this, n = null, r = 0, i = !1, a = !1, o = new Jn(), s = new G(), c = {
+		value: null,
+		needsUpdate: !1
+	};
+	this.uniform = c, this.numPlanes = 0, this.numIntersection = 0, this.init = function(e, t) {
+		let n = e.length !== 0 || t || r !== 0 || i;
+		return i = t, r = e.length, n;
+	}, this.beginShadows = function() {
+		a = !0, u(null);
+	}, this.endShadows = function() {
+		a = !1;
+	}, this.setGlobalState = function(e, t) {
+		n = u(e, t, 0);
+	}, this.setState = function(t, o, s) {
+		let d = t.clippingPlanes, f = t.clipIntersection, p = t.clipShadows, m = e.get(t);
+		if (!i || d === null || d.length === 0 || a && !p) a ? u(null) : l();
+		else {
+			let e = a ? 0 : r, t = e * 4, i = m.clippingState || null;
+			c.value = i, i = u(d, o, t, s);
+			for (let e = 0; e !== t; ++e) i[e] = n[e];
+			m.clippingState = i, this.numIntersection = f ? this.numPlanes : 0, this.numPlanes += e;
+		}
+	};
+	function l() {
+		c.value !== n && (c.value = n, c.needsUpdate = r > 0), t.numPlanes = r, t.numIntersection = 0;
+	}
+	function u(e, n, r, i) {
+		let a = e === null ? 0 : e.length, l = null;
+		if (a !== 0) {
+			if (l = c.value, i !== !0 || l === null) {
+				let t = r + a * 4, i = n.matrixWorldInverse;
+				s.getNormalMatrix(i), (l === null || l.length < t) && (l = new Float32Array(t));
+				for (let t = 0, n = r; t !== a; ++t, n += 4) o.copy(e[t]).applyMatrix4(i, s), o.normal.toArray(l, n), l[n + 3] = o.constant;
+			}
+			c.value = l, c.needsUpdate = !0;
+		}
+		return t.numPlanes = a, t.numIntersection = 0, l;
+	}
+}
+var vi = 4, yi = [
+	.125,
+	.215,
+	.35,
+	.446,
+	.526,
+	.582
+], bi = 20, xi = 256, Si = /*@__PURE__*/ new Hr(), Ci = /*@__PURE__*/ new Z(), wi = null, Ti = 0, Ei = 0, Di = !1, Oi = /*@__PURE__*/ new W(), ki = class {
+	constructor(e) {
+		this._renderer = e, this._pingPongRenderTarget = null, this._lodMax = 0, this._cubeSize = 0, this._sizeLods = [], this._sigmas = [], this._lodMeshes = [], this._backgroundBox = null, this._cubemapMaterial = null, this._equirectMaterial = null, this._blurMaterial = null, this._ggxMaterial = null;
+	}
+	fromScene(e, t = 0, n = .1, r = 100, i = {}) {
+		let { size: a = 256, position: o = Oi } = i;
+		wi = this._renderer.getRenderTarget(), Ti = this._renderer.getActiveCubeFace(), Ei = this._renderer.getActiveMipmapLevel(), Di = this._renderer.xr.enabled, this._renderer.xr.enabled = !1, this._setSize(a);
+		let s = this._allocateTargets();
+		return s.depthBuffer = !0, this._sceneToCubeUV(e, n, r, s, o), t > 0 && this._blur(s, 0, 0, t), this._applyPMREM(s), this._cleanup(s), s;
+	}
+	fromEquirectangular(e, t = null) {
+		return this._fromTexture(e, t);
+	}
+	fromCubemap(e, t = null) {
+		return this._fromTexture(e, t);
+	}
+	compileCubemapShader() {
+		this._cubemapMaterial === null && (this._cubemapMaterial = Ii(), this._compileMaterial(this._cubemapMaterial));
+	}
+	compileEquirectangularShader() {
+		this._equirectMaterial === null && (this._equirectMaterial = Fi(), this._compileMaterial(this._equirectMaterial));
+	}
+	dispose() {
+		this._dispose(), this._cubemapMaterial !== null && this._cubemapMaterial.dispose(), this._equirectMaterial !== null && this._equirectMaterial.dispose(), this._backgroundBox !== null && (this._backgroundBox.geometry.dispose(), this._backgroundBox.material.dispose());
+	}
+	_setSize(e) {
+		this._lodMax = Math.floor(Math.log2(e)), this._cubeSize = 2 ** this._lodMax;
+	}
+	_dispose() {
+		this._blurMaterial !== null && this._blurMaterial.dispose(), this._ggxMaterial !== null && this._ggxMaterial.dispose(), this._pingPongRenderTarget !== null && this._pingPongRenderTarget.dispose();
+		for (let e = 0; e < this._lodMeshes.length; e++) this._lodMeshes[e].geometry.dispose();
+	}
+	_cleanup(e) {
+		this._renderer.setRenderTarget(wi, Ti, Ei), this._renderer.xr.enabled = Di, e.scissorTest = !1, Mi(e, 0, 0, e.width, e.height);
+	}
+	_fromTexture(e, t) {
+		e.mapping === 301 || e.mapping === 302 ? this._setSize(e.image.length === 0 ? 16 : e.image[0].width || e.image[0].image.width) : this._setSize(e.image.width / 4), wi = this._renderer.getRenderTarget(), Ti = this._renderer.getActiveCubeFace(), Ei = this._renderer.getActiveMipmapLevel(), Di = this._renderer.xr.enabled, this._renderer.xr.enabled = !1;
+		let n = t || this._allocateTargets();
+		return this._textureToCubeUV(e, n), this._applyPMREM(n), this._cleanup(n), n;
+	}
+	_allocateTargets() {
+		let e = 3 * Math.max(this._cubeSize, 112), t = 4 * this._cubeSize, n = {
+			magFilter: i,
+			minFilter: i,
+			generateMipmaps: !1,
+			type: u,
+			format: m,
+			colorSpace: A,
+			depthBuffer: !1
+		}, r = ji(e, t, n);
+		if (this._pingPongRenderTarget === null || this._pingPongRenderTarget.width !== e || this._pingPongRenderTarget.height !== t) {
+			this._pingPongRenderTarget !== null && this._dispose(), this._pingPongRenderTarget = ji(e, t, n);
+			let { _lodMax: r } = this;
+			({lodMeshes: this._lodMeshes, sizeLods: this._sizeLods, sigmas: this._sigmas} = Ai(r)), this._blurMaterial = Pi(r, e, t), this._ggxMaterial = Ni(r, e, t);
+		}
+		return r;
+	}
+	_compileMaterial(e) {
+		let t = new Mn(new ln(), e);
+		this._renderer.compile(t, Si);
+	}
+	_sceneToCubeUV(e, t, n, r, i) {
+		let a = new Vr(90, 1, t, n), o = [
+			1,
+			-1,
+			1,
+			1,
+			1,
+			1
+		], s = [
+			1,
+			1,
+			1,
+			-1,
+			-1,
+			-1
+		], c = this._renderer, l = c.autoClear, u = c.toneMapping;
+		c.getClearColor(Ci), c.toneMapping = 0, c.autoClear = !1, c.state.buffers.depth.getReversed() && (c.setRenderTarget(r), c.clearDepth(), c.setRenderTarget(null)), this._backgroundBox === null && (this._backgroundBox = new Mn(new rr(), new bn({
+			name: "PMREM.Background",
+			side: 1,
+			depthWrite: !1,
+			depthTest: !1
+		})));
+		let d = this._backgroundBox, f = d.material, p = !1, m = e.background;
+		m ? m.isColor && (f.color.copy(m), e.background = null, p = !0) : (f.color.copy(Ci), p = !0);
+		for (let t = 0; t < 6; t++) {
+			let n = t % 3;
+			n === 0 ? (a.up.set(0, o[t], 0), a.position.set(i.x, i.y, i.z), a.lookAt(i.x + s[t], i.y, i.z)) : n === 1 ? (a.up.set(0, 0, o[t]), a.position.set(i.x, i.y, i.z), a.lookAt(i.x, i.y + s[t], i.z)) : (a.up.set(0, o[t], 0), a.position.set(i.x, i.y, i.z), a.lookAt(i.x, i.y, i.z + s[t]));
+			let l = this._cubeSize;
+			Mi(r, n * l, t > 2 ? l : 0, l, l), c.setRenderTarget(r), p && c.render(d, a), c.render(e, a);
+		}
+		c.toneMapping = u, c.autoClear = l, e.background = m;
+	}
+	_textureToCubeUV(e, t) {
+		let n = this._renderer, r = e.mapping === 301 || e.mapping === 302;
+		r ? (this._cubemapMaterial === null && (this._cubemapMaterial = Ii()), this._cubemapMaterial.uniforms.flipEnvMap.value = e.isRenderTargetTexture === !1 ? -1 : 1) : this._equirectMaterial === null && (this._equirectMaterial = Fi());
+		let i = r ? this._cubemapMaterial : this._equirectMaterial, a = this._lodMeshes[0];
+		a.material = i;
+		let o = i.uniforms;
+		o.envMap.value = e;
+		let s = this._cubeSize;
+		Mi(t, 0, 0, 3 * s, 2 * s), n.setRenderTarget(t), n.render(a, Si);
+	}
+	_applyPMREM(e) {
+		let t = this._renderer, n = t.autoClear;
+		t.autoClear = !1;
+		let r = this._lodMeshes.length;
+		for (let t = 1; t < r; t++) this._applyGGXFilter(e, t - 1, t);
+		t.autoClear = n;
+	}
+	_applyGGXFilter(e, t, n) {
+		let r = this._renderer, i = this._pingPongRenderTarget, a = this._ggxMaterial, o = this._lodMeshes[n];
+		o.material = a;
+		let s = a.uniforms, c = n / (this._lodMeshes.length - 1), l = t / (this._lodMeshes.length - 1), u = Math.sqrt(c * c - l * l) * (0 + c * 1.25), { _lodMax: d } = this, f = this._sizeLods[n], p = 3 * f * (n > d - vi ? n - d + vi : 0), m = 4 * (this._cubeSize - f);
+		s.envMap.value = e.texture, s.roughness.value = u, s.mipInt.value = d - t, Mi(i, p, m, 3 * f, 2 * f), r.setRenderTarget(i), r.render(o, Si), s.envMap.value = i.texture, s.roughness.value = 0, s.mipInt.value = d - n, Mi(e, p, m, 3 * f, 2 * f), r.setRenderTarget(e), r.render(o, Si);
+	}
+	_blur(e, t, n, r, i) {
+		let a = this._pingPongRenderTarget;
+		this._halfBlur(e, a, t, n, r, "latitudinal", i), this._halfBlur(a, e, n, n, r, "longitudinal", i);
+	}
+	_halfBlur(e, t, n, r, i, a, o) {
+		let s = this._renderer, c = this._blurMaterial;
+		a !== "latitudinal" && a !== "longitudinal" && I("blur direction must be either latitudinal or longitudinal!");
+		let l = this._lodMeshes[r];
+		l.material = c;
+		let u = c.uniforms, d = this._sizeLods[n] - 1, f = isFinite(i) ? Math.PI / (2 * d) : 2 * Math.PI / (2 * bi - 1), p = i / f, m = isFinite(i) ? 1 + Math.floor(3 * p) : bi;
+		m > bi && F(`sigmaRadians, ${i}, is too large and will clip, as it requested ${m} samples when the maximum is set to ${bi}`);
+		let h = [], g = 0;
+		for (let e = 0; e < bi; ++e) {
+			let t = e / p, n = Math.exp(-t * t / 2);
+			h.push(n), e === 0 ? g += n : e < m && (g += 2 * n);
+		}
+		for (let e = 0; e < h.length; e++) h[e] = h[e] / g;
+		u.envMap.value = e.texture, u.samples.value = m, u.weights.value = h, u.latitudinal.value = a === "latitudinal", o && (u.poleAxis.value = o);
+		let { _lodMax: _ } = this;
+		u.dTheta.value = f, u.mipInt.value = _ - n;
+		let v = this._sizeLods[r];
+		Mi(t, 3 * v * (r > _ - vi ? r - _ + vi : 0), 4 * (this._cubeSize - v), 3 * v, 2 * v), s.setRenderTarget(t), s.render(l, Si);
+	}
+};
+function Ai(e) {
+	let t = [], n = [], r = [], i = e, a = e - vi + 1 + yi.length;
+	for (let o = 0; o < a; o++) {
+		let a = 2 ** i;
+		t.push(a);
+		let s = 1 / a;
+		o > e - vi ? s = yi[o - e + vi - 1] : o === 0 && (s = 0), n.push(s);
+		let c = 1 / (a - 2), l = -c, u = 1 + c, d = [
+			l,
+			l,
+			u,
+			l,
+			u,
+			u,
+			l,
+			l,
+			u,
+			u,
+			l,
+			u
+		], f = /* @__PURE__ */ new Float32Array(108), p = /* @__PURE__ */ new Float32Array(72), m = /* @__PURE__ */ new Float32Array(36);
+		for (let e = 0; e < 6; e++) {
+			let t = e % 3 * 2 / 3 - 1, n = e > 2 ? 0 : -1, r = [
+				t,
+				n,
+				0,
+				t + 2 / 3,
+				n,
+				0,
+				t + 2 / 3,
+				n + 1,
+				0,
+				t,
+				n,
+				0,
+				t + 2 / 3,
+				n + 1,
+				0,
+				t,
+				n + 1,
+				0
+			];
+			f.set(r, 18 * e), p.set(d, 12 * e);
+			let i = [
+				e,
+				e,
+				e,
+				e,
+				e,
+				e
+			];
+			m.set(i, 6 * e);
+		}
+		let h = new ln();
+		h.setAttribute("position", new qt(f, 3)), h.setAttribute("uv", new qt(p, 2)), h.setAttribute("faceIndex", new qt(m, 1)), r.push(new Mn(h, null)), i > vi && i--;
+	}
+	return {
+		lodMeshes: r,
+		sizeLods: t,
+		sigmas: n
+	};
+}
+function ji(e, t, n) {
+	let r = new Me(e, t, n);
+	return r.texture.mapping = 306, r.texture.name = "PMREM.cubeUv", r.scissorTest = !0, r;
+}
+function Mi(e, t, n, r, i) {
+	e.viewport.set(t, n, r, i), e.scissor.set(t, n, r, i);
+}
+function Ni(e, t, n) {
+	return new mr({
+		name: "PMREMGGXConvolution",
+		defines: {
+			GGX_SAMPLES: xi,
+			CUBEUV_TEXEL_WIDTH: 1 / t,
+			CUBEUV_TEXEL_HEIGHT: 1 / n,
+			CUBEUV_MAX_MIP: `${e}.0`
+		},
+		uniforms: {
+			envMap: { value: null },
+			roughness: { value: 0 },
+			mipInt: { value: 0 }
+		},
+		vertexShader: Li(),
+		fragmentShader: "\n\n			precision highp float;\n			precision highp int;\n\n			varying vec3 vOutputDirection;\n\n			uniform sampler2D envMap;\n			uniform float roughness;\n			uniform float mipInt;\n\n			#define ENVMAP_TYPE_CUBE_UV\n			#include <cube_uv_reflection_fragment>\n\n			#define PI 3.14159265359\n\n			// Van der Corput radical inverse\n			float radicalInverse_VdC(uint bits) {\n				bits = (bits << 16u) | (bits >> 16u);\n				bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);\n				bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);\n				bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);\n				bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);\n				return float(bits) * 2.3283064365386963e-10; // / 0x100000000\n			}\n\n			// Hammersley sequence\n			vec2 hammersley(uint i, uint N) {\n				return vec2(float(i) / float(N), radicalInverse_VdC(i));\n			}\n\n			// GGX VNDF importance sampling (Eric Heitz 2018)\n			// \"Sampling the GGX Distribution of Visible Normals\"\n			// https://jcgt.org/published/0007/04/01/\n			vec3 importanceSampleGGX_VNDF(vec2 Xi, vec3 V, float roughness) {\n				float alpha = roughness * roughness;\n\n				// Section 4.1: Orthonormal basis\n				vec3 T1 = vec3(1.0, 0.0, 0.0);\n				vec3 T2 = cross(V, T1);\n\n				// Section 4.2: Parameterization of projected area\n				float r = sqrt(Xi.x);\n				float phi = 2.0 * PI * Xi.y;\n				float t1 = r * cos(phi);\n				float t2 = r * sin(phi);\n				float s = 0.5 * (1.0 + V.z);\n				t2 = (1.0 - s) * sqrt(1.0 - t1 * t1) + s * t2;\n\n				// Section 4.3: Reprojection onto hemisphere\n				vec3 Nh = t1 * T1 + t2 * T2 + sqrt(max(0.0, 1.0 - t1 * t1 - t2 * t2)) * V;\n\n				// Section 3.4: Transform back to ellipsoid configuration\n				return normalize(vec3(alpha * Nh.x, alpha * Nh.y, max(0.0, Nh.z)));\n			}\n\n			void main() {\n				vec3 N = normalize(vOutputDirection);\n				vec3 V = N; // Assume view direction equals normal for pre-filtering\n\n				vec3 prefilteredColor = vec3(0.0);\n				float totalWeight = 0.0;\n\n				// For very low roughness, just sample the environment directly\n				if (roughness < 0.001) {\n					gl_FragColor = vec4(bilinearCubeUV(envMap, N, mipInt), 1.0);\n					return;\n				}\n\n				// Tangent space basis for VNDF sampling\n				vec3 up = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);\n				vec3 tangent = normalize(cross(up, N));\n				vec3 bitangent = cross(N, tangent);\n\n				for(uint i = 0u; i < uint(GGX_SAMPLES); i++) {\n					vec2 Xi = hammersley(i, uint(GGX_SAMPLES));\n\n					// For PMREM, V = N, so in tangent space V is always (0, 0, 1)\n					vec3 H_tangent = importanceSampleGGX_VNDF(Xi, vec3(0.0, 0.0, 1.0), roughness);\n\n					// Transform H back to world space\n					vec3 H = normalize(tangent * H_tangent.x + bitangent * H_tangent.y + N * H_tangent.z);\n					vec3 L = normalize(2.0 * dot(V, H) * H - V);\n\n					float NdotL = max(dot(N, L), 0.0);\n\n					if(NdotL > 0.0) {\n						// Sample environment at fixed mip level\n						// VNDF importance sampling handles the distribution filtering\n						vec3 sampleColor = bilinearCubeUV(envMap, L, mipInt);\n\n						// Weight by NdotL for the split-sum approximation\n						// VNDF PDF naturally accounts for the visible microfacet distribution\n						prefilteredColor += sampleColor * NdotL;\n						totalWeight += NdotL;\n					}\n				}\n\n				if (totalWeight > 0.0) {\n					prefilteredColor = prefilteredColor / totalWeight;\n				}\n\n				gl_FragColor = vec4(prefilteredColor, 1.0);\n			}\n		",
+		blending: 0,
+		depthTest: !1,
+		depthWrite: !1
+	});
+}
+function Pi(e, t, n) {
+	let r = new Float32Array(bi), i = new W(0, 1, 0);
+	return new mr({
+		name: "SphericalGaussianBlur",
+		defines: {
+			n: bi,
+			CUBEUV_TEXEL_WIDTH: 1 / t,
+			CUBEUV_TEXEL_HEIGHT: 1 / n,
+			CUBEUV_MAX_MIP: `${e}.0`
+		},
+		uniforms: {
+			envMap: { value: null },
+			samples: { value: 1 },
+			weights: { value: r },
+			latitudinal: { value: !1 },
+			dTheta: { value: 0 },
+			mipInt: { value: 0 },
+			poleAxis: { value: i }
+		},
+		vertexShader: Li(),
+		fragmentShader: "\n\n			precision mediump float;\n			precision mediump int;\n\n			varying vec3 vOutputDirection;\n\n			uniform sampler2D envMap;\n			uniform int samples;\n			uniform float weights[ n ];\n			uniform bool latitudinal;\n			uniform float dTheta;\n			uniform float mipInt;\n			uniform vec3 poleAxis;\n\n			#define ENVMAP_TYPE_CUBE_UV\n			#include <cube_uv_reflection_fragment>\n\n			vec3 getSample( float theta, vec3 axis ) {\n\n				float cosTheta = cos( theta );\n				// Rodrigues' axis-angle rotation\n				vec3 sampleDirection = vOutputDirection * cosTheta\n					+ cross( axis, vOutputDirection ) * sin( theta )\n					+ axis * dot( axis, vOutputDirection ) * ( 1.0 - cosTheta );\n\n				return bilinearCubeUV( envMap, sampleDirection, mipInt );\n\n			}\n\n			void main() {\n\n				vec3 axis = latitudinal ? poleAxis : cross( poleAxis, vOutputDirection );\n\n				if ( all( equal( axis, vec3( 0.0 ) ) ) ) {\n\n					axis = vec3( vOutputDirection.z, 0.0, - vOutputDirection.x );\n\n				}\n\n				axis = normalize( axis );\n\n				gl_FragColor = vec4( 0.0, 0.0, 0.0, 1.0 );\n				gl_FragColor.rgb += weights[ 0 ] * getSample( 0.0, axis );\n\n				for ( int i = 1; i < n; i++ ) {\n\n					if ( i >= samples ) {\n\n						break;\n\n					}\n\n					float theta = dTheta * float( i );\n					gl_FragColor.rgb += weights[ i ] * getSample( -1.0 * theta, axis );\n					gl_FragColor.rgb += weights[ i ] * getSample( theta, axis );\n\n				}\n\n			}\n		",
+		blending: 0,
+		depthTest: !1,
+		depthWrite: !1
+	});
+}
+function Fi() {
+	return new mr({
+		name: "EquirectangularToCubeUV",
+		uniforms: { envMap: { value: null } },
+		vertexShader: Li(),
+		fragmentShader: "\n\n			precision mediump float;\n			precision mediump int;\n\n			varying vec3 vOutputDirection;\n\n			uniform sampler2D envMap;\n\n			#include <common>\n\n			void main() {\n\n				vec3 outputDirection = normalize( vOutputDirection );\n				vec2 uv = equirectUv( outputDirection );\n\n				gl_FragColor = vec4( texture2D ( envMap, uv ).rgb, 1.0 );\n\n			}\n		",
+		blending: 0,
+		depthTest: !1,
+		depthWrite: !1
+	});
+}
+function Ii() {
+	return new mr({
+		name: "CubemapToCubeUV",
+		uniforms: {
+			envMap: { value: null },
+			flipEnvMap: { value: -1 }
+		},
+		vertexShader: Li(),
+		fragmentShader: "\n\n			precision mediump float;\n			precision mediump int;\n\n			uniform float flipEnvMap;\n\n			varying vec3 vOutputDirection;\n\n			uniform samplerCube envMap;\n\n			void main() {\n\n				gl_FragColor = textureCube( envMap, vec3( flipEnvMap * vOutputDirection.x, vOutputDirection.yz ) );\n\n			}\n		",
+		blending: 0,
+		depthTest: !1,
+		depthWrite: !1
+	});
+}
+function Li() {
+	return "\n\n		precision mediump float;\n		precision mediump int;\n\n		attribute float faceIndex;\n\n		varying vec3 vOutputDirection;\n\n		// RH coordinate system; PMREM face-indexing convention\n		vec3 getDirection( vec2 uv, float face ) {\n\n			uv = 2.0 * uv - 1.0;\n\n			vec3 direction = vec3( uv, 1.0 );\n\n			if ( face == 0.0 ) {\n\n				direction = direction.zyx; // ( 1, v, u ) pos x\n\n			} else if ( face == 1.0 ) {\n\n				direction = direction.xzy;\n				direction.xz *= -1.0; // ( -u, 1, -v ) pos y\n\n			} else if ( face == 2.0 ) {\n\n				direction.x *= -1.0; // ( -u, v, 1 ) pos z\n\n			} else if ( face == 3.0 ) {\n\n				direction = direction.zyx;\n				direction.xz *= -1.0; // ( -1, v, -u ) neg x\n\n			} else if ( face == 4.0 ) {\n\n				direction = direction.xzy;\n				direction.xy *= -1.0; // ( -u, -1, v ) neg y\n\n			} else if ( face == 5.0 ) {\n\n				direction.z *= -1.0; // ( u, v, -1 ) neg z\n\n			}\n\n			return direction;\n\n		}\n\n		void main() {\n\n			vOutputDirection = getDirection( uv, faceIndex );\n			gl_Position = vec4( position, 1.0 );\n\n		}\n	";
+}
+var Ri = class extends Me {
+	constructor(e = 1, t = {}) {
+		super(e, e, t), this.isWebGLCubeRenderTarget = !0;
+		let n = {
+			width: e,
+			height: e,
+			depth: 1
+		}, r = [
+			n,
+			n,
+			n,
+			n,
+			n,
+			n
+		];
+		this.texture = new $n(r), this._setTextureOptions(t), this.texture.isRenderTargetTexture = !0;
+	}
+	fromEquirectangularTexture(e, t) {
+		this.texture.type = t.type, this.texture.colorSpace = t.colorSpace, this.texture.generateMipmaps = t.generateMipmaps, this.texture.minFilter = t.minFilter, this.texture.magFilter = t.magFilter;
+		let n = {
+			uniforms: { tEquirect: { value: null } },
+			vertexShader: "\n\n				varying vec3 vWorldDirection;\n\n				vec3 transformDirection( in vec3 dir, in mat4 matrix ) {\n\n					return normalize( ( matrix * vec4( dir, 0.0 ) ).xyz );\n\n				}\n\n				void main() {\n\n					vWorldDirection = transformDirection( position, modelMatrix );\n\n					#include <begin_vertex>\n					#include <project_vertex>\n\n				}\n			",
+			fragmentShader: "\n\n				uniform sampler2D tEquirect;\n\n				varying vec3 vWorldDirection;\n\n				#include <common>\n\n				void main() {\n\n					vec3 direction = normalize( vWorldDirection );\n\n					vec2 sampleUV = equirectUv( direction );\n\n					gl_FragColor = texture2D( tEquirect, sampleUV );\n\n				}\n			"
+		}, r = new rr(5, 5, 5), a = new mr({
+			name: "CubemapFromEquirect",
+			uniforms: or(n.uniforms),
+			vertexShader: n.vertexShader,
+			fragmentShader: n.fragmentShader,
+			side: 1,
+			blending: 0
+		});
+		a.uniforms.tEquirect.value = t;
+		let o = new Mn(r, a), s = t.minFilter;
+		return t.minFilter === 1008 && (t.minFilter = i), new Gr(1, 10, this).update(e, o), t.minFilter = s, o.geometry.dispose(), o.material.dispose(), this;
+	}
+	clear(e, t = !0, n = !0, r = !0) {
+		let i = e.getRenderTarget();
+		for (let i = 0; i < 6; i++) e.setRenderTarget(this, i), e.clear(t, n, r);
+		e.setRenderTarget(i);
+	}
+};
+function zi(e) {
+	let t = /* @__PURE__ */ new WeakMap(), n = /* @__PURE__ */ new WeakMap(), r = null;
+	function i(e, t = !1) {
+		return e == null ? null : t ? o(e) : a(e);
+	}
+	function a(n) {
+		if (n && n.isTexture) {
+			let r = n.mapping;
+			if (r === 303 || r === 304) if (t.has(n)) {
+				let e = t.get(n).texture;
+				return s(e, n.mapping);
+			} else {
+				let r = n.image;
+				if (r && r.height > 0) {
+					let i = new Ri(r.height);
+					return i.fromEquirectangularTexture(e, n), t.set(n, i), n.addEventListener("dispose", l), s(i.texture, n.mapping);
+				} else return null;
+			}
+		}
+		return n;
+	}
+	function o(t) {
+		if (t && t.isTexture) {
+			let i = t.mapping, a = i === 303 || i === 304, o = i === 301 || i === 302;
+			if (a || o) {
+				let i = n.get(t), s = i === void 0 ? 0 : i.texture.pmremVersion;
+				if (t.isRenderTargetTexture && t.pmremVersion !== s) return r === null && (r = new ki(e)), i = a ? r.fromEquirectangular(t, i) : r.fromCubemap(t, i), i.texture.pmremVersion = t.pmremVersion, n.set(t, i), i.texture;
+				if (i !== void 0) return i.texture;
+				{
+					let s = t.image;
+					return a && s && s.height > 0 || o && s && c(s) ? (r === null && (r = new ki(e)), i = a ? r.fromEquirectangular(t) : r.fromCubemap(t), i.texture.pmremVersion = t.pmremVersion, n.set(t, i), t.addEventListener("dispose", u), i.texture) : null;
+				}
+			}
+		}
+		return t;
+	}
+	function s(e, t) {
+		return t === 303 ? e.mapping = 301 : t === 304 && (e.mapping = 302), e;
+	}
+	function c(e) {
+		let t = 0;
+		for (let n = 0; n < 6; n++) e[n] !== void 0 && t++;
+		return t === 6;
+	}
+	function l(e) {
+		let n = e.target;
+		n.removeEventListener("dispose", l);
+		let r = t.get(n);
+		r !== void 0 && (t.delete(n), r.dispose());
+	}
+	function u(e) {
+		let t = e.target;
+		t.removeEventListener("dispose", u);
+		let r = n.get(t);
+		r !== void 0 && (n.delete(t), r.dispose());
+	}
+	function d() {
+		t = /* @__PURE__ */ new WeakMap(), n = /* @__PURE__ */ new WeakMap(), r !== null && (r.dispose(), r = null);
+	}
+	return {
+		get: i,
+		dispose: d
+	};
+}
+function Bi(e) {
+	let t = {};
+	function n(n) {
+		if (t[n] !== void 0) return t[n];
+		let r = e.getExtension(n);
+		return t[n] = r, r;
+	}
+	return {
+		has: function(e) {
+			return n(e) !== null;
+		},
+		init: function() {
+			n("EXT_color_buffer_float"), n("WEBGL_clip_cull_distance"), n("OES_texture_float_linear"), n("EXT_color_buffer_half_float"), n("WEBGL_multisampled_render_to_texture"), n("WEBGL_render_shared_exponent");
+		},
+		get: function(e) {
+			let t = n(e);
+			return t === null && L("WebGLRenderer: " + e + " extension not supported."), t;
+		}
+	};
+}
+function Vi(e, t, n, r) {
+	let i = {}, a = /* @__PURE__ */ new WeakMap();
+	function o(e) {
+		let s = e.target;
+		s.index !== null && t.remove(s.index);
+		for (let e in s.attributes) t.remove(s.attributes[e]);
+		s.removeEventListener("dispose", o), delete i[s.id];
+		let c = a.get(s);
+		c && (t.remove(c), a.delete(s)), r.releaseStatesOfGeometry(s), s.isInstancedBufferGeometry === !0 && delete s._maxInstanceCount, n.memory.geometries--;
+	}
+	function s(e, t) {
+		return i[t.id] === !0 ? t : (t.addEventListener("dispose", o), i[t.id] = !0, n.memory.geometries++, t);
+	}
+	function c(n) {
+		let r = n.attributes;
+		for (let n in r) t.update(r[n], e.ARRAY_BUFFER);
+	}
+	function l(e) {
+		let n = [], r = e.index, i = e.attributes.position, o = 0;
+		if (i === void 0) return;
+		if (r !== null) {
+			let e = r.array;
+			o = r.version;
+			for (let t = 0, r = e.length; t < r; t += 3) {
+				let r = e[t + 0], i = e[t + 1], a = e[t + 2];
+				n.push(r, i, i, a, a, r);
+			}
+		} else {
+			let e = i.array;
+			o = i.version;
+			for (let t = 0, r = e.length / 3 - 1; t < r; t += 3) {
+				let e = t + 0, r = t + 1, i = t + 2;
+				n.push(e, r, r, i, i, e);
+			}
+		}
+		let s = new (i.count >= 65535 ? Yt : Jt)(n, 1);
+		s.version = o;
+		let c = a.get(e);
+		c && t.remove(c), a.set(e, s);
+	}
+	function u(e) {
+		let t = a.get(e);
+		if (t) {
+			let n = e.index;
+			n !== null && t.version < n.version && l(e);
+		} else l(e);
+		return a.get(e);
+	}
+	return {
+		get: s,
+		update: c,
+		getWireframeAttribute: u
+	};
+}
+function Hi(e, t, n) {
+	let r;
+	function i(e) {
+		r = e;
+	}
+	let a, o;
+	function s(e) {
+		a = e.type, o = e.bytesPerElement;
+	}
+	function c(t, i) {
+		e.drawElements(r, i, a, t * o), n.update(i, r, 1);
+	}
+	function l(t, i, s) {
+		s !== 0 && (e.drawElementsInstanced(r, i, a, t * o, s), n.update(i, r, s));
+	}
+	function u(e, i, o) {
+		if (o === 0) return;
+		t.get("WEBGL_multi_draw").multiDrawElementsWEBGL(r, i, 0, a, e, 0, o);
+		let s = 0;
+		for (let e = 0; e < o; e++) s += i[e];
+		n.update(s, r, 1);
+	}
+	this.setMode = i, this.setIndex = s, this.render = c, this.renderInstances = l, this.renderMultiDraw = u;
+}
+function Ui(e) {
+	let t = {
+		geometries: 0,
+		textures: 0
+	}, n = {
+		frame: 0,
+		calls: 0,
+		triangles: 0,
+		points: 0,
+		lines: 0
+	};
+	function r(t, r, i) {
+		switch (n.calls++, r) {
+			case e.TRIANGLES:
+				n.triangles += t / 3 * i;
+				break;
+			case e.LINES:
+				n.lines += t / 2 * i;
+				break;
+			case e.LINE_STRIP:
+				n.lines += i * (t - 1);
+				break;
+			case e.LINE_LOOP:
+				n.lines += i * t;
+				break;
+			case e.POINTS:
+				n.points += i * t;
+				break;
+			default:
+				I("WebGLInfo: Unknown draw mode:", r);
+				break;
+		}
+	}
+	function i() {
+		n.calls = 0, n.triangles = 0, n.points = 0, n.lines = 0;
+	}
+	return {
+		memory: t,
+		render: n,
+		programs: null,
+		autoReset: !0,
+		reset: i,
+		update: r
+	};
+}
+function Wi(e, t, n) {
+	let r = /* @__PURE__ */ new WeakMap(), i = new je();
+	function a(a, o, s) {
+		let c = a.morphTargetInfluences, u = o.morphAttributes.position || o.morphAttributes.normal || o.morphAttributes.color, d = u === void 0 ? 0 : u.length, f = r.get(o);
+		if (f === void 0 || f.count !== d) {
+			f !== void 0 && f.texture.dispose();
+			let e = o.morphAttributes.position !== void 0, n = o.morphAttributes.normal !== void 0, a = o.morphAttributes.color !== void 0, s = o.morphAttributes.position || [], c = o.morphAttributes.normal || [], u = o.morphAttributes.color || [], p = 0;
+			e === !0 && (p = 1), n === !0 && (p = 2), a === !0 && (p = 3);
+			let m = o.attributes.position.count * p, h = 1;
+			m > t.maxTextureSize && (h = Math.ceil(m / t.maxTextureSize), m = t.maxTextureSize);
+			let g = new Float32Array(m * h * 4 * d), _ = new Ne(g, m, h, d);
+			_.type = l, _.needsUpdate = !0;
+			let v = p * 4;
+			for (let t = 0; t < d; t++) {
+				let r = s[t], o = c[t], l = u[t], d = m * h * 4 * t;
+				for (let t = 0; t < r.count; t++) {
+					let s = t * v;
+					e === !0 && (i.fromBufferAttribute(r, t), g[d + s + 0] = i.x, g[d + s + 1] = i.y, g[d + s + 2] = i.z, g[d + s + 3] = 0), n === !0 && (i.fromBufferAttribute(o, t), g[d + s + 4] = i.x, g[d + s + 5] = i.y, g[d + s + 6] = i.z, g[d + s + 7] = 0), a === !0 && (i.fromBufferAttribute(l, t), g[d + s + 8] = i.x, g[d + s + 9] = i.y, g[d + s + 10] = i.z, g[d + s + 11] = l.itemSize === 4 ? i.w : 1);
+				}
+			}
+			f = {
+				count: d,
+				texture: _,
+				size: new U(m, h)
+			}, r.set(o, f);
+			function y() {
+				_.dispose(), r.delete(o), o.removeEventListener("dispose", y);
+			}
+			o.addEventListener("dispose", y);
+		}
+		if (a.isInstancedMesh === !0 && a.morphTexture !== null) s.getUniforms().setValue(e, "morphTexture", a.morphTexture, n);
+		else {
+			let t = 0;
+			for (let e = 0; e < c.length; e++) t += c[e];
+			let n = o.morphTargetsRelative ? 1 : 1 - t;
+			s.getUniforms().setValue(e, "morphTargetBaseInfluence", n), s.getUniforms().setValue(e, "morphTargetInfluences", c);
+		}
+		s.getUniforms().setValue(e, "morphTargetsTexture", f.texture, n), s.getUniforms().setValue(e, "morphTargetsTextureSize", f.size);
+	}
+	return { update: a };
+}
+function Gi(e, t, n, r, i) {
+	let a = /* @__PURE__ */ new WeakMap();
+	function o(r) {
+		let o = i.render.frame, s = r.geometry, l = t.get(r, s);
+		if (a.get(l) !== o && (t.update(l), a.set(l, o)), r.isInstancedMesh && (r.hasEventListener("dispose", c) === !1 && r.addEventListener("dispose", c), a.get(r) !== o && (n.update(r.instanceMatrix, e.ARRAY_BUFFER), r.instanceColor !== null && n.update(r.instanceColor, e.ARRAY_BUFFER), a.set(r, o))), r.isSkinnedMesh) {
+			let e = r.skeleton;
+			a.get(e) !== o && (e.update(), a.set(e, o));
+		}
+		return l;
+	}
+	function s() {
+		a = /* @__PURE__ */ new WeakMap();
+	}
+	function c(e) {
+		let t = e.target;
+		t.removeEventListener("dispose", c), r.releaseStatesOfObject(t), n.remove(t.instanceMatrix), t.instanceColor !== null && n.remove(t.instanceColor);
+	}
+	return {
+		update: o,
+		dispose: s
+	};
+}
+var Ki = {
+	1: "LINEAR_TONE_MAPPING",
+	2: "REINHARD_TONE_MAPPING",
+	3: "CINEON_TONE_MAPPING",
+	4: "ACES_FILMIC_TONE_MAPPING",
+	6: "AGX_TONE_MAPPING",
+	7: "NEUTRAL_TONE_MAPPING",
+	5: "CUSTOM_TONE_MAPPING"
+};
+function qi(e, t, n, r, i, a) {
+	let o = new Me(t, n, {
+		type: e,
+		depthBuffer: i,
+		stencilBuffer: a,
+		samples: r ? 4 : 0,
+		depthTexture: i ? new er(t, n) : void 0
+	}), s = new Me(t, n, {
+		type: u,
+		depthBuffer: !1,
+		stencilBuffer: !1
+	}), c = new ln();
+	c.setAttribute("position", new Xt([
+		-1,
+		3,
+		0,
+		-1,
+		-1,
+		0,
+		3,
+		-1,
+		0
+	], 3)), c.setAttribute("uv", new Xt([
+		0,
+		2,
+		0,
+		0,
+		2,
+		0
+	], 2));
+	let l = new hr({
+		uniforms: { tDiffuse: { value: null } },
+		vertexShader: "\n			precision highp float;\n\n			uniform mat4 modelViewMatrix;\n			uniform mat4 projectionMatrix;\n\n			attribute vec3 position;\n			attribute vec2 uv;\n\n			varying vec2 vUv;\n\n			void main() {\n				vUv = uv;\n				gl_Position = projectionMatrix * modelViewMatrix * vec4( position, 1.0 );\n			}",
+		fragmentShader: "\n			precision highp float;\n\n			uniform sampler2D tDiffuse;\n\n			varying vec2 vUv;\n\n			#include <tonemapping_pars_fragment>\n			#include <colorspace_pars_fragment>\n\n			void main() {\n				gl_FragColor = texture2D( tDiffuse, vUv );\n\n				#ifdef LINEAR_TONE_MAPPING\n					gl_FragColor.rgb = LinearToneMapping( gl_FragColor.rgb );\n				#elif defined( REINHARD_TONE_MAPPING )\n					gl_FragColor.rgb = ReinhardToneMapping( gl_FragColor.rgb );\n				#elif defined( CINEON_TONE_MAPPING )\n					gl_FragColor.rgb = CineonToneMapping( gl_FragColor.rgb );\n				#elif defined( ACES_FILMIC_TONE_MAPPING )\n					gl_FragColor.rgb = ACESFilmicToneMapping( gl_FragColor.rgb );\n				#elif defined( AGX_TONE_MAPPING )\n					gl_FragColor.rgb = AgXToneMapping( gl_FragColor.rgb );\n				#elif defined( NEUTRAL_TONE_MAPPING )\n					gl_FragColor.rgb = NeutralToneMapping( gl_FragColor.rgb );\n				#elif defined( CUSTOM_TONE_MAPPING )\n					gl_FragColor.rgb = CustomToneMapping( gl_FragColor.rgb );\n				#endif\n\n				#ifdef SRGB_TRANSFER\n					gl_FragColor = sRGBTransferOETF( gl_FragColor );\n				#endif\n			}",
+		depthTest: !1,
+		depthWrite: !1
+	}), d = new Mn(c, l), f = new Hr(-1, 1, 1, -1, 0, 1), p = null, m = null, h = !1, g, _ = null, v = [], y = !1;
+	this.setSize = function(e, t) {
+		o.setSize(e, t), s.setSize(e, t);
+		for (let n = 0; n < v.length; n++) {
+			let r = v[n];
+			r.setSize && r.setSize(e, t);
+		}
+	}, this.setEffects = function(e) {
+		v = e, y = v.length > 0 && v[0].isRenderPass === !0;
+		let t = o.width, n = o.height;
+		for (let e = 0; e < v.length; e++) {
+			let r = v[e];
+			r.setSize && r.setSize(t, n);
+		}
+	}, this.begin = function(e, t) {
+		if (h || e.toneMapping === 0 && v.length === 0) return !1;
+		if (_ = t, t !== null) {
+			let e = t.width, n = t.height;
+			(o.width !== e || o.height !== n) && this.setSize(e, n);
+		}
+		return y === !1 && e.setRenderTarget(o), g = e.toneMapping, e.toneMapping = 0, !0;
+	}, this.hasRenderPass = function() {
+		return y;
+	}, this.end = function(e, t) {
+		e.toneMapping = g, h = !0;
+		let n = o, r = s;
+		for (let i = 0; i < v.length; i++) {
+			let a = v[i];
+			if (a.enabled !== !1 && (a.render(e, r, n, t), a.needsSwap !== !1)) {
+				let e = n;
+				n = r, r = e;
+			}
+		}
+		if (p !== e.outputColorSpace || m !== e.toneMapping) {
+			p = e.outputColorSpace, m = e.toneMapping, l.defines = {}, K.getTransfer(p) === "srgb" && (l.defines.SRGB_TRANSFER = "");
+			let t = Ki[m];
+			t && (l.defines[t] = ""), l.needsUpdate = !0;
+		}
+		l.uniforms.tDiffuse.value = n.texture, e.setRenderTarget(_), e.render(d, f), _ = null, h = !1;
+	}, this.isCompositing = function() {
+		return h;
+	}, this.dispose = function() {
+		o.depthTexture && o.depthTexture.dispose(), o.dispose(), s.dispose(), c.dispose(), l.dispose();
+	};
+}
+var Ji = /*@__PURE__*/ new Ae(), Yi = /*@__PURE__*/ new er(1, 1), Xi = /*@__PURE__*/ new Ne(), Zi = /*@__PURE__*/ new Pe(), Qi = /*@__PURE__*/ new $n(), $i = [], ea = [], ta = /* @__PURE__ */ new Float32Array(16), na = /* @__PURE__ */ new Float32Array(9), ra = /* @__PURE__ */ new Float32Array(4);
+function ia(e, t, n) {
+	let r = e[0];
+	if (r <= 0 || r > 0) return e;
+	let i = t * n, a = $i[i];
+	if (a === void 0 && (a = new Float32Array(i), $i[i] = a), t !== 0) {
+		r.toArray(a, 0);
+		for (let r = 1, i = 0; r !== t; ++r) i += n, e[r].toArray(a, i);
+	}
+	return a;
+}
+function aa(e, t) {
+	if (e.length !== t.length) return !1;
+	for (let n = 0, r = e.length; n < r; n++) if (e[n] !== t[n]) return !1;
+	return !0;
+}
+function oa(e, t) {
+	for (let n = 0, r = t.length; n < r; n++) e[n] = t[n];
+}
+function sa(e, t) {
+	let n = ea[t];
+	n === void 0 && (n = new Int32Array(t), ea[t] = n);
+	for (let r = 0; r !== t; ++r) n[r] = e.allocateTextureUnit();
+	return n;
+}
+function ca(e, t) {
+	let n = this.cache;
+	n[0] !== t && (e.uniform1f(this.addr, t), n[0] = t);
+}
+function la(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y) && (e.uniform2f(this.addr, t.x, t.y), n[0] = t.x, n[1] = t.y);
+	else {
+		if (aa(n, t)) return;
+		e.uniform2fv(this.addr, t), oa(n, t);
+	}
+}
+function ua(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y || n[2] !== t.z) && (e.uniform3f(this.addr, t.x, t.y, t.z), n[0] = t.x, n[1] = t.y, n[2] = t.z);
+	else if (t.r !== void 0) (n[0] !== t.r || n[1] !== t.g || n[2] !== t.b) && (e.uniform3f(this.addr, t.r, t.g, t.b), n[0] = t.r, n[1] = t.g, n[2] = t.b);
+	else {
+		if (aa(n, t)) return;
+		e.uniform3fv(this.addr, t), oa(n, t);
+	}
+}
+function da(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y || n[2] !== t.z || n[3] !== t.w) && (e.uniform4f(this.addr, t.x, t.y, t.z, t.w), n[0] = t.x, n[1] = t.y, n[2] = t.z, n[3] = t.w);
+	else {
+		if (aa(n, t)) return;
+		e.uniform4fv(this.addr, t), oa(n, t);
+	}
+}
+function fa(e, t) {
+	let n = this.cache, r = t.elements;
+	if (r === void 0) {
+		if (aa(n, t)) return;
+		e.uniformMatrix2fv(this.addr, !1, t), oa(n, t);
+	} else {
+		if (aa(n, r)) return;
+		ra.set(r), e.uniformMatrix2fv(this.addr, !1, ra), oa(n, r);
+	}
+}
+function pa(e, t) {
+	let n = this.cache, r = t.elements;
+	if (r === void 0) {
+		if (aa(n, t)) return;
+		e.uniformMatrix3fv(this.addr, !1, t), oa(n, t);
+	} else {
+		if (aa(n, r)) return;
+		na.set(r), e.uniformMatrix3fv(this.addr, !1, na), oa(n, r);
+	}
+}
+function ma(e, t) {
+	let n = this.cache, r = t.elements;
+	if (r === void 0) {
+		if (aa(n, t)) return;
+		e.uniformMatrix4fv(this.addr, !1, t), oa(n, t);
+	} else {
+		if (aa(n, r)) return;
+		ta.set(r), e.uniformMatrix4fv(this.addr, !1, ta), oa(n, r);
+	}
+}
+function ha(e, t) {
+	let n = this.cache;
+	n[0] !== t && (e.uniform1i(this.addr, t), n[0] = t);
+}
+function ga(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y) && (e.uniform2i(this.addr, t.x, t.y), n[0] = t.x, n[1] = t.y);
+	else {
+		if (aa(n, t)) return;
+		e.uniform2iv(this.addr, t), oa(n, t);
+	}
+}
+function _a(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y || n[2] !== t.z) && (e.uniform3i(this.addr, t.x, t.y, t.z), n[0] = t.x, n[1] = t.y, n[2] = t.z);
+	else {
+		if (aa(n, t)) return;
+		e.uniform3iv(this.addr, t), oa(n, t);
+	}
+}
+function va(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y || n[2] !== t.z || n[3] !== t.w) && (e.uniform4i(this.addr, t.x, t.y, t.z, t.w), n[0] = t.x, n[1] = t.y, n[2] = t.z, n[3] = t.w);
+	else {
+		if (aa(n, t)) return;
+		e.uniform4iv(this.addr, t), oa(n, t);
+	}
+}
+function ya(e, t) {
+	let n = this.cache;
+	n[0] !== t && (e.uniform1ui(this.addr, t), n[0] = t);
+}
+function ba(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y) && (e.uniform2ui(this.addr, t.x, t.y), n[0] = t.x, n[1] = t.y);
+	else {
+		if (aa(n, t)) return;
+		e.uniform2uiv(this.addr, t), oa(n, t);
+	}
+}
+function xa(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y || n[2] !== t.z) && (e.uniform3ui(this.addr, t.x, t.y, t.z), n[0] = t.x, n[1] = t.y, n[2] = t.z);
+	else {
+		if (aa(n, t)) return;
+		e.uniform3uiv(this.addr, t), oa(n, t);
+	}
+}
+function Sa(e, t) {
+	let n = this.cache;
+	if (t.x !== void 0) (n[0] !== t.x || n[1] !== t.y || n[2] !== t.z || n[3] !== t.w) && (e.uniform4ui(this.addr, t.x, t.y, t.z, t.w), n[0] = t.x, n[1] = t.y, n[2] = t.z, n[3] = t.w);
+	else {
+		if (aa(n, t)) return;
+		e.uniform4uiv(this.addr, t), oa(n, t);
+	}
+}
+function Ca(e, t, n) {
+	let r = this.cache, i = n.allocateTextureUnit();
+	r[0] !== i && (e.uniform1i(this.addr, i), r[0] = i);
+	let a;
+	this.type === e.SAMPLER_2D_SHADOW ? (Yi.compareFunction = n.isReversedDepthBuffer() ? 518 : 515, a = Yi) : a = Ji, n.setTexture2D(t || a, i);
+}
+function wa(e, t, n) {
+	let r = this.cache, i = n.allocateTextureUnit();
+	r[0] !== i && (e.uniform1i(this.addr, i), r[0] = i), n.setTexture3D(t || Zi, i);
+}
+function Ta(e, t, n) {
+	let r = this.cache, i = n.allocateTextureUnit();
+	r[0] !== i && (e.uniform1i(this.addr, i), r[0] = i), n.setTextureCube(t || Qi, i);
+}
+function Ea(e, t, n) {
+	let r = this.cache, i = n.allocateTextureUnit();
+	r[0] !== i && (e.uniform1i(this.addr, i), r[0] = i), n.setTexture2DArray(t || Xi, i);
+}
+function Da(e) {
+	switch (e) {
+		case 5126: return ca;
+		case 35664: return la;
+		case 35665: return ua;
+		case 35666: return da;
+		case 35674: return fa;
+		case 35675: return pa;
+		case 35676: return ma;
+		case 5124:
+		case 35670: return ha;
+		case 35667:
+		case 35671: return ga;
+		case 35668:
+		case 35672: return _a;
+		case 35669:
+		case 35673: return va;
+		case 5125: return ya;
+		case 36294: return ba;
+		case 36295: return xa;
+		case 36296: return Sa;
+		case 35678:
+		case 36198:
+		case 36298:
+		case 36306:
+		case 35682: return Ca;
+		case 35679:
+		case 36299:
+		case 36307: return wa;
+		case 35680:
+		case 36300:
+		case 36308:
+		case 36293: return Ta;
+		case 36289:
+		case 36303:
+		case 36311:
+		case 36292: return Ea;
+	}
+}
+function Oa(e, t) {
+	e.uniform1fv(this.addr, t);
+}
+function ka(e, t) {
+	let n = ia(t, this.size, 2);
+	e.uniform2fv(this.addr, n);
+}
+function Aa(e, t) {
+	let n = ia(t, this.size, 3);
+	e.uniform3fv(this.addr, n);
+}
+function ja(e, t) {
+	let n = ia(t, this.size, 4);
+	e.uniform4fv(this.addr, n);
+}
+function Ma(e, t) {
+	let n = ia(t, this.size, 4);
+	e.uniformMatrix2fv(this.addr, !1, n);
+}
+function Na(e, t) {
+	let n = ia(t, this.size, 9);
+	e.uniformMatrix3fv(this.addr, !1, n);
+}
+function Pa(e, t) {
+	let n = ia(t, this.size, 16);
+	e.uniformMatrix4fv(this.addr, !1, n);
+}
+function Fa(e, t) {
+	e.uniform1iv(this.addr, t);
+}
+function Ia(e, t) {
+	e.uniform2iv(this.addr, t);
+}
+function La(e, t) {
+	e.uniform3iv(this.addr, t);
+}
+function Ra(e, t) {
+	e.uniform4iv(this.addr, t);
+}
+function za(e, t) {
+	e.uniform1uiv(this.addr, t);
+}
+function Ba(e, t) {
+	e.uniform2uiv(this.addr, t);
+}
+function Va(e, t) {
+	e.uniform3uiv(this.addr, t);
+}
+function Ha(e, t) {
+	e.uniform4uiv(this.addr, t);
+}
+function Ua(e, t, n) {
+	let r = this.cache, i = t.length, a = sa(n, i);
+	aa(r, a) || (e.uniform1iv(this.addr, a), oa(r, a));
+	let o;
+	o = this.type === e.SAMPLER_2D_SHADOW ? Yi : Ji;
+	for (let e = 0; e !== i; ++e) n.setTexture2D(t[e] || o, a[e]);
+}
+function Wa(e, t, n) {
+	let r = this.cache, i = t.length, a = sa(n, i);
+	aa(r, a) || (e.uniform1iv(this.addr, a), oa(r, a));
+	for (let e = 0; e !== i; ++e) n.setTexture3D(t[e] || Zi, a[e]);
+}
+function Ga(e, t, n) {
+	let r = this.cache, i = t.length, a = sa(n, i);
+	aa(r, a) || (e.uniform1iv(this.addr, a), oa(r, a));
+	for (let e = 0; e !== i; ++e) n.setTextureCube(t[e] || Qi, a[e]);
+}
+function Ka(e, t, n) {
+	let r = this.cache, i = t.length, a = sa(n, i);
+	aa(r, a) || (e.uniform1iv(this.addr, a), oa(r, a));
+	for (let e = 0; e !== i; ++e) n.setTexture2DArray(t[e] || Xi, a[e]);
+}
+function qa(e) {
+	switch (e) {
+		case 5126: return Oa;
+		case 35664: return ka;
+		case 35665: return Aa;
+		case 35666: return ja;
+		case 35674: return Ma;
+		case 35675: return Na;
+		case 35676: return Pa;
+		case 5124:
+		case 35670: return Fa;
+		case 35667:
+		case 35671: return Ia;
+		case 35668:
+		case 35672: return La;
+		case 35669:
+		case 35673: return Ra;
+		case 5125: return za;
+		case 36294: return Ba;
+		case 36295: return Va;
+		case 36296: return Ha;
+		case 35678:
+		case 36198:
+		case 36298:
+		case 36306:
+		case 35682: return Ua;
+		case 35679:
+		case 36299:
+		case 36307: return Wa;
+		case 35680:
+		case 36300:
+		case 36308:
+		case 36293: return Ga;
+		case 36289:
+		case 36303:
+		case 36311:
+		case 36292: return Ka;
+	}
+}
+var Ja = class {
+	constructor(e, t, n) {
+		this.id = e, this.addr = n, this.cache = [], this.type = t.type, this.setValue = Da(t.type);
+	}
+}, Ya = class {
+	constructor(e, t, n) {
+		this.id = e, this.addr = n, this.cache = [], this.type = t.type, this.size = t.size, this.setValue = qa(t.type);
+	}
+}, Xa = class {
+	constructor(e) {
+		this.id = e, this.seq = [], this.map = {};
+	}
+	setValue(e, t, n) {
+		let r = this.seq;
+		for (let i = 0, a = r.length; i !== a; ++i) {
+			let a = r[i];
+			a.setValue(e, t[a.id], n);
+		}
+	}
+}, Za = /(\w+)(\])?(\[|\.)?/g;
+function Qa(e, t) {
+	e.seq.push(t), e.map[t.id] = t;
+}
+function $a(e, t, n) {
+	let r = e.name, i = r.length;
+	for (Za.lastIndex = 0;;) {
+		let a = Za.exec(r), o = Za.lastIndex, s = a[1], c = a[2] === "]", l = a[3];
+		if (c && (s |= 0), l === void 0 || l === "[" && o + 2 === i) {
+			Qa(n, l === void 0 ? new Ja(s, e, t) : new Ya(s, e, t));
+			break;
+		} else {
+			let e = n.map[s];
+			e === void 0 && (e = new Xa(s), Qa(n, e)), n = e;
+		}
+	}
+}
+var eo = class {
+	constructor(e, t) {
+		this.seq = [], this.map = {};
+		let n = e.getProgramParameter(t, e.ACTIVE_UNIFORMS);
+		for (let r = 0; r < n; ++r) {
+			let n = e.getActiveUniform(t, r);
+			$a(n, e.getUniformLocation(t, n.name), this);
+		}
+		let r = [], i = [];
+		for (let t of this.seq) t.type === e.SAMPLER_2D_SHADOW || t.type === e.SAMPLER_CUBE_SHADOW || t.type === e.SAMPLER_2D_ARRAY_SHADOW ? r.push(t) : i.push(t);
+		r.length > 0 && (this.seq = r.concat(i));
+	}
+	setValue(e, t, n, r) {
+		let i = this.map[t];
+		i !== void 0 && i.setValue(e, n, r);
+	}
+	setOptional(e, t, n) {
+		let r = t[n];
+		r !== void 0 && this.setValue(e, n, r);
+	}
+	static upload(e, t, n, r) {
+		for (let i = 0, a = t.length; i !== a; ++i) {
+			let a = t[i], o = n[a.id];
+			o.needsUpdate !== !1 && a.setValue(e, o.value, r);
+		}
+	}
+	static seqWithValue(e, t) {
+		let n = [];
+		for (let r = 0, i = e.length; r !== i; ++r) {
+			let i = e[r];
+			i.id in t && n.push(i);
+		}
+		return n;
+	}
+};
+function to(e, t, n) {
+	let r = e.createShader(t);
+	return e.shaderSource(r, n), e.compileShader(r), r;
+}
+var no = 37297, ro = 0;
+function io(e, t) {
+	let n = e.split("\n"), r = [], i = Math.max(t - 6, 0), a = Math.min(t + 6, n.length);
+	for (let e = i; e < a; e++) {
+		let i = e + 1;
+		r.push(`${i === t ? ">" : " "} ${i}: ${n[e]}`);
+	}
+	return r.join("\n");
+}
+var ao = /*@__PURE__*/ new G();
+function oo(e) {
+	K._getMatrix(ao, K.workingColorSpace, e);
+	let t = `mat3( ${ao.elements.map((e) => e.toFixed(4))} )`;
+	switch (K.getTransfer(e)) {
+		case ee: return [t, "LinearTransferOETF"];
+		case j: return [t, "sRGBTransferOETF"];
+		default: return F("WebGLProgram: Unsupported color space: ", e), [t, "LinearTransferOETF"];
+	}
+}
+function so(e, t, n) {
+	let r = e.getShaderParameter(t, e.COMPILE_STATUS), i = (e.getShaderInfoLog(t) || "").trim();
+	if (r && i === "") return "";
+	let a = /ERROR: 0:(\d+)/.exec(i);
+	if (a) {
+		let r = parseInt(a[1]);
+		return n.toUpperCase() + "\n\n" + i + "\n\n" + io(e.getShaderSource(t), r);
+	} else return i;
+}
+function co(e, t) {
+	let n = oo(t);
+	return [
+		`vec4 ${e}( vec4 value ) {`,
+		`	return ${n[1]}( vec4( value.rgb * ${n[0]}, value.a ) );`,
+		"}"
+	].join("\n");
+}
+var lo = {
+	1: "Linear",
+	2: "Reinhard",
+	3: "Cineon",
+	4: "ACESFilmic",
+	6: "AgX",
+	7: "Neutral",
+	5: "Custom"
+};
+function uo(e, t) {
+	let n = lo[t];
+	return n === void 0 ? (F("WebGLProgram: Unsupported toneMapping:", t), "vec3 " + e + "( vec3 color ) { return LinearToneMapping( color ); }") : "vec3 " + e + "( vec3 color ) { return " + n + "ToneMapping( color ); }";
+}
+var fo = /*@__PURE__*/ new W();
+function po() {
+	return K.getLuminanceCoefficients(fo), [
+		"float luminance( const in vec3 rgb ) {",
+		`	const vec3 weights = vec3( ${fo.x.toFixed(4)}, ${fo.y.toFixed(4)}, ${fo.z.toFixed(4)} );`,
+		"	return dot( weights, rgb );",
+		"}"
+	].join("\n");
+}
+function mo(e) {
+	return [e.extensionClipCullDistance ? "#extension GL_ANGLE_clip_cull_distance : require" : "", e.extensionMultiDraw ? "#extension GL_ANGLE_multi_draw : require" : ""].filter(_o).join("\n");
+}
+function ho(e) {
+	let t = [];
+	for (let n in e) {
+		let r = e[n];
+		r !== !1 && t.push("#define " + n + " " + r);
+	}
+	return t.join("\n");
+}
+function go(e, t) {
+	let n = {}, r = e.getProgramParameter(t, e.ACTIVE_ATTRIBUTES);
+	for (let i = 0; i < r; i++) {
+		let r = e.getActiveAttrib(t, i), a = r.name, o = 1;
+		r.type === e.FLOAT_MAT2 && (o = 2), r.type === e.FLOAT_MAT3 && (o = 3), r.type === e.FLOAT_MAT4 && (o = 4), n[a] = {
+			type: r.type,
+			location: e.getAttribLocation(t, a),
+			locationSize: o
+		};
+	}
+	return n;
+}
+function _o(e) {
+	return e !== "";
+}
+function vo(e, t) {
+	let n = t.numSpotLightShadows + t.numSpotLightMaps - t.numSpotLightShadowsWithMaps;
+	return e.replace(/NUM_DIR_LIGHTS/g, t.numDirLights).replace(/NUM_SPOT_LIGHTS/g, t.numSpotLights).replace(/NUM_SPOT_LIGHT_MAPS/g, t.numSpotLightMaps).replace(/NUM_SPOT_LIGHT_COORDS/g, n).replace(/NUM_RECT_AREA_LIGHTS/g, t.numRectAreaLights).replace(/NUM_POINT_LIGHTS/g, t.numPointLights).replace(/NUM_HEMI_LIGHTS/g, t.numHemiLights).replace(/NUM_DIR_LIGHT_SHADOWS/g, t.numDirLightShadows).replace(/NUM_SPOT_LIGHT_SHADOWS_WITH_MAPS/g, t.numSpotLightShadowsWithMaps).replace(/NUM_SPOT_LIGHT_SHADOWS/g, t.numSpotLightShadows).replace(/NUM_POINT_LIGHT_SHADOWS/g, t.numPointLightShadows);
+}
+function yo(e, t) {
+	return e.replace(/NUM_CLIPPING_PLANES/g, t.numClippingPlanes).replace(/UNION_CLIPPING_PLANES/g, t.numClippingPlanes - t.numClipIntersection);
+}
+var bo = /^[ \t]*#include +<([\w\d./]+)>/gm;
+function xo(e) {
+	return e.replace(bo, Co);
+}
+var So = /* @__PURE__ */ new Map();
+function Co(e, t) {
+	let n = Q[t];
+	if (n === void 0) {
+		let e = So.get(t);
+		if (e !== void 0) n = Q[e], F("WebGLRenderer: Shader chunk \"%s\" has been deprecated. Use \"%s\" instead.", t, e);
+		else throw Error("THREE.WebGLProgram: Can not resolve #include <" + t + ">");
+	}
+	return xo(n);
+}
+var wo = /#pragma unroll_loop_start\s+for\s*\(\s*int\s+i\s*=\s*(\d+)\s*;\s*i\s*<\s*(\d+)\s*;\s*i\s*\+\+\s*\)\s*{([\s\S]+?)}\s+#pragma unroll_loop_end/g;
+function To(e) {
+	return e.replace(wo, Eo);
+}
+function Eo(e, t, n, r) {
+	let i = "";
+	for (let e = parseInt(t); e < parseInt(n); e++) i += r.replace(/\[\s*i\s*\]/g, "[ " + e + " ]").replace(/UNROLLED_LOOP_INDEX/g, e);
+	return i;
+}
+function Do(e) {
+	let t = `precision ${e.precision} float;
+	precision ${e.precision} int;
+	precision ${e.precision} sampler2D;
+	precision ${e.precision} samplerCube;
+	precision ${e.precision} sampler3D;
+	precision ${e.precision} sampler2DArray;
+	precision ${e.precision} sampler2DShadow;
+	precision ${e.precision} samplerCubeShadow;
+	precision ${e.precision} sampler2DArrayShadow;
+	precision ${e.precision} isampler2D;
+	precision ${e.precision} isampler3D;
+	precision ${e.precision} isamplerCube;
+	precision ${e.precision} isampler2DArray;
+	precision ${e.precision} usampler2D;
+	precision ${e.precision} usampler3D;
+	precision ${e.precision} usamplerCube;
+	precision ${e.precision} usampler2DArray;
+	`;
+	return e.precision === "highp" ? t += "\n#define HIGH_PRECISION" : e.precision === "mediump" ? t += "\n#define MEDIUM_PRECISION" : e.precision === "lowp" && (t += "\n#define LOW_PRECISION"), t;
+}
+var Oo = {
+	1: "SHADOWMAP_TYPE_PCF",
+	3: "SHADOWMAP_TYPE_VSM"
+};
+function ko(e) {
+	return Oo[e.shadowMapType] || "SHADOWMAP_TYPE_BASIC";
+}
+var Ao = {
+	301: "ENVMAP_TYPE_CUBE",
+	302: "ENVMAP_TYPE_CUBE",
+	306: "ENVMAP_TYPE_CUBE_UV"
+};
+function jo(e) {
+	return e.envMap === !1 ? "ENVMAP_TYPE_CUBE" : Ao[e.envMapMode] || "ENVMAP_TYPE_CUBE";
+}
+var Mo = { 302: "ENVMAP_MODE_REFRACTION" };
+function No(e) {
+	return e.envMap === !1 ? "ENVMAP_MODE_REFLECTION" : Mo[e.envMapMode] || "ENVMAP_MODE_REFLECTION";
+}
+var Po = {
+	0: "ENVMAP_BLENDING_MULTIPLY",
+	1: "ENVMAP_BLENDING_MIX",
+	2: "ENVMAP_BLENDING_ADD"
+};
+function Fo(e) {
+	return e.envMap === !1 ? "ENVMAP_BLENDING_NONE" : Po[e.combine] || "ENVMAP_BLENDING_NONE";
+}
+function Io(e) {
+	let t = e.envMapCubeUVHeight;
+	if (t === null) return null;
+	let n = Math.log2(t) - 2, r = 1 / t;
+	return {
+		texelWidth: 1 / (3 * Math.max(2 ** n, 112)),
+		texelHeight: r,
+		maxMip: n
+	};
+}
+function Lo(e, t, n, r) {
+	let i = e.getContext(), a = n.defines, o = n.vertexShader, s = n.fragmentShader, c = ko(n), l = jo(n), u = No(n), d = Fo(n), f = Io(n), p = mo(n), m = ho(a), h = i.createProgram(), g, _, v = n.glslVersion ? "#version " + n.glslVersion + "\n" : "";
+	n.isRawShaderMaterial ? (g = [
+		"#define SHADER_TYPE " + n.shaderType,
+		"#define SHADER_NAME " + n.shaderName,
+		m
+	].filter(_o).join("\n"), g.length > 0 && (g += "\n"), _ = [
+		"#define SHADER_TYPE " + n.shaderType,
+		"#define SHADER_NAME " + n.shaderName,
+		m
+	].filter(_o).join("\n"), _.length > 0 && (_ += "\n")) : (g = [
+		Do(n),
+		"#define SHADER_TYPE " + n.shaderType,
+		"#define SHADER_NAME " + n.shaderName,
+		m,
+		n.extensionClipCullDistance ? "#define USE_CLIP_DISTANCE" : "",
+		n.batching ? "#define USE_BATCHING" : "",
+		n.batchingColor ? "#define USE_BATCHING_COLOR" : "",
+		n.instancing ? "#define USE_INSTANCING" : "",
+		n.instancingColor ? "#define USE_INSTANCING_COLOR" : "",
+		n.instancingMorph ? "#define USE_INSTANCING_MORPH" : "",
+		n.useFog && n.fog ? "#define USE_FOG" : "",
+		n.useFog && n.fogExp2 ? "#define FOG_EXP2" : "",
+		n.map ? "#define USE_MAP" : "",
+		n.envMap ? "#define USE_ENVMAP" : "",
+		n.envMap ? "#define " + u : "",
+		n.lightMap ? "#define USE_LIGHTMAP" : "",
+		n.aoMap ? "#define USE_AOMAP" : "",
+		n.bumpMap ? "#define USE_BUMPMAP" : "",
+		n.normalMap ? "#define USE_NORMALMAP" : "",
+		n.normalMapObjectSpace ? "#define USE_NORMALMAP_OBJECTSPACE" : "",
+		n.normalMapTangentSpace ? "#define USE_NORMALMAP_TANGENTSPACE" : "",
+		n.displacementMap ? "#define USE_DISPLACEMENTMAP" : "",
+		n.emissiveMap ? "#define USE_EMISSIVEMAP" : "",
+		n.anisotropy ? "#define USE_ANISOTROPY" : "",
+		n.anisotropyMap ? "#define USE_ANISOTROPYMAP" : "",
+		n.clearcoatMap ? "#define USE_CLEARCOATMAP" : "",
+		n.clearcoatRoughnessMap ? "#define USE_CLEARCOAT_ROUGHNESSMAP" : "",
+		n.clearcoatNormalMap ? "#define USE_CLEARCOAT_NORMALMAP" : "",
+		n.iridescenceMap ? "#define USE_IRIDESCENCEMAP" : "",
+		n.iridescenceThicknessMap ? "#define USE_IRIDESCENCE_THICKNESSMAP" : "",
+		n.specularMap ? "#define USE_SPECULARMAP" : "",
+		n.specularColorMap ? "#define USE_SPECULAR_COLORMAP" : "",
+		n.specularIntensityMap ? "#define USE_SPECULAR_INTENSITYMAP" : "",
+		n.roughnessMap ? "#define USE_ROUGHNESSMAP" : "",
+		n.metalnessMap ? "#define USE_METALNESSMAP" : "",
+		n.alphaMap ? "#define USE_ALPHAMAP" : "",
+		n.alphaHash ? "#define USE_ALPHAHASH" : "",
+		n.transmission ? "#define USE_TRANSMISSION" : "",
+		n.transmissionMap ? "#define USE_TRANSMISSIONMAP" : "",
+		n.thicknessMap ? "#define USE_THICKNESSMAP" : "",
+		n.sheenColorMap ? "#define USE_SHEEN_COLORMAP" : "",
+		n.sheenRoughnessMap ? "#define USE_SHEEN_ROUGHNESSMAP" : "",
+		n.mapUv ? "#define MAP_UV " + n.mapUv : "",
+		n.alphaMapUv ? "#define ALPHAMAP_UV " + n.alphaMapUv : "",
+		n.lightMapUv ? "#define LIGHTMAP_UV " + n.lightMapUv : "",
+		n.aoMapUv ? "#define AOMAP_UV " + n.aoMapUv : "",
+		n.emissiveMapUv ? "#define EMISSIVEMAP_UV " + n.emissiveMapUv : "",
+		n.bumpMapUv ? "#define BUMPMAP_UV " + n.bumpMapUv : "",
+		n.normalMapUv ? "#define NORMALMAP_UV " + n.normalMapUv : "",
+		n.displacementMapUv ? "#define DISPLACEMENTMAP_UV " + n.displacementMapUv : "",
+		n.metalnessMapUv ? "#define METALNESSMAP_UV " + n.metalnessMapUv : "",
+		n.roughnessMapUv ? "#define ROUGHNESSMAP_UV " + n.roughnessMapUv : "",
+		n.anisotropyMapUv ? "#define ANISOTROPYMAP_UV " + n.anisotropyMapUv : "",
+		n.clearcoatMapUv ? "#define CLEARCOATMAP_UV " + n.clearcoatMapUv : "",
+		n.clearcoatNormalMapUv ? "#define CLEARCOAT_NORMALMAP_UV " + n.clearcoatNormalMapUv : "",
+		n.clearcoatRoughnessMapUv ? "#define CLEARCOAT_ROUGHNESSMAP_UV " + n.clearcoatRoughnessMapUv : "",
+		n.iridescenceMapUv ? "#define IRIDESCENCEMAP_UV " + n.iridescenceMapUv : "",
+		n.iridescenceThicknessMapUv ? "#define IRIDESCENCE_THICKNESSMAP_UV " + n.iridescenceThicknessMapUv : "",
+		n.sheenColorMapUv ? "#define SHEEN_COLORMAP_UV " + n.sheenColorMapUv : "",
+		n.sheenRoughnessMapUv ? "#define SHEEN_ROUGHNESSMAP_UV " + n.sheenRoughnessMapUv : "",
+		n.specularMapUv ? "#define SPECULARMAP_UV " + n.specularMapUv : "",
+		n.specularColorMapUv ? "#define SPECULAR_COLORMAP_UV " + n.specularColorMapUv : "",
+		n.specularIntensityMapUv ? "#define SPECULAR_INTENSITYMAP_UV " + n.specularIntensityMapUv : "",
+		n.transmissionMapUv ? "#define TRANSMISSIONMAP_UV " + n.transmissionMapUv : "",
+		n.thicknessMapUv ? "#define THICKNESSMAP_UV " + n.thicknessMapUv : "",
+		n.vertexTangents && n.flatShading === !1 ? "#define USE_TANGENT" : "",
+		n.vertexNormals ? "#define HAS_NORMAL" : "",
+		n.vertexColors ? "#define USE_COLOR" : "",
+		n.vertexAlphas ? "#define USE_COLOR_ALPHA" : "",
+		n.vertexUv1s ? "#define USE_UV1" : "",
+		n.vertexUv2s ? "#define USE_UV2" : "",
+		n.vertexUv3s ? "#define USE_UV3" : "",
+		n.pointsUvs ? "#define USE_POINTS_UV" : "",
+		n.flatShading ? "#define FLAT_SHADED" : "",
+		n.skinning ? "#define USE_SKINNING" : "",
+		n.morphTargets ? "#define USE_MORPHTARGETS" : "",
+		n.morphNormals && n.flatShading === !1 ? "#define USE_MORPHNORMALS" : "",
+		n.morphColors ? "#define USE_MORPHCOLORS" : "",
+		n.morphTargetsCount > 0 ? "#define MORPHTARGETS_TEXTURE_STRIDE " + n.morphTextureStride : "",
+		n.morphTargetsCount > 0 ? "#define MORPHTARGETS_COUNT " + n.morphTargetsCount : "",
+		n.doubleSided ? "#define DOUBLE_SIDED" : "",
+		n.flipSided ? "#define FLIP_SIDED" : "",
+		n.shadowMapEnabled ? "#define USE_SHADOWMAP" : "",
+		n.shadowMapEnabled ? "#define " + c : "",
+		n.sizeAttenuation ? "#define USE_SIZEATTENUATION" : "",
+		n.numLightProbes > 0 ? "#define USE_LIGHT_PROBES" : "",
+		n.logarithmicDepthBuffer ? "#define USE_LOGARITHMIC_DEPTH_BUFFER" : "",
+		n.reversedDepthBuffer ? "#define USE_REVERSED_DEPTH_BUFFER" : "",
+		"uniform mat4 modelMatrix;",
+		"uniform mat4 modelViewMatrix;",
+		"uniform mat4 projectionMatrix;",
+		"uniform mat4 viewMatrix;",
+		"uniform mat3 normalMatrix;",
+		"uniform vec3 cameraPosition;",
+		"uniform bool isOrthographic;",
+		"#ifdef USE_INSTANCING",
+		"	attribute mat4 instanceMatrix;",
+		"#endif",
+		"#ifdef USE_INSTANCING_COLOR",
+		"	attribute vec3 instanceColor;",
+		"#endif",
+		"#ifdef USE_INSTANCING_MORPH",
+		"	uniform sampler2D morphTexture;",
+		"#endif",
+		"attribute vec3 position;",
+		"attribute vec3 normal;",
+		"attribute vec2 uv;",
+		"#ifdef USE_UV1",
+		"	attribute vec2 uv1;",
+		"#endif",
+		"#ifdef USE_UV2",
+		"	attribute vec2 uv2;",
+		"#endif",
+		"#ifdef USE_UV3",
+		"	attribute vec2 uv3;",
+		"#endif",
+		"#ifdef USE_TANGENT",
+		"	attribute vec4 tangent;",
+		"#endif",
+		"#if defined( USE_COLOR_ALPHA )",
+		"	attribute vec4 color;",
+		"#elif defined( USE_COLOR )",
+		"	attribute vec3 color;",
+		"#endif",
+		"#ifdef USE_SKINNING",
+		"	attribute vec4 skinIndex;",
+		"	attribute vec4 skinWeight;",
+		"#endif",
+		"\n"
+	].filter(_o).join("\n"), _ = [
+		Do(n),
+		"#define SHADER_TYPE " + n.shaderType,
+		"#define SHADER_NAME " + n.shaderName,
+		m,
+		n.useFog && n.fog ? "#define USE_FOG" : "",
+		n.useFog && n.fogExp2 ? "#define FOG_EXP2" : "",
+		n.alphaToCoverage ? "#define ALPHA_TO_COVERAGE" : "",
+		n.map ? "#define USE_MAP" : "",
+		n.matcap ? "#define USE_MATCAP" : "",
+		n.envMap ? "#define USE_ENVMAP" : "",
+		n.envMap ? "#define " + l : "",
+		n.envMap ? "#define " + u : "",
+		n.envMap ? "#define " + d : "",
+		f ? "#define CUBEUV_TEXEL_WIDTH " + f.texelWidth : "",
+		f ? "#define CUBEUV_TEXEL_HEIGHT " + f.texelHeight : "",
+		f ? "#define CUBEUV_MAX_MIP " + f.maxMip + ".0" : "",
+		n.lightMap ? "#define USE_LIGHTMAP" : "",
+		n.aoMap ? "#define USE_AOMAP" : "",
+		n.bumpMap ? "#define USE_BUMPMAP" : "",
+		n.normalMap ? "#define USE_NORMALMAP" : "",
+		n.normalMapObjectSpace ? "#define USE_NORMALMAP_OBJECTSPACE" : "",
+		n.normalMapTangentSpace ? "#define USE_NORMALMAP_TANGENTSPACE" : "",
+		n.packedNormalMap ? "#define USE_PACKED_NORMALMAP" : "",
+		n.emissiveMap ? "#define USE_EMISSIVEMAP" : "",
+		n.anisotropy ? "#define USE_ANISOTROPY" : "",
+		n.anisotropyMap ? "#define USE_ANISOTROPYMAP" : "",
+		n.clearcoat ? "#define USE_CLEARCOAT" : "",
+		n.clearcoatMap ? "#define USE_CLEARCOATMAP" : "",
+		n.clearcoatRoughnessMap ? "#define USE_CLEARCOAT_ROUGHNESSMAP" : "",
+		n.clearcoatNormalMap ? "#define USE_CLEARCOAT_NORMALMAP" : "",
+		n.dispersion ? "#define USE_DISPERSION" : "",
+		n.iridescence ? "#define USE_IRIDESCENCE" : "",
+		n.iridescenceMap ? "#define USE_IRIDESCENCEMAP" : "",
+		n.iridescenceThicknessMap ? "#define USE_IRIDESCENCE_THICKNESSMAP" : "",
+		n.specularMap ? "#define USE_SPECULARMAP" : "",
+		n.specularColorMap ? "#define USE_SPECULAR_COLORMAP" : "",
+		n.specularIntensityMap ? "#define USE_SPECULAR_INTENSITYMAP" : "",
+		n.roughnessMap ? "#define USE_ROUGHNESSMAP" : "",
+		n.metalnessMap ? "#define USE_METALNESSMAP" : "",
+		n.alphaMap ? "#define USE_ALPHAMAP" : "",
+		n.alphaTest ? "#define USE_ALPHATEST" : "",
+		n.alphaHash ? "#define USE_ALPHAHASH" : "",
+		n.sheen ? "#define USE_SHEEN" : "",
+		n.sheenColorMap ? "#define USE_SHEEN_COLORMAP" : "",
+		n.sheenRoughnessMap ? "#define USE_SHEEN_ROUGHNESSMAP" : "",
+		n.transmission ? "#define USE_TRANSMISSION" : "",
+		n.transmissionMap ? "#define USE_TRANSMISSIONMAP" : "",
+		n.thicknessMap ? "#define USE_THICKNESSMAP" : "",
+		n.vertexTangents && n.flatShading === !1 ? "#define USE_TANGENT" : "",
+		n.vertexColors || n.instancingColor ? "#define USE_COLOR" : "",
+		n.vertexAlphas || n.batchingColor ? "#define USE_COLOR_ALPHA" : "",
+		n.vertexUv1s ? "#define USE_UV1" : "",
+		n.vertexUv2s ? "#define USE_UV2" : "",
+		n.vertexUv3s ? "#define USE_UV3" : "",
+		n.pointsUvs ? "#define USE_POINTS_UV" : "",
+		n.gradientMap ? "#define USE_GRADIENTMAP" : "",
+		n.flatShading ? "#define FLAT_SHADED" : "",
+		n.doubleSided ? "#define DOUBLE_SIDED" : "",
+		n.flipSided ? "#define FLIP_SIDED" : "",
+		n.shadowMapEnabled ? "#define USE_SHADOWMAP" : "",
+		n.shadowMapEnabled ? "#define " + c : "",
+		n.premultipliedAlpha ? "#define PREMULTIPLIED_ALPHA" : "",
+		n.numLightProbes > 0 ? "#define USE_LIGHT_PROBES" : "",
+		n.numLightProbeGrids > 0 ? "#define USE_LIGHT_PROBES_GRID" : "",
+		n.decodeVideoTexture ? "#define DECODE_VIDEO_TEXTURE" : "",
+		n.decodeVideoTextureEmissive ? "#define DECODE_VIDEO_TEXTURE_EMISSIVE" : "",
+		n.logarithmicDepthBuffer ? "#define USE_LOGARITHMIC_DEPTH_BUFFER" : "",
+		n.reversedDepthBuffer ? "#define USE_REVERSED_DEPTH_BUFFER" : "",
+		"uniform mat4 viewMatrix;",
+		"uniform vec3 cameraPosition;",
+		"uniform bool isOrthographic;",
+		n.toneMapping === 0 ? "" : "#define TONE_MAPPING",
+		n.toneMapping === 0 ? "" : Q.tonemapping_pars_fragment,
+		n.toneMapping === 0 ? "" : uo("toneMapping", n.toneMapping),
+		n.dithering ? "#define DITHERING" : "",
+		n.opaque ? "#define OPAQUE" : "",
+		Q.colorspace_pars_fragment,
+		co("linearToOutputTexel", n.outputColorSpace),
+		po(),
+		n.useDepthPacking ? "#define DEPTH_PACKING " + n.depthPacking : "",
+		"\n"
+	].filter(_o).join("\n")), o = xo(o), o = vo(o, n), o = yo(o, n), s = xo(s), s = vo(s, n), s = yo(s, n), o = To(o), s = To(s), n.isRawShaderMaterial !== !0 && (v = "#version 300 es\n", g = [
+		p,
+		"#define attribute in",
+		"#define varying out",
+		"#define texture2D texture"
+	].join("\n") + "\n" + g, _ = [
+		"#define varying in",
+		n.glslVersion === "300 es" ? "" : "layout(location = 0) out highp vec4 pc_fragColor;",
+		n.glslVersion === "300 es" ? "" : "#define gl_FragColor pc_fragColor",
+		"#define gl_FragDepthEXT gl_FragDepth",
+		"#define texture2D texture",
+		"#define textureCube texture",
+		"#define texture2DProj textureProj",
+		"#define texture2DLodEXT textureLod",
+		"#define texture2DProjLodEXT textureProjLod",
+		"#define textureCubeLodEXT textureLod",
+		"#define texture2DGradEXT textureGrad",
+		"#define texture2DProjGradEXT textureProjGrad",
+		"#define textureCubeGradEXT textureGrad"
+	].join("\n") + "\n" + _);
+	let y = v + g + o, b = v + _ + s, x = to(i, i.VERTEX_SHADER, y), S = to(i, i.FRAGMENT_SHADER, b);
+	i.attachShader(h, x), i.attachShader(h, S), n.index0AttributeName === void 0 ? n.hasPositionAttribute === !0 && i.bindAttribLocation(h, 0, "position") : i.bindAttribLocation(h, 0, n.index0AttributeName), i.linkProgram(h);
+	function C(t) {
+		if (e.debug.checkShaderErrors) {
+			let n = i.getProgramInfoLog(h) || "", r = i.getShaderInfoLog(x) || "", a = i.getShaderInfoLog(S) || "", o = n.trim(), s = r.trim(), c = a.trim(), l = !0, u = !0;
+			if (i.getProgramParameter(h, i.LINK_STATUS) === !1) if (l = !1, typeof e.debug.onShaderError == "function") e.debug.onShaderError(i, h, x, S);
+			else {
+				let e = so(i, x, "vertex"), n = so(i, S, "fragment");
+				I("WebGLProgram: Shader Error " + i.getError() + " - VALIDATE_STATUS " + i.getProgramParameter(h, i.VALIDATE_STATUS) + "\n\nMaterial Name: " + t.name + "\nMaterial Type: " + t.type + "\n\nProgram Info Log: " + o + "\n" + e + "\n" + n);
+			}
+			else o === "" ? (s === "" || c === "") && (u = !1) : F("WebGLProgram: Program Info Log:", o);
+			u && (t.diagnostics = {
+				runnable: l,
+				programLog: o,
+				vertexShader: {
+					log: s,
+					prefix: g
+				},
+				fragmentShader: {
+					log: c,
+					prefix: _
+				}
+			});
+		}
+		i.deleteShader(x), i.deleteShader(S), w = new eo(i, h), T = go(i, h);
+	}
+	let w;
+	this.getUniforms = function() {
+		return w === void 0 && C(this), w;
+	};
+	let T;
+	this.getAttributes = function() {
+		return T === void 0 && C(this), T;
+	};
+	let E = n.rendererExtensionParallelShaderCompile === !1;
+	return this.isReady = function() {
+		return E === !1 && (E = i.getProgramParameter(h, no)), E;
+	}, this.destroy = function() {
+		r.releaseStatesOfProgram(this), i.deleteProgram(h), this.program = void 0;
+	}, this.type = n.shaderType, this.name = n.shaderName, this.id = ro++, this.cacheKey = t, this.usedTimes = 1, this.program = h, this.vertexShader = x, this.fragmentShader = S, this;
+}
+var Ro = 0, zo = class {
+	constructor() {
+		this.shaderCache = /* @__PURE__ */ new Map(), this.materialCache = /* @__PURE__ */ new Map();
+	}
+	update(e, t, n) {
+		let r = this._getShaderCacheForMaterial(e);
+		return r.has(t) === !1 && (r.add(t), t.usedTimes++), r.has(n) === !1 && (r.add(n), n.usedTimes++), this;
+	}
+	remove(e) {
+		let t = this.materialCache.get(e);
+		for (let e of t) e.usedTimes--, e.usedTimes === 0 && this.shaderCache.delete(e.code);
+		return this.materialCache.delete(e), this;
+	}
+	getVertexShaderStage(e) {
+		return this._getShaderStage(e.vertexShader);
+	}
+	getFragmentShaderStage(e) {
+		return this._getShaderStage(e.fragmentShader);
+	}
+	dispose() {
+		this.shaderCache.clear(), this.materialCache.clear();
+	}
+	_getShaderCacheForMaterial(e) {
+		let t = this.materialCache, n = t.get(e);
+		return n === void 0 && (n = /* @__PURE__ */ new Set(), t.set(e, n)), n;
+	}
+	_getShaderStage(e) {
+		let t = this.shaderCache, n = t.get(e);
+		return n === void 0 && (n = new Bo(e), t.set(e, n)), n;
+	}
+}, Bo = class {
+	constructor(e) {
+		this.id = Ro++, this.code = e, this.usedTimes = 0;
+	}
+};
+function Vo(e) {
+	return e === 1030 || e === 37490 || e === 36285;
+}
+function Ho(e, t, n, r, i, a) {
+	let o = new Ue(), s = new zo(), c = /* @__PURE__ */ new Set(), l = [], u = /* @__PURE__ */ new Map(), d = r.logarithmicDepthBuffer, f = r.precision, p = {
+		MeshDepthMaterial: "depth",
+		MeshDistanceMaterial: "distance",
+		MeshNormalMaterial: "normal",
+		MeshBasicMaterial: "basic",
+		MeshLambertMaterial: "lambert",
+		MeshPhongMaterial: "phong",
+		MeshToonMaterial: "toon",
+		MeshStandardMaterial: "physical",
+		MeshPhysicalMaterial: "physical",
+		MeshMatcapMaterial: "matcap",
+		LineBasicMaterial: "basic",
+		LineDashedMaterial: "dashed",
+		PointsMaterial: "points",
+		ShadowMaterial: "shadow",
+		SpriteMaterial: "sprite"
+	};
+	function m(e) {
+		return c.add(e), e === 0 ? "uv" : `uv${e}`;
+	}
+	function h(i, o, l, u, h, g) {
+		let _ = u.fog, v = h.geometry, y = i.isMeshStandardMaterial || i.isMeshLambertMaterial || i.isMeshPhongMaterial ? u.environment : null, b = i.isMeshStandardMaterial || i.isMeshLambertMaterial && !i.envMap || i.isMeshPhongMaterial && !i.envMap, x = t.get(i.envMap || y, b), S = x && x.mapping === 306 ? x.image.height : null, C = p[i.type];
+		i.precision !== null && (f = r.getMaxPrecision(i.precision), f !== i.precision && F("WebGLProgram.getParameters:", i.precision, "not supported, using", f, "instead."));
+		let w = v.morphAttributes.position || v.morphAttributes.normal || v.morphAttributes.color, T = w === void 0 ? 0 : w.length, E = 0;
+		v.morphAttributes.position !== void 0 && (E = 1), v.morphAttributes.normal !== void 0 && (E = 2), v.morphAttributes.color !== void 0 && (E = 3);
+		let D, O, k, A;
+		if (C) {
+			let e = li[C];
+			D = e.vertexShader, O = e.fragmentShader;
+		} else {
+			D = i.vertexShader, O = i.fragmentShader;
+			let e = s.getVertexShaderStage(i), t = s.getFragmentShaderStage(i);
+			s.update(i, e, t), k = e.id, A = t.id;
+		}
+		let ee = e.getRenderTarget(), j = e.state.buffers.depth.getReversed(), M = h.isInstancedMesh === !0, te = h.isBatchedMesh === !0, ne = !!i.map, N = !!i.matcap, re = !!x, ie = !!i.aoMap, P = !!i.lightMap, ae = !!i.bumpMap && i.wireframe === !1, oe = !!i.normalMap, I = !!i.displacementMap, L = !!i.emissiveMap, se = !!i.metalnessMap, ce = !!i.roughnessMap, R = i.anisotropy > 0, z = i.clearcoat > 0, le = i.dispersion > 0, ue = i.iridescence > 0, B = i.sheen > 0, V = i.transmission > 0, de = R && !!i.anisotropyMap, fe = z && !!i.clearcoatMap, pe = z && !!i.clearcoatNormalMap, H = z && !!i.clearcoatRoughnessMap, U = ue && !!i.iridescenceMap, me = ue && !!i.iridescenceThicknessMap, W = B && !!i.sheenColorMap, he = B && !!i.sheenRoughnessMap, ge = !!i.specularMap, G = !!i.specularColorMap, _e = !!i.specularIntensityMap, ve = V && !!i.transmissionMap, ye = V && !!i.thicknessMap, be = !!i.gradientMap, xe = !!i.alphaMap, Se = i.alphaTest > 0, Ce = !!i.alphaHash, we = !!i.extensions, Te = 0;
+		i.toneMapped && (ee === null || ee.isXRRenderTarget === !0) && (Te = e.toneMapping);
+		let Ee = {
+			shaderID: C,
+			shaderType: i.type,
+			shaderName: i.name,
+			vertexShader: D,
+			fragmentShader: O,
+			defines: i.defines,
+			customVertexShaderID: k,
+			customFragmentShaderID: A,
+			isRawShaderMaterial: i.isRawShaderMaterial === !0,
+			glslVersion: i.glslVersion,
+			precision: f,
+			batching: te,
+			batchingColor: te && h._colorsTexture !== null,
+			instancing: M,
+			instancingColor: M && h.instanceColor !== null,
+			instancingMorph: M && h.morphTexture !== null,
+			outputColorSpace: ee === null ? e.outputColorSpace : ee.isXRRenderTarget === !0 ? ee.texture.colorSpace : K.workingColorSpace,
+			alphaToCoverage: !!i.alphaToCoverage,
+			map: ne,
+			matcap: N,
+			envMap: re,
+			envMapMode: re && x.mapping,
+			envMapCubeUVHeight: S,
+			aoMap: ie,
+			lightMap: P,
+			bumpMap: ae,
+			normalMap: oe,
+			displacementMap: I,
+			emissiveMap: L,
+			normalMapObjectSpace: oe && i.normalMapType === 1,
+			normalMapTangentSpace: oe && i.normalMapType === 0,
+			packedNormalMap: oe && i.normalMapType === 0 && Vo(i.normalMap.format),
+			metalnessMap: se,
+			roughnessMap: ce,
+			anisotropy: R,
+			anisotropyMap: de,
+			clearcoat: z,
+			clearcoatMap: fe,
+			clearcoatNormalMap: pe,
+			clearcoatRoughnessMap: H,
+			dispersion: le,
+			iridescence: ue,
+			iridescenceMap: U,
+			iridescenceThicknessMap: me,
+			sheen: B,
+			sheenColorMap: W,
+			sheenRoughnessMap: he,
+			specularMap: ge,
+			specularColorMap: G,
+			specularIntensityMap: _e,
+			transmission: V,
+			transmissionMap: ve,
+			thicknessMap: ye,
+			gradientMap: be,
+			opaque: i.transparent === !1 && i.blending === 1 && i.alphaToCoverage === !1,
+			alphaMap: xe,
+			alphaTest: Se,
+			alphaHash: Ce,
+			combine: i.combine,
+			mapUv: ne && m(i.map.channel),
+			aoMapUv: ie && m(i.aoMap.channel),
+			lightMapUv: P && m(i.lightMap.channel),
+			bumpMapUv: ae && m(i.bumpMap.channel),
+			normalMapUv: oe && m(i.normalMap.channel),
+			displacementMapUv: I && m(i.displacementMap.channel),
+			emissiveMapUv: L && m(i.emissiveMap.channel),
+			metalnessMapUv: se && m(i.metalnessMap.channel),
+			roughnessMapUv: ce && m(i.roughnessMap.channel),
+			anisotropyMapUv: de && m(i.anisotropyMap.channel),
+			clearcoatMapUv: fe && m(i.clearcoatMap.channel),
+			clearcoatNormalMapUv: pe && m(i.clearcoatNormalMap.channel),
+			clearcoatRoughnessMapUv: H && m(i.clearcoatRoughnessMap.channel),
+			iridescenceMapUv: U && m(i.iridescenceMap.channel),
+			iridescenceThicknessMapUv: me && m(i.iridescenceThicknessMap.channel),
+			sheenColorMapUv: W && m(i.sheenColorMap.channel),
+			sheenRoughnessMapUv: he && m(i.sheenRoughnessMap.channel),
+			specularMapUv: ge && m(i.specularMap.channel),
+			specularColorMapUv: G && m(i.specularColorMap.channel),
+			specularIntensityMapUv: _e && m(i.specularIntensityMap.channel),
+			transmissionMapUv: ve && m(i.transmissionMap.channel),
+			thicknessMapUv: ye && m(i.thicknessMap.channel),
+			alphaMapUv: xe && m(i.alphaMap.channel),
+			vertexTangents: !!v.attributes.tangent && (oe || R),
+			vertexNormals: !!v.attributes.normal,
+			vertexColors: i.vertexColors,
+			vertexAlphas: i.vertexColors === !0 && !!v.attributes.color && v.attributes.color.itemSize === 4,
+			pointsUvs: h.isPoints === !0 && !!v.attributes.uv && (ne || xe),
+			fog: !!_,
+			useFog: i.fog === !0,
+			fogExp2: !!_ && _.isFogExp2,
+			flatShading: i.wireframe === !1 && (i.flatShading === !0 || v.attributes.normal === void 0 && oe === !1 && (i.isMeshLambertMaterial || i.isMeshPhongMaterial || i.isMeshStandardMaterial || i.isMeshPhysicalMaterial)),
+			sizeAttenuation: i.sizeAttenuation === !0,
+			logarithmicDepthBuffer: d,
+			reversedDepthBuffer: j,
+			skinning: h.isSkinnedMesh === !0,
+			hasPositionAttribute: v.attributes.position !== void 0,
+			morphTargets: v.morphAttributes.position !== void 0,
+			morphNormals: v.morphAttributes.normal !== void 0,
+			morphColors: v.morphAttributes.color !== void 0,
+			morphTargetsCount: T,
+			morphTextureStride: E,
+			numDirLights: o.directional.length,
+			numPointLights: o.point.length,
+			numSpotLights: o.spot.length,
+			numSpotLightMaps: o.spotLightMap.length,
+			numRectAreaLights: o.rectArea.length,
+			numHemiLights: o.hemi.length,
+			numDirLightShadows: o.directionalShadowMap.length,
+			numPointLightShadows: o.pointShadowMap.length,
+			numSpotLightShadows: o.spotShadowMap.length,
+			numSpotLightShadowsWithMaps: o.numSpotLightShadowsWithMaps,
+			numLightProbes: o.numLightProbes,
+			numLightProbeGrids: g.length,
+			numClippingPlanes: a.numPlanes,
+			numClipIntersection: a.numIntersection,
+			dithering: i.dithering,
+			shadowMapEnabled: e.shadowMap.enabled && l.length > 0,
+			shadowMapType: e.shadowMap.type,
+			toneMapping: Te,
+			decodeVideoTexture: ne && i.map.isVideoTexture === !0 && K.getTransfer(i.map.colorSpace) === "srgb",
+			decodeVideoTextureEmissive: L && i.emissiveMap.isVideoTexture === !0 && K.getTransfer(i.emissiveMap.colorSpace) === "srgb",
+			premultipliedAlpha: i.premultipliedAlpha,
+			doubleSided: i.side === 2,
+			flipSided: i.side === 1,
+			useDepthPacking: i.depthPacking >= 0,
+			depthPacking: i.depthPacking || 0,
+			index0AttributeName: i.index0AttributeName,
+			extensionClipCullDistance: we && i.extensions.clipCullDistance === !0 && n.has("WEBGL_clip_cull_distance"),
+			extensionMultiDraw: (we && i.extensions.multiDraw === !0 || te) && n.has("WEBGL_multi_draw"),
+			rendererExtensionParallelShaderCompile: n.has("KHR_parallel_shader_compile"),
+			customProgramCacheKey: i.customProgramCacheKey()
+		};
+		return Ee.vertexUv1s = c.has(1), Ee.vertexUv2s = c.has(2), Ee.vertexUv3s = c.has(3), c.clear(), Ee;
+	}
+	function g(t) {
+		let n = [];
+		if (t.shaderID ? n.push(t.shaderID) : (n.push(t.customVertexShaderID), n.push(t.customFragmentShaderID)), t.defines !== void 0) for (let e in t.defines) n.push(e), n.push(t.defines[e]);
+		return t.isRawShaderMaterial === !1 && (_(n, t), v(n, t), n.push(e.outputColorSpace)), n.push(t.customProgramCacheKey), n.join();
+	}
+	function _(e, t) {
+		e.push(t.precision), e.push(t.outputColorSpace), e.push(t.envMapMode), e.push(t.envMapCubeUVHeight), e.push(t.mapUv), e.push(t.alphaMapUv), e.push(t.lightMapUv), e.push(t.aoMapUv), e.push(t.bumpMapUv), e.push(t.normalMapUv), e.push(t.displacementMapUv), e.push(t.emissiveMapUv), e.push(t.metalnessMapUv), e.push(t.roughnessMapUv), e.push(t.anisotropyMapUv), e.push(t.clearcoatMapUv), e.push(t.clearcoatNormalMapUv), e.push(t.clearcoatRoughnessMapUv), e.push(t.iridescenceMapUv), e.push(t.iridescenceThicknessMapUv), e.push(t.sheenColorMapUv), e.push(t.sheenRoughnessMapUv), e.push(t.specularMapUv), e.push(t.specularColorMapUv), e.push(t.specularIntensityMapUv), e.push(t.transmissionMapUv), e.push(t.thicknessMapUv), e.push(t.combine), e.push(t.fogExp2), e.push(t.sizeAttenuation), e.push(t.morphTargetsCount), e.push(t.morphAttributeCount), e.push(t.numDirLights), e.push(t.numPointLights), e.push(t.numSpotLights), e.push(t.numSpotLightMaps), e.push(t.numHemiLights), e.push(t.numRectAreaLights), e.push(t.numDirLightShadows), e.push(t.numPointLightShadows), e.push(t.numSpotLightShadows), e.push(t.numSpotLightShadowsWithMaps), e.push(t.numLightProbes), e.push(t.shadowMapType), e.push(t.toneMapping), e.push(t.numClippingPlanes), e.push(t.numClipIntersection), e.push(t.depthPacking);
+	}
+	function v(e, t) {
+		o.disableAll(), t.instancing && o.enable(0), t.instancingColor && o.enable(1), t.instancingMorph && o.enable(2), t.matcap && o.enable(3), t.envMap && o.enable(4), t.normalMapObjectSpace && o.enable(5), t.normalMapTangentSpace && o.enable(6), t.clearcoat && o.enable(7), t.iridescence && o.enable(8), t.alphaTest && o.enable(9), t.vertexColors && o.enable(10), t.vertexAlphas && o.enable(11), t.vertexUv1s && o.enable(12), t.vertexUv2s && o.enable(13), t.vertexUv3s && o.enable(14), t.vertexTangents && o.enable(15), t.anisotropy && o.enable(16), t.alphaHash && o.enable(17), t.batching && o.enable(18), t.dispersion && o.enable(19), t.batchingColor && o.enable(20), t.gradientMap && o.enable(21), t.packedNormalMap && o.enable(22), t.vertexNormals && o.enable(23), e.push(o.mask), o.disableAll(), t.fog && o.enable(0), t.useFog && o.enable(1), t.flatShading && o.enable(2), t.logarithmicDepthBuffer && o.enable(3), t.reversedDepthBuffer && o.enable(4), t.skinning && o.enable(5), t.morphTargets && o.enable(6), t.morphNormals && o.enable(7), t.morphColors && o.enable(8), t.premultipliedAlpha && o.enable(9), t.shadowMapEnabled && o.enable(10), t.doubleSided && o.enable(11), t.flipSided && o.enable(12), t.useDepthPacking && o.enable(13), t.dithering && o.enable(14), t.transmission && o.enable(15), t.sheen && o.enable(16), t.opaque && o.enable(17), t.pointsUvs && o.enable(18), t.decodeVideoTexture && o.enable(19), t.decodeVideoTextureEmissive && o.enable(20), t.alphaToCoverage && o.enable(21), t.numLightProbeGrids > 0 && o.enable(22), t.hasPositionAttribute && o.enable(23), e.push(o.mask);
+	}
+	function y(e) {
+		let t = p[e.type], n;
+		if (t) {
+			let e = li[t];
+			n = dr.clone(e.uniforms);
+		} else n = e.uniforms;
+		return n;
+	}
+	function b(t, n) {
+		let r = u.get(n);
+		return r === void 0 ? (r = new Lo(e, n, t, i), l.push(r), u.set(n, r)) : ++r.usedTimes, r;
+	}
+	function x(e) {
+		if (--e.usedTimes === 0) {
+			let t = l.indexOf(e);
+			l[t] = l[l.length - 1], l.pop(), u.delete(e.cacheKey), e.destroy();
+		}
+	}
+	function S(e) {
+		s.remove(e);
+	}
+	function C() {
+		s.dispose();
+	}
+	return {
+		getParameters: h,
+		getProgramCacheKey: g,
+		getUniforms: y,
+		acquireProgram: b,
+		releaseProgram: x,
+		releaseShaderCache: S,
+		programs: l,
+		dispose: C
+	};
+}
+function Uo() {
+	let e = /* @__PURE__ */ new WeakMap();
+	function t(t) {
+		return e.has(t);
+	}
+	function n(t) {
+		let n = e.get(t);
+		return n === void 0 && (n = {}, e.set(t, n)), n;
+	}
+	function r(t) {
+		e.delete(t);
+	}
+	function i(t, n, r) {
+		e.get(t)[n] = r;
+	}
+	function a() {
+		e = /* @__PURE__ */ new WeakMap();
+	}
+	return {
+		has: t,
+		get: n,
+		remove: r,
+		update: i,
+		dispose: a
+	};
+}
+function Wo(e, t) {
+	return e.groupOrder === t.groupOrder ? e.renderOrder === t.renderOrder ? e.material.id === t.material.id ? e.materialVariant === t.materialVariant ? e.z === t.z ? e.id - t.id : e.z - t.z : e.materialVariant - t.materialVariant : e.material.id - t.material.id : e.renderOrder - t.renderOrder : e.groupOrder - t.groupOrder;
+}
+function Go(e, t) {
+	return e.groupOrder === t.groupOrder ? e.renderOrder === t.renderOrder ? e.z === t.z ? e.id - t.id : t.z - e.z : e.renderOrder - t.renderOrder : e.groupOrder - t.groupOrder;
+}
+function Ko() {
+	let e = [], t = 0, n = [], r = [], i = [];
+	function a() {
+		t = 0, n.length = 0, r.length = 0, i.length = 0;
+	}
+	function o(e) {
+		let t = 0;
+		return e.isInstancedMesh && (t += 2), e.isSkinnedMesh && (t += 1), t;
+	}
+	function s(n, r, i, a, s, c) {
+		let l = e[t];
+		return l === void 0 ? (l = {
+			id: n.id,
+			object: n,
+			geometry: r,
+			material: i,
+			materialVariant: o(n),
+			groupOrder: a,
+			renderOrder: n.renderOrder,
+			z: s,
+			group: c
+		}, e[t] = l) : (l.id = n.id, l.object = n, l.geometry = r, l.material = i, l.materialVariant = o(n), l.groupOrder = a, l.renderOrder = n.renderOrder, l.z = s, l.group = c), t++, l;
+	}
+	function c(e, t, a, o, c, l) {
+		let u = s(e, t, a, o, c, l);
+		a.transmission > 0 ? r.push(u) : a.transparent === !0 ? i.push(u) : n.push(u);
+	}
+	function l(e, t, a, o, c, l) {
+		let u = s(e, t, a, o, c, l);
+		a.transmission > 0 ? r.unshift(u) : a.transparent === !0 ? i.unshift(u) : n.unshift(u);
+	}
+	function u(e, t, a) {
+		n.length > 1 && n.sort(e || Wo), r.length > 1 && r.sort(t || Go), i.length > 1 && i.sort(t || Go), a && (n.reverse(), r.reverse(), i.reverse());
+	}
+	function d() {
+		for (let n = t, r = e.length; n < r; n++) {
+			let t = e[n];
+			if (t.id === null) break;
+			t.id = null, t.object = null, t.geometry = null, t.material = null, t.group = null;
+		}
+	}
+	return {
+		opaque: n,
+		transmissive: r,
+		transparent: i,
+		init: a,
+		push: c,
+		unshift: l,
+		finish: d,
+		sort: u
+	};
+}
+function qo() {
+	let e = /* @__PURE__ */ new WeakMap();
+	function t(t, n) {
+		let r = e.get(t), i;
+		return r === void 0 ? (i = new Ko(), e.set(t, [i])) : n >= r.length ? (i = new Ko(), r.push(i)) : i = r[n], i;
+	}
+	function n() {
+		e = /* @__PURE__ */ new WeakMap();
+	}
+	return {
+		get: t,
+		dispose: n
+	};
+}
+function Jo() {
+	let e = {};
+	return { get: function(t) {
+		if (e[t.id] !== void 0) return e[t.id];
+		let n;
+		switch (t.type) {
+			case "DirectionalLight":
+				n = {
+					direction: new W(),
+					color: new Z()
+				};
+				break;
+			case "SpotLight":
+				n = {
+					position: new W(),
+					direction: new W(),
+					color: new Z(),
+					distance: 0,
+					coneCos: 0,
+					penumbraCos: 0,
+					decay: 0
+				};
+				break;
+			case "PointLight":
+				n = {
+					position: new W(),
+					color: new Z(),
+					distance: 0,
+					decay: 0
+				};
+				break;
+			case "HemisphereLight":
+				n = {
+					direction: new W(),
+					skyColor: new Z(),
+					groundColor: new Z()
+				};
+				break;
+			case "RectAreaLight":
+				n = {
+					color: new Z(),
+					position: new W(),
+					halfWidth: new W(),
+					halfHeight: new W()
+				};
+				break;
+		}
+		return e[t.id] = n, n;
+	} };
+}
+function Yo() {
+	let e = {};
+	return { get: function(t) {
+		if (e[t.id] !== void 0) return e[t.id];
+		let n;
+		switch (t.type) {
+			case "DirectionalLight":
+				n = {
+					shadowIntensity: 1,
+					shadowBias: 0,
+					shadowNormalBias: 0,
+					shadowRadius: 1,
+					shadowMapSize: new U()
+				};
+				break;
+			case "SpotLight":
+				n = {
+					shadowIntensity: 1,
+					shadowBias: 0,
+					shadowNormalBias: 0,
+					shadowRadius: 1,
+					shadowMapSize: new U()
+				};
+				break;
+			case "PointLight":
+				n = {
+					shadowIntensity: 1,
+					shadowBias: 0,
+					shadowNormalBias: 0,
+					shadowRadius: 1,
+					shadowMapSize: new U(),
+					shadowCameraNear: 1,
+					shadowCameraFar: 1e3
+				};
+				break;
+		}
+		return e[t.id] = n, n;
+	} };
+}
+var Xo = 0;
+function Zo(e, t) {
+	return (t.castShadow ? 2 : 0) - (e.castShadow ? 2 : 0) + +!!t.map - !!e.map;
+}
+function Qo(e) {
+	let t = new Jo(), n = Yo(), r = {
+		version: 0,
+		hash: {
+			directionalLength: -1,
+			pointLength: -1,
+			spotLength: -1,
+			rectAreaLength: -1,
+			hemiLength: -1,
+			numDirectionalShadows: -1,
+			numPointShadows: -1,
+			numSpotShadows: -1,
+			numSpotMaps: -1,
+			numLightProbes: -1
+		},
+		ambient: [
+			0,
+			0,
+			0
+		],
+		probe: [],
+		directional: [],
+		directionalShadow: [],
+		directionalShadowMap: [],
+		directionalShadowMatrix: [],
+		spot: [],
+		spotLightMap: [],
+		spotShadow: [],
+		spotShadowMap: [],
+		spotLightMatrix: [],
+		rectArea: [],
+		rectAreaLTC1: null,
+		rectAreaLTC2: null,
+		point: [],
+		pointShadow: [],
+		pointShadowMap: [],
+		pointShadowMatrix: [],
+		hemi: [],
+		numSpotLightShadowsWithMaps: 0,
+		numLightProbes: 0
+	};
+	for (let e = 0; e < 9; e++) r.probe.push(new W());
+	let i = new W(), a = new Fe(), o = new Fe();
+	function s(i) {
+		let a = 0, o = 0, s = 0;
+		for (let e = 0; e < 9; e++) r.probe[e].set(0, 0, 0);
+		let c = 0, l = 0, u = 0, d = 0, f = 0, p = 0, m = 0, h = 0, g = 0, _ = 0, v = 0;
+		i.sort(Zo);
+		for (let e = 0, y = i.length; e < y; e++) {
+			let y = i[e], b = y.color, x = y.intensity, S = y.distance, C = null;
+			if (y.shadow && y.shadow.map && (C = y.shadow.map.texture.format === 1030 ? y.shadow.map.texture : y.shadow.map.depthTexture || y.shadow.map.texture), y.isAmbientLight) a += b.r * x, o += b.g * x, s += b.b * x;
+			else if (y.isLightProbe) {
+				for (let e = 0; e < 9; e++) r.probe[e].addScaledVector(y.sh.coefficients[e], x);
+				v++;
+			} else if (y.isDirectionalLight) {
+				let e = t.get(y);
+				if (e.color.copy(y.color).multiplyScalar(y.intensity), y.castShadow) {
+					let e = y.shadow, t = n.get(y);
+					t.shadowIntensity = e.intensity, t.shadowBias = e.bias, t.shadowNormalBias = e.normalBias, t.shadowRadius = e.radius, t.shadowMapSize = e.mapSize, r.directionalShadow[c] = t, r.directionalShadowMap[c] = C, r.directionalShadowMatrix[c] = y.shadow.matrix, p++;
+				}
+				r.directional[c] = e, c++;
+			} else if (y.isSpotLight) {
+				let e = t.get(y);
+				e.position.setFromMatrixPosition(y.matrixWorld), e.color.copy(b).multiplyScalar(x), e.distance = S, e.coneCos = Math.cos(y.angle), e.penumbraCos = Math.cos(y.angle * (1 - y.penumbra)), e.decay = y.decay, r.spot[u] = e;
+				let i = y.shadow;
+				if (y.map && (r.spotLightMap[g] = y.map, g++, i.updateMatrices(y), y.castShadow && _++), r.spotLightMatrix[u] = i.matrix, y.castShadow) {
+					let e = n.get(y);
+					e.shadowIntensity = i.intensity, e.shadowBias = i.bias, e.shadowNormalBias = i.normalBias, e.shadowRadius = i.radius, e.shadowMapSize = i.mapSize, r.spotShadow[u] = e, r.spotShadowMap[u] = C, h++;
+				}
+				u++;
+			} else if (y.isRectAreaLight) {
+				let e = t.get(y);
+				e.color.copy(b).multiplyScalar(x), e.halfWidth.set(y.width * .5, 0, 0), e.halfHeight.set(0, y.height * .5, 0), r.rectArea[d] = e, d++;
+			} else if (y.isPointLight) {
+				let e = t.get(y);
+				if (e.color.copy(y.color).multiplyScalar(y.intensity), e.distance = y.distance, e.decay = y.decay, y.castShadow) {
+					let e = y.shadow, t = n.get(y);
+					t.shadowIntensity = e.intensity, t.shadowBias = e.bias, t.shadowNormalBias = e.normalBias, t.shadowRadius = e.radius, t.shadowMapSize = e.mapSize, t.shadowCameraNear = e.camera.near, t.shadowCameraFar = e.camera.far, r.pointShadow[l] = t, r.pointShadowMap[l] = C, r.pointShadowMatrix[l] = y.shadow.matrix, m++;
+				}
+				r.point[l] = e, l++;
+			} else if (y.isHemisphereLight) {
+				let e = t.get(y);
+				e.skyColor.copy(y.color).multiplyScalar(x), e.groundColor.copy(y.groundColor).multiplyScalar(x), r.hemi[f] = e, f++;
+			}
+		}
+		d > 0 && (e.has("OES_texture_float_linear") === !0 ? (r.rectAreaLTC1 = $.LTC_FLOAT_1, r.rectAreaLTC2 = $.LTC_FLOAT_2) : (r.rectAreaLTC1 = $.LTC_HALF_1, r.rectAreaLTC2 = $.LTC_HALF_2)), r.ambient[0] = a, r.ambient[1] = o, r.ambient[2] = s;
+		let y = r.hash;
+		(y.directionalLength !== c || y.pointLength !== l || y.spotLength !== u || y.rectAreaLength !== d || y.hemiLength !== f || y.numDirectionalShadows !== p || y.numPointShadows !== m || y.numSpotShadows !== h || y.numSpotMaps !== g || y.numLightProbes !== v) && (r.directional.length = c, r.spot.length = u, r.rectArea.length = d, r.point.length = l, r.hemi.length = f, r.directionalShadow.length = p, r.directionalShadowMap.length = p, r.pointShadow.length = m, r.pointShadowMap.length = m, r.spotShadow.length = h, r.spotShadowMap.length = h, r.directionalShadowMatrix.length = p, r.pointShadowMatrix.length = m, r.spotLightMatrix.length = h + g - _, r.spotLightMap.length = g, r.numSpotLightShadowsWithMaps = _, r.numLightProbes = v, y.directionalLength = c, y.pointLength = l, y.spotLength = u, y.rectAreaLength = d, y.hemiLength = f, y.numDirectionalShadows = p, y.numPointShadows = m, y.numSpotShadows = h, y.numSpotMaps = g, y.numLightProbes = v, r.version = Xo++);
+	}
+	function c(e, t) {
+		let n = 0, s = 0, c = 0, l = 0, u = 0, d = t.matrixWorldInverse;
+		for (let t = 0, f = e.length; t < f; t++) {
+			let f = e[t];
+			if (f.isDirectionalLight) {
+				let e = r.directional[n];
+				e.direction.setFromMatrixPosition(f.matrixWorld), i.setFromMatrixPosition(f.target.matrixWorld), e.direction.sub(i), e.direction.transformDirection(d), n++;
+			} else if (f.isSpotLight) {
+				let e = r.spot[c];
+				e.position.setFromMatrixPosition(f.matrixWorld), e.position.applyMatrix4(d), e.direction.setFromMatrixPosition(f.matrixWorld), i.setFromMatrixPosition(f.target.matrixWorld), e.direction.sub(i), e.direction.transformDirection(d), c++;
+			} else if (f.isRectAreaLight) {
+				let e = r.rectArea[l];
+				e.position.setFromMatrixPosition(f.matrixWorld), e.position.applyMatrix4(d), o.identity(), a.copy(f.matrixWorld), a.premultiply(d), o.extractRotation(a), e.halfWidth.set(f.width * .5, 0, 0), e.halfHeight.set(0, f.height * .5, 0), e.halfWidth.applyMatrix4(o), e.halfHeight.applyMatrix4(o), l++;
+			} else if (f.isPointLight) {
+				let e = r.point[s];
+				e.position.setFromMatrixPosition(f.matrixWorld), e.position.applyMatrix4(d), s++;
+			} else if (f.isHemisphereLight) {
+				let e = r.hemi[u];
+				e.direction.setFromMatrixPosition(f.matrixWorld), e.direction.transformDirection(d), u++;
+			}
+		}
+	}
+	return {
+		setup: s,
+		setupView: c,
+		state: r
+	};
+}
+function $o(e) {
+	let t = new Qo(e), n = [], r = [], i = [];
+	function a(e) {
+		d.camera = e, n.length = 0, r.length = 0, i.length = 0;
+	}
+	function o(e) {
+		n.push(e);
+	}
+	function s(e) {
+		r.push(e);
+	}
+	function c(e) {
+		i.push(e);
+	}
+	function l() {
+		t.setup(n);
+	}
+	function u(e) {
+		t.setupView(n, e);
+	}
+	let d = {
+		lightsArray: n,
+		shadowsArray: r,
+		lightProbeGridArray: i,
+		camera: null,
+		lights: t,
+		transmissionRenderTarget: {},
+		textureUnits: 0
+	};
+	return {
+		init: a,
+		state: d,
+		setupLights: l,
+		setupLightsView: u,
+		pushLight: o,
+		pushShadow: s,
+		pushLightProbeGrid: c
+	};
+}
+function es(e) {
+	let t = /* @__PURE__ */ new WeakMap();
+	function n(n, r = 0) {
+		let i = t.get(n), a;
+		return i === void 0 ? (a = new $o(e), t.set(n, [a])) : r >= i.length ? (a = new $o(e), i.push(a)) : a = i[r], a;
+	}
+	function r() {
+		t = /* @__PURE__ */ new WeakMap();
+	}
+	return {
+		get: n,
+		dispose: r
+	};
+}
+var ts = "void main() {\n	gl_Position = vec4( position, 1.0 );\n}", ns = "uniform sampler2D shadow_pass;\nuniform vec2 resolution;\nuniform float radius;\nvoid main() {\n	const float samples = float( VSM_SAMPLES );\n	float mean = 0.0;\n	float squared_mean = 0.0;\n	float uvStride = samples <= 1.0 ? 0.0 : 2.0 / ( samples - 1.0 );\n	float uvStart = samples <= 1.0 ? 0.0 : - 1.0;\n	for ( float i = 0.0; i < samples; i ++ ) {\n		float uvOffset = uvStart + i * uvStride;\n		#ifdef HORIZONTAL_PASS\n			vec2 distribution = texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( uvOffset, 0.0 ) * radius ) / resolution ).rg;\n			mean += distribution.x;\n			squared_mean += distribution.y * distribution.y + distribution.x * distribution.x;\n		#else\n			float depth = texture2D( shadow_pass, ( gl_FragCoord.xy + vec2( 0.0, uvOffset ) * radius ) / resolution ).r;\n			mean += depth;\n			squared_mean += depth * depth;\n		#endif\n	}\n	mean = mean / samples;\n	squared_mean = squared_mean / samples;\n	float std_dev = sqrt( max( 0.0, squared_mean - mean * mean ) );\n	gl_FragColor = vec4( mean, std_dev, 0.0, 1.0 );\n}", rs = [
+	/*@__PURE__*/ new W(1, 0, 0),
+	/*@__PURE__*/ new W(-1, 0, 0),
+	/*@__PURE__*/ new W(0, 1, 0),
+	/*@__PURE__*/ new W(0, -1, 0),
+	/*@__PURE__*/ new W(0, 0, 1),
+	/*@__PURE__*/ new W(0, 0, -1)
+], is = [
+	/*@__PURE__*/ new W(0, -1, 0),
+	/*@__PURE__*/ new W(0, -1, 0),
+	/*@__PURE__*/ new W(0, 0, 1),
+	/*@__PURE__*/ new W(0, 0, -1),
+	/*@__PURE__*/ new W(0, -1, 0),
+	/*@__PURE__*/ new W(0, -1, 0)
+], as = /*@__PURE__*/ new Fe(), os = /*@__PURE__*/ new W(), ss = /*@__PURE__*/ new W();
+function cs(e, t, n) {
+	let a = new Qn(), o = new U(), s = new U(), d = new je(), f = new gr(), p = new _r(), m = {}, g = n.maxTextureSize, _ = {
+		0: 1,
+		1: 0,
+		2: 2
+	}, v = new mr({
+		defines: { VSM_SAMPLES: 8 },
+		uniforms: {
+			shadow_pass: { value: null },
+			resolution: { value: new U() },
+			radius: { value: 4 }
+		},
+		vertexShader: ts,
+		fragmentShader: ns
+	}), b = v.clone();
+	b.defines.HORIZONTAL_PASS = 1;
+	let x = new ln();
+	x.setAttribute("position", new qt(new Float32Array([
+		-1,
+		-1,
+		.5,
+		3,
+		-1,
+		.5,
+		-1,
+		3,
+		.5
+	]), 3));
+	let S = new Mn(x, v), C = this;
+	this.enabled = !1, this.autoUpdate = !0, this.needsUpdate = !1, this.type = 1;
+	let w = this.type;
+	this.render = function(t, n, f) {
+		if (C.enabled === !1 || C.autoUpdate === !1 && C.needsUpdate === !1 || t.length === 0) return;
+		this.type === 2 && (F("WebGLShadowMap: PCFSoftShadowMap has been deprecated. Using PCFShadowMap instead."), this.type = 1);
+		let p = e.getRenderTarget(), m = e.getActiveCubeFace(), _ = e.getActiveMipmapLevel(), v = e.state;
+		v.setBlending(0), v.buffers.depth.getReversed() === !0 ? v.buffers.color.setClear(0, 0, 0, 0) : v.buffers.color.setClear(1, 1, 1, 1), v.buffers.depth.setTest(!0), v.setScissorTest(!1);
+		let b = w !== this.type;
+		b && n.traverse(function(e) {
+			e.material && (Array.isArray(e.material) ? e.material.forEach((e) => e.needsUpdate = !0) : e.material.needsUpdate = !0);
+		});
+		for (let p = 0, m = t.length; p < m; p++) {
+			let m = t[p], _ = m.shadow;
+			if (_ === void 0) {
+				F("WebGLShadowMap:", m, "has no shadow.");
+				continue;
+			}
+			if (_.autoUpdate === !1 && _.needsUpdate === !1) continue;
+			o.copy(_.mapSize);
+			let x = _.getFrameExtents();
+			o.multiply(x), s.copy(_.mapSize), (o.x > g || o.y > g) && (o.x > g && (s.x = Math.floor(g / x.x), o.x = s.x * x.x, _.mapSize.x = s.x), o.y > g && (s.y = Math.floor(g / x.y), o.y = s.y * x.y, _.mapSize.y = s.y));
+			let S = e.state.buffers.depth.getReversed();
+			if (_.camera._reversedDepth = S, _.map === null || b === !0) {
+				if (_.map !== null && (_.map.depthTexture !== null && (_.map.depthTexture.dispose(), _.map.depthTexture = null), _.map.dispose()), this.type === 3) {
+					if (m.isPointLight) {
+						F("WebGLShadowMap: VSM shadow maps are not supported for PointLights. Use PCF or BasicShadowMap instead.");
+						continue;
+					}
+					_.map = new Me(o.x, o.y, {
+						format: y,
+						type: u,
+						minFilter: i,
+						magFilter: i,
+						generateMipmaps: !1
+					}), _.map.texture.name = m.name + ".shadowMap", _.map.depthTexture = new er(o.x, o.y, l), _.map.depthTexture.name = m.name + ".shadowMapDepth", _.map.depthTexture.format = h, _.map.depthTexture.compareFunction = null, _.map.depthTexture.minFilter = r, _.map.depthTexture.magFilter = r;
+				} else m.isPointLight ? (_.map = new Ri(o.x), _.map.depthTexture = new tr(o.x, c)) : (_.map = new Me(o.x, o.y), _.map.depthTexture = new er(o.x, o.y, c)), _.map.depthTexture.name = m.name + ".shadowMap", _.map.depthTexture.format = h, this.type === 1 ? (_.map.depthTexture.compareFunction = S ? 518 : 515, _.map.depthTexture.minFilter = i, _.map.depthTexture.magFilter = i) : (_.map.depthTexture.compareFunction = null, _.map.depthTexture.minFilter = r, _.map.depthTexture.magFilter = r);
+				_.camera.updateProjectionMatrix();
+			}
+			let C = _.map.isWebGLCubeRenderTarget ? 6 : 1;
+			for (let t = 0; t < C; t++) {
+				if (_.map.isWebGLCubeRenderTarget) e.setRenderTarget(_.map, t), e.clear();
+				else {
+					t === 0 && (e.setRenderTarget(_.map), e.clear());
+					let n = _.getViewport(t);
+					d.set(s.x * n.x, s.y * n.y, s.x * n.z, s.y * n.w), v.viewport(d);
+				}
+				if (m.isPointLight) {
+					let e = _.camera, n = _.matrix, r = m.distance || e.far;
+					r !== e.far && (e.far = r, e.updateProjectionMatrix()), os.setFromMatrixPosition(m.matrixWorld), e.position.copy(os), ss.copy(e.position), ss.add(rs[t]), e.up.copy(is[t]), e.lookAt(ss), e.updateMatrixWorld(), n.makeTranslation(-os.x, -os.y, -os.z), as.multiplyMatrices(e.projectionMatrix, e.matrixWorldInverse), _._frustum.setFromProjectionMatrix(as, e.coordinateSystem, e.reversedDepth);
+				} else _.updateMatrices(m);
+				a = _.getFrustum(), D(n, f, _.camera, m, this.type);
+			}
+			_.isPointLightShadow !== !0 && this.type === 3 && T(_, f), _.needsUpdate = !1;
+		}
+		w = this.type, C.needsUpdate = !1, e.setRenderTarget(p, m, _);
+	};
+	function T(n, r) {
+		let i = t.update(S);
+		v.defines.VSM_SAMPLES !== n.blurSamples && (v.defines.VSM_SAMPLES = n.blurSamples, b.defines.VSM_SAMPLES = n.blurSamples, v.needsUpdate = !0, b.needsUpdate = !0), n.mapPass === null && (n.mapPass = new Me(o.x, o.y, {
+			format: y,
+			type: u
+		})), v.uniforms.shadow_pass.value = n.map.depthTexture, v.uniforms.resolution.value = n.mapSize, v.uniforms.radius.value = n.radius, e.setRenderTarget(n.mapPass), e.clear(), e.renderBufferDirect(r, null, i, v, S, null), b.uniforms.shadow_pass.value = n.mapPass.texture, b.uniforms.resolution.value = n.mapSize, b.uniforms.radius.value = n.radius, e.setRenderTarget(n.map), e.clear(), e.renderBufferDirect(r, null, i, b, S, null);
+	}
+	function E(t, n, r, i) {
+		let a = null, o = r.isPointLight === !0 ? t.customDistanceMaterial : t.customDepthMaterial;
+		if (o !== void 0) a = o;
+		else if (a = r.isPointLight === !0 ? p : f, e.localClippingEnabled && n.clipShadows === !0 && Array.isArray(n.clippingPlanes) && n.clippingPlanes.length !== 0 || n.displacementMap && n.displacementScale !== 0 || n.alphaMap && n.alphaTest > 0 || n.map && n.alphaTest > 0 || n.alphaToCoverage === !0) {
+			let e = a.uuid, t = n.uuid, r = m[e];
+			r === void 0 && (r = {}, m[e] = r);
+			let i = r[t];
+			i === void 0 && (i = a.clone(), r[t] = i, n.addEventListener("dispose", O)), a = i;
+		}
+		if (a.visible = n.visible, a.wireframe = n.wireframe, i === 3 ? a.side = n.shadowSide === null ? n.side : n.shadowSide : a.side = n.shadowSide === null ? _[n.side] : n.shadowSide, a.alphaMap = n.alphaMap, a.alphaTest = n.alphaToCoverage === !0 ? .5 : n.alphaTest, a.map = n.map, a.clipShadows = n.clipShadows, a.clippingPlanes = n.clippingPlanes, a.clipIntersection = n.clipIntersection, a.displacementMap = n.displacementMap, a.displacementScale = n.displacementScale, a.displacementBias = n.displacementBias, a.wireframeLinewidth = n.wireframeLinewidth, a.linewidth = n.linewidth, r.isPointLight === !0 && a.isMeshDistanceMaterial === !0) {
+			let t = e.properties.get(a);
+			t.light = r;
+		}
+		return a;
+	}
+	function D(n, r, i, o, s) {
+		if (n.visible === !1) return;
+		if (n.layers.test(r.layers) && (n.isMesh || n.isLine || n.isPoints) && (n.castShadow || n.receiveShadow && s === 3) && (!n.frustumCulled || a.intersectsObject(n))) {
+			n.modelViewMatrix.multiplyMatrices(i.matrixWorldInverse, n.matrixWorld);
+			let a = t.update(n), c = n.material;
+			if (Array.isArray(c)) {
+				let t = a.groups;
+				for (let l = 0, u = t.length; l < u; l++) {
+					let u = t[l], d = c[u.materialIndex];
+					if (d && d.visible) {
+						let t = E(n, d, o, s);
+						n.onBeforeShadow(e, n, r, i, a, t, u), e.renderBufferDirect(i, null, a, t, n, u), n.onAfterShadow(e, n, r, i, a, t, u);
+					}
+				}
+			} else if (c.visible) {
+				let t = E(n, c, o, s);
+				n.onBeforeShadow(e, n, r, i, a, t, null), e.renderBufferDirect(i, null, a, t, n, null), n.onAfterShadow(e, n, r, i, a, t, null);
+			}
+		}
+		let c = n.children;
+		for (let e = 0, t = c.length; e < t; e++) D(c[e], r, i, o, s);
+	}
+	function O(e) {
+		e.target.removeEventListener("dispose", O);
+		for (let t in m) {
+			let n = m[t], r = e.target.uuid;
+			r in n && (n[r].dispose(), delete n[r]);
+		}
+	}
+}
+function ls(e, t) {
+	function n() {
+		let t = !1, n = new je(), r = null, i = new je(0, 0, 0, 0);
+		return {
+			setMask: function(n) {
+				r !== n && !t && (e.colorMask(n, n, n, n), r = n);
+			},
+			setLocked: function(e) {
+				t = e;
+			},
+			setClear: function(t, r, a, o, s) {
+				s === !0 && (t *= o, r *= o, a *= o), n.set(t, r, a, o), i.equals(n) === !1 && (e.clearColor(t, r, a, o), i.copy(n));
+			},
+			reset: function() {
+				t = !1, r = null, i.set(-1, 0, 0, 0);
+			}
+		};
+	}
+	function r() {
+		let n = !1, r = !1, i = null, a = null, o = null;
+		return {
+			setReversed: function(e) {
+				if (r !== e) {
+					let n = t.get("EXT_clip_control");
+					e ? n.clipControlEXT(n.LOWER_LEFT_EXT, n.ZERO_TO_ONE_EXT) : n.clipControlEXT(n.LOWER_LEFT_EXT, n.NEGATIVE_ONE_TO_ONE_EXT), r = e;
+					let i = o;
+					o = null, this.setClear(i);
+				}
+			},
+			getReversed: function() {
+				return r;
+			},
+			setTest: function(t) {
+				t ? se(e.DEPTH_TEST) : R(e.DEPTH_TEST);
+			},
+			setMask: function(t) {
+				i !== t && !n && (e.depthMask(t), i = t);
+			},
+			setFunc: function(t) {
+				if (r && (t = ce[t]), a !== t) {
+					switch (t) {
+						case 0:
+							e.depthFunc(e.NEVER);
+							break;
+						case 1:
+							e.depthFunc(e.ALWAYS);
+							break;
+						case 2:
+							e.depthFunc(e.LESS);
+							break;
+						case 3:
+							e.depthFunc(e.LEQUAL);
+							break;
+						case 4:
+							e.depthFunc(e.EQUAL);
+							break;
+						case 5:
+							e.depthFunc(e.GEQUAL);
+							break;
+						case 6:
+							e.depthFunc(e.GREATER);
+							break;
+						case 7:
+							e.depthFunc(e.NOTEQUAL);
+							break;
+						default: e.depthFunc(e.LEQUAL);
+					}
+					a = t;
+				}
+			},
+			setLocked: function(e) {
+				n = e;
+			},
+			setClear: function(t) {
+				o !== t && (o = t, r && (t = 1 - t), e.clearDepth(t));
+			},
+			reset: function() {
+				n = !1, i = null, a = null, o = null, r = !1;
+			}
+		};
+	}
+	function i() {
+		let t = !1, n = null, r = null, i = null, a = null, o = null, s = null, c = null, l = null;
+		return {
+			setTest: function(n) {
+				t || (n ? se(e.STENCIL_TEST) : R(e.STENCIL_TEST));
+			},
+			setMask: function(r) {
+				n !== r && !t && (e.stencilMask(r), n = r);
+			},
+			setFunc: function(t, n, o) {
+				(r !== t || i !== n || a !== o) && (e.stencilFunc(t, n, o), r = t, i = n, a = o);
+			},
+			setOp: function(t, n, r) {
+				(o !== t || s !== n || c !== r) && (e.stencilOp(t, n, r), o = t, s = n, c = r);
+			},
+			setLocked: function(e) {
+				t = e;
+			},
+			setClear: function(t) {
+				l !== t && (e.clearStencil(t), l = t);
+			},
+			reset: function() {
+				t = !1, n = null, r = null, i = null, a = null, o = null, s = null, c = null, l = null;
+			}
+		};
+	}
+	let a = new n(), o = new r(), s = new i(), c = /* @__PURE__ */ new WeakMap(), l = /* @__PURE__ */ new WeakMap(), u = {}, d = {}, f = {}, p = /* @__PURE__ */ new WeakMap(), m = [], h = null, g = !1, _ = null, v = null, y = null, b = null, x = null, S = null, C = null, w = new Z(0, 0, 0), T = 0, E = !1, D = null, O = null, k = null, A = null, ee = null, j = e.getParameter(e.MAX_COMBINED_TEXTURE_IMAGE_UNITS), M = !1, te = 0, ne = e.getParameter(e.VERSION);
+	ne.indexOf("WebGL") === -1 ? ne.indexOf("OpenGL ES") !== -1 && (te = parseFloat(/^OpenGL ES (\d)/.exec(ne)[1]), M = te >= 2) : (te = parseFloat(/^WebGL (\d)/.exec(ne)[1]), M = te >= 1);
+	let N = null, re = {}, ie = e.getParameter(e.SCISSOR_BOX), P = e.getParameter(e.VIEWPORT), ae = new je().fromArray(ie), oe = new je().fromArray(P);
+	function F(t, n, r, i) {
+		let a = /* @__PURE__ */ new Uint8Array(4), o = e.createTexture();
+		e.bindTexture(t, o), e.texParameteri(t, e.TEXTURE_MIN_FILTER, e.NEAREST), e.texParameteri(t, e.TEXTURE_MAG_FILTER, e.NEAREST);
+		for (let o = 0; o < r; o++) t === e.TEXTURE_3D || t === e.TEXTURE_2D_ARRAY ? e.texImage3D(n, 0, e.RGBA, 1, 1, i, 0, e.RGBA, e.UNSIGNED_BYTE, a) : e.texImage2D(n + o, 0, e.RGBA, 1, 1, 0, e.RGBA, e.UNSIGNED_BYTE, a);
+		return o;
+	}
+	let L = {};
+	L[e.TEXTURE_2D] = F(e.TEXTURE_2D, e.TEXTURE_2D, 1), L[e.TEXTURE_CUBE_MAP] = F(e.TEXTURE_CUBE_MAP, e.TEXTURE_CUBE_MAP_POSITIVE_X, 6), L[e.TEXTURE_2D_ARRAY] = F(e.TEXTURE_2D_ARRAY, e.TEXTURE_2D_ARRAY, 1, 1), L[e.TEXTURE_3D] = F(e.TEXTURE_3D, e.TEXTURE_3D, 1, 1), a.setClear(0, 0, 0, 1), o.setClear(1), s.setClear(0), se(e.DEPTH_TEST), o.setFunc(3), pe(!1), H(1), se(e.CULL_FACE), de(0);
+	function se(t) {
+		u[t] !== !0 && (e.enable(t), u[t] = !0);
+	}
+	function R(t) {
+		u[t] !== !1 && (e.disable(t), u[t] = !1);
+	}
+	function z(t, n) {
+		return f[t] === n ? !1 : (e.bindFramebuffer(t, n), f[t] = n, t === e.DRAW_FRAMEBUFFER && (f[e.FRAMEBUFFER] = n), t === e.FRAMEBUFFER && (f[e.DRAW_FRAMEBUFFER] = n), !0);
+	}
+	function le(t, n) {
+		let r = m, i = !1;
+		if (t) {
+			r = p.get(n), r === void 0 && (r = [], p.set(n, r));
+			let a = t.textures;
+			if (r.length !== a.length || r[0] !== e.COLOR_ATTACHMENT0) {
+				for (let t = 0, n = a.length; t < n; t++) r[t] = e.COLOR_ATTACHMENT0 + t;
+				r.length = a.length, i = !0;
+			}
+		} else r[0] !== e.BACK && (r[0] = e.BACK, i = !0);
+		i && e.drawBuffers(r);
+	}
+	function ue(t) {
+		return h === t ? !1 : (e.useProgram(t), h = t, !0);
+	}
+	let B = {
+		100: e.FUNC_ADD,
+		101: e.FUNC_SUBTRACT,
+		102: e.FUNC_REVERSE_SUBTRACT
+	};
+	B[103] = e.MIN, B[104] = e.MAX;
+	let V = {
+		200: e.ZERO,
+		201: e.ONE,
+		202: e.SRC_COLOR,
+		204: e.SRC_ALPHA,
+		210: e.SRC_ALPHA_SATURATE,
+		208: e.DST_COLOR,
+		206: e.DST_ALPHA,
+		203: e.ONE_MINUS_SRC_COLOR,
+		205: e.ONE_MINUS_SRC_ALPHA,
+		209: e.ONE_MINUS_DST_COLOR,
+		207: e.ONE_MINUS_DST_ALPHA,
+		211: e.CONSTANT_COLOR,
+		212: e.ONE_MINUS_CONSTANT_COLOR,
+		213: e.CONSTANT_ALPHA,
+		214: e.ONE_MINUS_CONSTANT_ALPHA
+	};
+	function de(t, n, r, i, a, o, s, c, l, u) {
+		if (t === 0) {
+			g === !0 && (R(e.BLEND), g = !1);
+			return;
+		}
+		if (g === !1 && (se(e.BLEND), g = !0), t !== 5) {
+			if (t !== _ || u !== E) {
+				if ((v !== 100 || x !== 100) && (e.blendEquation(e.FUNC_ADD), v = 100, x = 100), u) switch (t) {
+					case 1:
+						e.blendFuncSeparate(e.ONE, e.ONE_MINUS_SRC_ALPHA, e.ONE, e.ONE_MINUS_SRC_ALPHA);
+						break;
+					case 2:
+						e.blendFunc(e.ONE, e.ONE);
+						break;
+					case 3:
+						e.blendFuncSeparate(e.ZERO, e.ONE_MINUS_SRC_COLOR, e.ZERO, e.ONE);
+						break;
+					case 4:
+						e.blendFuncSeparate(e.DST_COLOR, e.ONE_MINUS_SRC_ALPHA, e.ZERO, e.ONE);
+						break;
+					default:
+						I("WebGLState: Invalid blending: ", t);
+						break;
+				}
+				else switch (t) {
+					case 1:
+						e.blendFuncSeparate(e.SRC_ALPHA, e.ONE_MINUS_SRC_ALPHA, e.ONE, e.ONE_MINUS_SRC_ALPHA);
+						break;
+					case 2:
+						e.blendFuncSeparate(e.SRC_ALPHA, e.ONE, e.ONE, e.ONE);
+						break;
+					case 3:
+						I("WebGLState: SubtractiveBlending requires material.premultipliedAlpha = true");
+						break;
+					case 4:
+						I("WebGLState: MultiplyBlending requires material.premultipliedAlpha = true");
+						break;
+					default:
+						I("WebGLState: Invalid blending: ", t);
+						break;
+				}
+				y = null, b = null, S = null, C = null, w.set(0, 0, 0), T = 0, _ = t, E = u;
+			}
+			return;
+		}
+		a ||= n, o ||= r, s ||= i, (n !== v || a !== x) && (e.blendEquationSeparate(B[n], B[a]), v = n, x = a), (r !== y || i !== b || o !== S || s !== C) && (e.blendFuncSeparate(V[r], V[i], V[o], V[s]), y = r, b = i, S = o, C = s), (c.equals(w) === !1 || l !== T) && (e.blendColor(c.r, c.g, c.b, l), w.copy(c), T = l), _ = t, E = !1;
+	}
+	function fe(t, n) {
+		t.side === 2 ? R(e.CULL_FACE) : se(e.CULL_FACE);
+		let r = t.side === 1;
+		n && (r = !r), pe(r), t.blending === 1 && t.transparent === !1 ? de(0) : de(t.blending, t.blendEquation, t.blendSrc, t.blendDst, t.blendEquationAlpha, t.blendSrcAlpha, t.blendDstAlpha, t.blendColor, t.blendAlpha, t.premultipliedAlpha), o.setFunc(t.depthFunc), o.setTest(t.depthTest), o.setMask(t.depthWrite), a.setMask(t.colorWrite);
+		let i = t.stencilWrite;
+		s.setTest(i), i && (s.setMask(t.stencilWriteMask), s.setFunc(t.stencilFunc, t.stencilRef, t.stencilFuncMask), s.setOp(t.stencilFail, t.stencilZFail, t.stencilZPass)), me(t.polygonOffset, t.polygonOffsetFactor, t.polygonOffsetUnits), t.alphaToCoverage === !0 ? se(e.SAMPLE_ALPHA_TO_COVERAGE) : R(e.SAMPLE_ALPHA_TO_COVERAGE);
+	}
+	function pe(t) {
+		D !== t && (t ? e.frontFace(e.CW) : e.frontFace(e.CCW), D = t);
+	}
+	function H(t) {
+		t === 0 ? R(e.CULL_FACE) : (se(e.CULL_FACE), t !== O && (t === 1 ? e.cullFace(e.BACK) : t === 2 ? e.cullFace(e.FRONT) : e.cullFace(e.FRONT_AND_BACK))), O = t;
+	}
+	function U(t) {
+		t !== k && (M && e.lineWidth(t), k = t);
+	}
+	function me(t, n, r) {
+		t ? (se(e.POLYGON_OFFSET_FILL), (A !== n || ee !== r) && (A = n, ee = r, o.getReversed() && (n = -n), e.polygonOffset(n, r))) : R(e.POLYGON_OFFSET_FILL);
+	}
+	function W(t) {
+		t ? se(e.SCISSOR_TEST) : R(e.SCISSOR_TEST);
+	}
+	function he(t) {
+		t === void 0 && (t = e.TEXTURE0 + j - 1), N !== t && (e.activeTexture(t), N = t);
+	}
+	function ge(t, n, r) {
+		r === void 0 && (r = N === null ? e.TEXTURE0 + j - 1 : N);
+		let i = re[r];
+		i === void 0 && (i = {
+			type: void 0,
+			texture: void 0
+		}, re[r] = i), (i.type !== t || i.texture !== n) && (N !== r && (e.activeTexture(r), N = r), e.bindTexture(t, n || L[t]), i.type = t, i.texture = n);
+	}
+	function G() {
+		let t = re[N];
+		t !== void 0 && t.type !== void 0 && (e.bindTexture(t.type, null), t.type = void 0, t.texture = void 0);
+	}
+	function _e() {
+		try {
+			e.compressedTexImage2D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function ve() {
+		try {
+			e.compressedTexImage3D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function ye() {
+		try {
+			e.texSubImage2D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function be() {
+		try {
+			e.texSubImage3D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function K() {
+		try {
+			e.compressedTexSubImage2D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function xe() {
+		try {
+			e.compressedTexSubImage3D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function Se() {
+		try {
+			e.texStorage2D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function Ce() {
+		try {
+			e.texStorage3D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function we() {
+		try {
+			e.texImage2D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function Te() {
+		try {
+			e.texImage3D(...arguments);
+		} catch (e) {
+			I("WebGLState:", e);
+		}
+	}
+	function Ee(t) {
+		return d[t] === void 0 ? e.getParameter(t) : d[t];
+	}
+	function De(t, n) {
+		d[t] !== n && (e.pixelStorei(t, n), d[t] = n);
+	}
+	function Oe(t) {
+		ae.equals(t) === !1 && (e.scissor(t.x, t.y, t.z, t.w), ae.copy(t));
+	}
+	function ke(t) {
+		oe.equals(t) === !1 && (e.viewport(t.x, t.y, t.z, t.w), oe.copy(t));
+	}
+	function Ae(t, n) {
+		let r = l.get(n);
+		r === void 0 && (r = /* @__PURE__ */ new WeakMap(), l.set(n, r));
+		let i = r.get(t);
+		i === void 0 && (i = e.getUniformBlockIndex(n, t.name), r.set(t, i));
+	}
+	function q(t, n) {
+		let r = l.get(n).get(t);
+		c.get(n) !== r && (e.uniformBlockBinding(n, r, t.__bindingPointIndex), c.set(n, r));
+	}
+	function Me() {
+		e.disable(e.BLEND), e.disable(e.CULL_FACE), e.disable(e.DEPTH_TEST), e.disable(e.POLYGON_OFFSET_FILL), e.disable(e.SCISSOR_TEST), e.disable(e.STENCIL_TEST), e.disable(e.SAMPLE_ALPHA_TO_COVERAGE), e.blendEquation(e.FUNC_ADD), e.blendFunc(e.ONE, e.ZERO), e.blendFuncSeparate(e.ONE, e.ZERO, e.ONE, e.ZERO), e.blendColor(0, 0, 0, 0), e.colorMask(!0, !0, !0, !0), e.clearColor(0, 0, 0, 0), e.depthMask(!0), e.depthFunc(e.LESS), o.setReversed(!1), e.clearDepth(1), e.stencilMask(4294967295), e.stencilFunc(e.ALWAYS, 0, 4294967295), e.stencilOp(e.KEEP, e.KEEP, e.KEEP), e.clearStencil(0), e.cullFace(e.BACK), e.frontFace(e.CCW), e.polygonOffset(0, 0), e.activeTexture(e.TEXTURE0), e.bindFramebuffer(e.FRAMEBUFFER, null), e.bindFramebuffer(e.DRAW_FRAMEBUFFER, null), e.bindFramebuffer(e.READ_FRAMEBUFFER, null), e.useProgram(null), e.lineWidth(1), e.scissor(0, 0, e.canvas.width, e.canvas.height), e.viewport(0, 0, e.canvas.width, e.canvas.height), e.pixelStorei(e.PACK_ALIGNMENT, 4), e.pixelStorei(e.UNPACK_ALIGNMENT, 4), e.pixelStorei(e.UNPACK_FLIP_Y_WEBGL, !1), e.pixelStorei(e.UNPACK_PREMULTIPLY_ALPHA_WEBGL, !1), e.pixelStorei(e.UNPACK_COLORSPACE_CONVERSION_WEBGL, e.BROWSER_DEFAULT_WEBGL), e.pixelStorei(e.PACK_ROW_LENGTH, 0), e.pixelStorei(e.PACK_SKIP_PIXELS, 0), e.pixelStorei(e.PACK_SKIP_ROWS, 0), e.pixelStorei(e.UNPACK_ROW_LENGTH, 0), e.pixelStorei(e.UNPACK_IMAGE_HEIGHT, 0), e.pixelStorei(e.UNPACK_SKIP_PIXELS, 0), e.pixelStorei(e.UNPACK_SKIP_ROWS, 0), e.pixelStorei(e.UNPACK_SKIP_IMAGES, 0), u = {}, d = {}, N = null, re = {}, f = {}, p = /* @__PURE__ */ new WeakMap(), m = [], h = null, g = !1, _ = null, v = null, y = null, b = null, x = null, S = null, C = null, w = new Z(0, 0, 0), T = 0, E = !1, D = null, O = null, k = null, A = null, ee = null, ae.set(0, 0, e.canvas.width, e.canvas.height), oe.set(0, 0, e.canvas.width, e.canvas.height), a.reset(), o.reset(), s.reset();
+	}
+	return {
+		buffers: {
+			color: a,
+			depth: o,
+			stencil: s
+		},
+		enable: se,
+		disable: R,
+		bindFramebuffer: z,
+		drawBuffers: le,
+		useProgram: ue,
+		setBlending: de,
+		setMaterial: fe,
+		setFlipSided: pe,
+		setCullFace: H,
+		setLineWidth: U,
+		setPolygonOffset: me,
+		setScissorTest: W,
+		activeTexture: he,
+		bindTexture: ge,
+		unbindTexture: G,
+		compressedTexImage2D: _e,
+		compressedTexImage3D: ve,
+		texImage2D: we,
+		texImage3D: Te,
+		pixelStorei: De,
+		getParameter: Ee,
+		updateUBOMapping: Ae,
+		uniformBlockBinding: q,
+		texStorage2D: Se,
+		texStorage3D: Ce,
+		texSubImage2D: ye,
+		texSubImage3D: be,
+		compressedTexSubImage2D: K,
+		compressedTexSubImage3D: xe,
+		scissor: Oe,
+		viewport: ke,
+		reset: Me
+	};
+}
+function us(o, s, c, l, u, d, f) {
+	let p = s.has("WEBGL_multisampled_render_to_texture") ? s.get("WEBGL_multisampled_render_to_texture") : null, m = typeof navigator > "u" ? !1 : /OculusBrowser/g.test(navigator.userAgent), h = new U(), _ = /* @__PURE__ */ new WeakMap(), v = /* @__PURE__ */ new Set(), y, b = /* @__PURE__ */ new WeakMap(), x = !1;
+	try {
+		x = typeof OffscreenCanvas < "u" && new OffscreenCanvas(1, 1).getContext("2d") !== null;
+	} catch {}
+	function S(e, t) {
+		return x ? new OffscreenCanvas(e, t) : re("canvas");
+	}
+	function C(e, t, n) {
+		let r = 1, i = De(e);
+		if ((i.width > n || i.height > n) && (r = n / Math.max(i.width, i.height)), r < 1) if (typeof HTMLImageElement < "u" && e instanceof HTMLImageElement || typeof HTMLCanvasElement < "u" && e instanceof HTMLCanvasElement || typeof ImageBitmap < "u" && e instanceof ImageBitmap || typeof VideoFrame < "u" && e instanceof VideoFrame) {
+			let n = Math.floor(r * i.width), a = Math.floor(r * i.height);
+			y === void 0 && (y = S(n, a));
+			let o = t ? S(n, a) : y;
+			return o.width = n, o.height = a, o.getContext("2d").drawImage(e, 0, 0, n, a), F("WebGLRenderer: Texture has been resized from (" + i.width + "x" + i.height + ") to (" + n + "x" + a + ")."), o;
+		} else return "data" in e && F("WebGLRenderer: Image in DataTexture is too big (" + i.width + "x" + i.height + ")."), e;
+		return e;
+	}
+	function w(e) {
+		return e.generateMipmaps;
+	}
+	function T(e) {
+		o.generateMipmap(e);
+	}
+	function E(e) {
+		return e.isWebGLCubeRenderTarget ? o.TEXTURE_CUBE_MAP : e.isWebGL3DRenderTarget ? o.TEXTURE_3D : e.isWebGLArrayRenderTarget || e.isCompressedArrayTexture ? o.TEXTURE_2D_ARRAY : o.TEXTURE_2D;
+	}
+	function D(e, t, n, r, i, a = !1) {
+		if (e !== null) {
+			if (o[e] !== void 0) return o[e];
+			F("WebGLRenderer: Attempt to use non-existing WebGL internal format '" + e + "'");
+		}
+		let c;
+		r && (c = s.get("EXT_texture_norm16"), c || F("WebGLRenderer: Unable to use normalized textures without EXT_texture_norm16 extension"));
+		let l = t;
+		if (t === o.RED && (n === o.FLOAT && (l = o.R32F), n === o.HALF_FLOAT && (l = o.R16F), n === o.UNSIGNED_BYTE && (l = o.R8), n === o.UNSIGNED_SHORT && c && (l = c.R16_EXT), n === o.SHORT && c && (l = c.R16_SNORM_EXT)), t === o.RED_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.R8UI), n === o.UNSIGNED_SHORT && (l = o.R16UI), n === o.UNSIGNED_INT && (l = o.R32UI), n === o.BYTE && (l = o.R8I), n === o.SHORT && (l = o.R16I), n === o.INT && (l = o.R32I)), t === o.RG && (n === o.FLOAT && (l = o.RG32F), n === o.HALF_FLOAT && (l = o.RG16F), n === o.UNSIGNED_BYTE && (l = o.RG8), n === o.UNSIGNED_SHORT && c && (l = c.RG16_EXT), n === o.SHORT && c && (l = c.RG16_SNORM_EXT)), t === o.RG_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.RG8UI), n === o.UNSIGNED_SHORT && (l = o.RG16UI), n === o.UNSIGNED_INT && (l = o.RG32UI), n === o.BYTE && (l = o.RG8I), n === o.SHORT && (l = o.RG16I), n === o.INT && (l = o.RG32I)), t === o.RGB_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.RGB8UI), n === o.UNSIGNED_SHORT && (l = o.RGB16UI), n === o.UNSIGNED_INT && (l = o.RGB32UI), n === o.BYTE && (l = o.RGB8I), n === o.SHORT && (l = o.RGB16I), n === o.INT && (l = o.RGB32I)), t === o.RGBA_INTEGER && (n === o.UNSIGNED_BYTE && (l = o.RGBA8UI), n === o.UNSIGNED_SHORT && (l = o.RGBA16UI), n === o.UNSIGNED_INT && (l = o.RGBA32UI), n === o.BYTE && (l = o.RGBA8I), n === o.SHORT && (l = o.RGBA16I), n === o.INT && (l = o.RGBA32I)), t === o.RGB && (n === o.UNSIGNED_SHORT && c && (l = c.RGB16_EXT), n === o.SHORT && c && (l = c.RGB16_SNORM_EXT), n === o.UNSIGNED_INT_5_9_9_9_REV && (l = o.RGB9_E5), n === o.UNSIGNED_INT_10F_11F_11F_REV && (l = o.R11F_G11F_B10F)), t === o.RGBA) {
+			let e = a ? ee : K.getTransfer(i);
+			n === o.FLOAT && (l = o.RGBA32F), n === o.HALF_FLOAT && (l = o.RGBA16F), n === o.UNSIGNED_BYTE && (l = e === "srgb" ? o.SRGB8_ALPHA8 : o.RGBA8), n === o.UNSIGNED_SHORT && c && (l = c.RGBA16_EXT), n === o.SHORT && c && (l = c.RGBA16_SNORM_EXT), n === o.UNSIGNED_SHORT_4_4_4_4 && (l = o.RGBA4), n === o.UNSIGNED_SHORT_5_5_5_1 && (l = o.RGB5_A1);
+		}
+		return (l === o.R16F || l === o.R32F || l === o.RG16F || l === o.RG32F || l === o.RGBA16F || l === o.RGBA32F) && s.get("EXT_color_buffer_float"), l;
+	}
+	function O(e, t) {
+		let n;
+		return e ? t === null || t === 1014 || t === 1020 ? n = o.DEPTH24_STENCIL8 : t === 1015 ? n = o.DEPTH32F_STENCIL8 : t === 1012 && (n = o.DEPTH24_STENCIL8, F("DepthTexture: 16 bit depth attachment is not supported with stencil. Using 24-bit attachment.")) : t === null || t === 1014 || t === 1020 ? n = o.DEPTH_COMPONENT24 : t === 1015 ? n = o.DEPTH_COMPONENT32F : t === 1012 && (n = o.DEPTH_COMPONENT16), n;
+	}
+	function k(e, t) {
+		return w(e) === !0 || e.isFramebufferTexture && e.minFilter !== 1003 && e.minFilter !== 1006 ? Math.log2(Math.max(t.width, t.height)) + 1 : e.mipmaps !== void 0 && e.mipmaps.length > 0 ? e.mipmaps.length : e.isCompressedTexture && Array.isArray(e.image) ? t.mipmaps.length : 1;
+	}
+	function A(e) {
+		let t = e.target;
+		t.removeEventListener("dispose", A), M(t), t.isVideoTexture && _.delete(t), t.isHTMLTexture && v.delete(t);
+	}
+	function j(e) {
+		let t = e.target;
+		t.removeEventListener("dispose", j), ne(t);
+	}
+	function M(e) {
+		let t = l.get(e);
+		if (t.__webglInit === void 0) return;
+		let n = e.source, r = b.get(n);
+		if (r) {
+			let i = r[t.__cacheKey];
+			i.usedTimes--, i.usedTimes === 0 && te(e), Object.keys(r).length === 0 && b.delete(n);
+		}
+		l.remove(e);
+	}
+	function te(e) {
+		let t = l.get(e);
+		o.deleteTexture(t.__webglTexture);
+		let n = e.source, r = b.get(n);
+		delete r[t.__cacheKey], f.memory.textures--;
+	}
+	function ne(e) {
+		let t = l.get(e);
+		if (e.depthTexture && (e.depthTexture.dispose(), l.remove(e.depthTexture)), e.isWebGLCubeRenderTarget) for (let e = 0; e < 6; e++) {
+			if (Array.isArray(t.__webglFramebuffer[e])) for (let n = 0; n < t.__webglFramebuffer[e].length; n++) o.deleteFramebuffer(t.__webglFramebuffer[e][n]);
+			else o.deleteFramebuffer(t.__webglFramebuffer[e]);
+			t.__webglDepthbuffer && o.deleteRenderbuffer(t.__webglDepthbuffer[e]);
+		}
+		else {
+			if (Array.isArray(t.__webglFramebuffer)) for (let e = 0; e < t.__webglFramebuffer.length; e++) o.deleteFramebuffer(t.__webglFramebuffer[e]);
+			else o.deleteFramebuffer(t.__webglFramebuffer);
+			if (t.__webglDepthbuffer && o.deleteRenderbuffer(t.__webglDepthbuffer), t.__webglMultisampledFramebuffer && o.deleteFramebuffer(t.__webglMultisampledFramebuffer), t.__webglColorRenderbuffer) for (let e = 0; e < t.__webglColorRenderbuffer.length; e++) t.__webglColorRenderbuffer[e] && o.deleteRenderbuffer(t.__webglColorRenderbuffer[e]);
+			t.__webglDepthRenderbuffer && o.deleteRenderbuffer(t.__webglDepthRenderbuffer);
+		}
+		let n = e.textures;
+		for (let e = 0, t = n.length; e < t; e++) {
+			let t = l.get(n[e]);
+			t.__webglTexture && (o.deleteTexture(t.__webglTexture), f.memory.textures--), l.remove(n[e]);
+		}
+		l.remove(e);
+	}
+	let N = 0;
+	function ie() {
+		N = 0;
+	}
+	function P() {
+		return N;
+	}
+	function ae(e) {
+		N = e;
+	}
+	function oe() {
+		let e = N;
+		return e >= u.maxTextures && F("WebGLTextures: Trying to use " + e + " texture units while this GPU supports only " + u.maxTextures), N += 1, e;
+	}
+	function L(e) {
+		let t = [];
+		return t.push(e.wrapS), t.push(e.wrapT), t.push(e.wrapR || 0), t.push(e.magFilter), t.push(e.minFilter), t.push(e.anisotropy), t.push(e.internalFormat), t.push(e.format), t.push(e.type), t.push(e.generateMipmaps), t.push(e.premultiplyAlpha), t.push(e.flipY), t.push(e.unpackAlignment), t.push(e.colorSpace), t.join();
+	}
+	function se(e, t) {
+		let n = l.get(e);
+		if (e.isVideoTexture && Te(e), e.isRenderTargetTexture === !1 && e.isExternalTexture !== !0 && e.version > 0 && n.__version !== e.version) {
+			let r = e.image;
+			if (r === null) F("WebGLRenderer: Texture marked for update but no image data found.");
+			else if (r.complete === !1) F("WebGLRenderer: Texture marked for update but image is incomplete");
+			else {
+				H(n, e, t);
+				return;
+			}
+		} else e.isExternalTexture && (n.__webglTexture = e.sourceTexture ? e.sourceTexture : null);
+		c.bindTexture(o.TEXTURE_2D, n.__webglTexture, o.TEXTURE0 + t);
+	}
+	function ce(e, t) {
+		let n = l.get(e);
+		if (e.isRenderTargetTexture === !1 && e.version > 0 && n.__version !== e.version) {
+			H(n, e, t);
+			return;
+		} else e.isExternalTexture && (n.__webglTexture = e.sourceTexture ? e.sourceTexture : null);
+		c.bindTexture(o.TEXTURE_2D_ARRAY, n.__webglTexture, o.TEXTURE0 + t);
+	}
+	function R(e, t) {
+		let n = l.get(e);
+		if (e.isRenderTargetTexture === !1 && e.version > 0 && n.__version !== e.version) {
+			H(n, e, t);
+			return;
+		}
+		c.bindTexture(o.TEXTURE_3D, n.__webglTexture, o.TEXTURE0 + t);
+	}
+	function z(e, t) {
+		let n = l.get(e);
+		if (e.isCubeDepthTexture !== !0 && e.version > 0 && n.__version !== e.version) {
+			me(n, e, t);
+			return;
+		}
+		c.bindTexture(o.TEXTURE_CUBE_MAP, n.__webglTexture, o.TEXTURE0 + t);
+	}
+	let le = {
+		[e]: o.REPEAT,
+		[t]: o.CLAMP_TO_EDGE,
+		[n]: o.MIRRORED_REPEAT
+	}, ue = {
+		[r]: o.NEAREST,
+		1004: o.NEAREST_MIPMAP_NEAREST,
+		1005: o.NEAREST_MIPMAP_LINEAR,
+		[i]: o.LINEAR,
+		1007: o.LINEAR_MIPMAP_NEAREST,
+		[a]: o.LINEAR_MIPMAP_LINEAR
+	}, B = {
+		512: o.NEVER,
+		519: o.ALWAYS,
+		513: o.LESS,
+		515: o.LEQUAL,
+		514: o.EQUAL,
+		518: o.GEQUAL,
+		516: o.GREATER,
+		517: o.NOTEQUAL
+	};
+	function V(e, t) {
+		if (t.type === 1015 && s.has("OES_texture_float_linear") === !1 && (t.magFilter === 1006 || t.magFilter === 1007 || t.magFilter === 1005 || t.magFilter === 1008 || t.minFilter === 1006 || t.minFilter === 1007 || t.minFilter === 1005 || t.minFilter === 1008) && F("WebGLRenderer: Unable to use linear filtering with floating point textures. OES_texture_float_linear not supported on this device."), o.texParameteri(e, o.TEXTURE_WRAP_S, le[t.wrapS]), o.texParameteri(e, o.TEXTURE_WRAP_T, le[t.wrapT]), (e === o.TEXTURE_3D || e === o.TEXTURE_2D_ARRAY) && o.texParameteri(e, o.TEXTURE_WRAP_R, le[t.wrapR]), o.texParameteri(e, o.TEXTURE_MAG_FILTER, ue[t.magFilter]), o.texParameteri(e, o.TEXTURE_MIN_FILTER, ue[t.minFilter]), t.compareFunction && (o.texParameteri(e, o.TEXTURE_COMPARE_MODE, o.COMPARE_REF_TO_TEXTURE), o.texParameteri(e, o.TEXTURE_COMPARE_FUNC, B[t.compareFunction])), s.has("EXT_texture_filter_anisotropic") === !0) {
+			if (t.magFilter === 1003 || t.minFilter !== 1005 && t.minFilter !== 1008 || t.type === 1015 && s.has("OES_texture_float_linear") === !1) return;
+			if (t.anisotropy > 1 || l.get(t).__currentAnisotropy) {
+				let n = s.get("EXT_texture_filter_anisotropic");
+				o.texParameterf(e, n.TEXTURE_MAX_ANISOTROPY_EXT, Math.min(t.anisotropy, u.getMaxAnisotropy())), l.get(t).__currentAnisotropy = t.anisotropy;
+			}
+		}
+	}
+	function de(e, t) {
+		let n = !1;
+		e.__webglInit === void 0 && (e.__webglInit = !0, t.addEventListener("dispose", A));
+		let r = t.source, i = b.get(r);
+		i === void 0 && (i = {}, b.set(r, i));
+		let a = L(t);
+		if (a !== e.__cacheKey) {
+			i[a] === void 0 && (i[a] = {
+				texture: o.createTexture(),
+				usedTimes: 0
+			}, f.memory.textures++, n = !0), i[a].usedTimes++;
+			let r = i[e.__cacheKey];
+			r !== void 0 && (i[e.__cacheKey].usedTimes--, r.usedTimes === 0 && te(t)), e.__cacheKey = a, e.__webglTexture = i[a].texture;
+		}
+		return n;
+	}
+	function fe(e, t, n) {
+		return Math.floor(Math.floor(e / n) / t);
+	}
+	function pe(e, t, n, r) {
+		let i = e.updateRanges;
+		if (i.length === 0) c.texSubImage2D(o.TEXTURE_2D, 0, 0, 0, t.width, t.height, n, r, t.data);
+		else {
+			i.sort((e, t) => e.start - t.start);
+			let a = 0;
+			for (let e = 1; e < i.length; e++) {
+				let n = i[a], r = i[e], o = n.start + n.count, s = fe(r.start, t.width, 4), c = fe(n.start, t.width, 4);
+				r.start <= o + 1 && s === c && fe(r.start + r.count - 1, t.width, 4) === s ? n.count = Math.max(n.count, r.start + r.count - n.start) : (++a, i[a] = r);
+			}
+			i.length = a + 1;
+			let s = c.getParameter(o.UNPACK_ROW_LENGTH), l = c.getParameter(o.UNPACK_SKIP_PIXELS), u = c.getParameter(o.UNPACK_SKIP_ROWS);
+			c.pixelStorei(o.UNPACK_ROW_LENGTH, t.width);
+			for (let e = 0, a = i.length; e < a; e++) {
+				let a = i[e], s = Math.floor(a.start / 4), l = Math.ceil(a.count / 4), u = s % t.width, d = Math.floor(s / t.width), f = l;
+				c.pixelStorei(o.UNPACK_SKIP_PIXELS, u), c.pixelStorei(o.UNPACK_SKIP_ROWS, d), c.texSubImage2D(o.TEXTURE_2D, 0, u, d, f, 1, n, r, t.data);
+			}
+			e.clearUpdateRanges(), c.pixelStorei(o.UNPACK_ROW_LENGTH, s), c.pixelStorei(o.UNPACK_SKIP_PIXELS, l), c.pixelStorei(o.UNPACK_SKIP_ROWS, u);
+		}
+	}
+	function H(e, t, n) {
+		let r = o.TEXTURE_2D;
+		(t.isDataArrayTexture || t.isCompressedArrayTexture) && (r = o.TEXTURE_2D_ARRAY), t.isData3DTexture && (r = o.TEXTURE_3D);
+		let i = de(e, t), a = t.source;
+		c.bindTexture(r, e.__webglTexture, o.TEXTURE0 + n);
+		let s = l.get(a);
+		if (a.version !== s.__version || i === !0) {
+			if (c.activeTexture(o.TEXTURE0 + n), !(typeof ImageBitmap < "u" && t.image instanceof ImageBitmap)) {
+				let e = K.getPrimaries(K.workingColorSpace), n = t.colorSpace === "" ? null : K.getPrimaries(t.colorSpace), r = t.colorSpace === "" || e === n ? o.NONE : o.BROWSER_DEFAULT_WEBGL;
+				c.pixelStorei(o.UNPACK_FLIP_Y_WEBGL, t.flipY), c.pixelStorei(o.UNPACK_PREMULTIPLY_ALPHA_WEBGL, t.premultiplyAlpha), c.pixelStorei(o.UNPACK_COLORSPACE_CONVERSION_WEBGL, r);
+			}
+			c.pixelStorei(o.UNPACK_ALIGNMENT, t.unpackAlignment);
+			let e = C(t.image, !1, u.maxTextureSize);
+			e = Ee(t, e);
+			let l = d.convert(t.format, t.colorSpace), f = d.convert(t.type), p = D(t.internalFormat, l, f, t.normalized, t.colorSpace, t.isVideoTexture);
+			V(r, t);
+			let m, h = t.mipmaps, _ = t.isVideoTexture !== !0, y = s.__version === void 0 || i === !0, b = a.dataReady, x = k(t, e);
+			if (t.isDepthTexture) p = O(t.format === g, t.type), y && (_ ? c.texStorage2D(o.TEXTURE_2D, 1, p, e.width, e.height) : c.texImage2D(o.TEXTURE_2D, 0, p, e.width, e.height, 0, l, f, null));
+			else if (t.isDataTexture) if (h.length > 0) {
+				_ && y && c.texStorage2D(o.TEXTURE_2D, x, p, h[0].width, h[0].height);
+				for (let e = 0, t = h.length; e < t; e++) m = h[e], _ ? b && c.texSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, f, m.data) : c.texImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, l, f, m.data);
+				t.generateMipmaps = !1;
+			} else _ ? (y && c.texStorage2D(o.TEXTURE_2D, x, p, e.width, e.height), b && pe(t, e, l, f)) : c.texImage2D(o.TEXTURE_2D, 0, p, e.width, e.height, 0, l, f, e.data);
+			else if (t.isCompressedTexture) if (t.isCompressedArrayTexture) {
+				_ && y && c.texStorage3D(o.TEXTURE_2D_ARRAY, x, p, h[0].width, h[0].height, e.depth);
+				for (let n = 0, r = h.length; n < r; n++) if (m = h[n], t.format !== 1023) if (l !== null) if (_) {
+					if (b) if (t.layerUpdates.size > 0) {
+						let e = ai(m.width, m.height, t.format, t.type);
+						for (let r of t.layerUpdates) {
+							let t = m.data.subarray(r * e / m.data.BYTES_PER_ELEMENT, (r + 1) * e / m.data.BYTES_PER_ELEMENT);
+							c.compressedTexSubImage3D(o.TEXTURE_2D_ARRAY, n, 0, 0, r, m.width, m.height, 1, l, t);
+						}
+						t.clearLayerUpdates();
+					} else c.compressedTexSubImage3D(o.TEXTURE_2D_ARRAY, n, 0, 0, 0, m.width, m.height, e.depth, l, m.data);
+				} else c.compressedTexImage3D(o.TEXTURE_2D_ARRAY, n, p, m.width, m.height, e.depth, 0, m.data, 0, 0);
+				else F("WebGLRenderer: Attempt to load unsupported compressed texture format in .uploadTexture()");
+				else _ ? b && c.texSubImage3D(o.TEXTURE_2D_ARRAY, n, 0, 0, 0, m.width, m.height, e.depth, l, f, m.data) : c.texImage3D(o.TEXTURE_2D_ARRAY, n, p, m.width, m.height, e.depth, 0, l, f, m.data);
+			} else {
+				_ && y && c.texStorage2D(o.TEXTURE_2D, x, p, h[0].width, h[0].height);
+				for (let e = 0, n = h.length; e < n; e++) m = h[e], t.format === 1023 ? _ ? b && c.texSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, f, m.data) : c.texImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, l, f, m.data) : l === null ? F("WebGLRenderer: Attempt to load unsupported compressed texture format in .uploadTexture()") : _ ? b && c.compressedTexSubImage2D(o.TEXTURE_2D, e, 0, 0, m.width, m.height, l, m.data) : c.compressedTexImage2D(o.TEXTURE_2D, e, p, m.width, m.height, 0, m.data);
+			}
+			else if (t.isDataArrayTexture) if (_) {
+				if (y && c.texStorage3D(o.TEXTURE_2D_ARRAY, x, p, e.width, e.height, e.depth), b) if (t.layerUpdates.size > 0) {
+					let n = ai(e.width, e.height, t.format, t.type);
+					for (let r of t.layerUpdates) {
+						let t = e.data.subarray(r * n / e.data.BYTES_PER_ELEMENT, (r + 1) * n / e.data.BYTES_PER_ELEMENT);
+						c.texSubImage3D(o.TEXTURE_2D_ARRAY, 0, 0, 0, r, e.width, e.height, 1, l, f, t);
+					}
+					t.clearLayerUpdates();
+				} else c.texSubImage3D(o.TEXTURE_2D_ARRAY, 0, 0, 0, 0, e.width, e.height, e.depth, l, f, e.data);
+			} else c.texImage3D(o.TEXTURE_2D_ARRAY, 0, p, e.width, e.height, e.depth, 0, l, f, e.data);
+			else if (t.isData3DTexture) _ ? (y && c.texStorage3D(o.TEXTURE_3D, x, p, e.width, e.height, e.depth), b && c.texSubImage3D(o.TEXTURE_3D, 0, 0, 0, 0, e.width, e.height, e.depth, l, f, e.data)) : c.texImage3D(o.TEXTURE_3D, 0, p, e.width, e.height, e.depth, 0, l, f, e.data);
+			else if (t.isFramebufferTexture) {
+				if (y) if (_) c.texStorage2D(o.TEXTURE_2D, x, p, e.width, e.height);
+				else {
+					let t = e.width, n = e.height;
+					for (let e = 0; e < x; e++) c.texImage2D(o.TEXTURE_2D, e, p, t, n, 0, l, f, null), t >>= 1, n >>= 1;
+				}
+			} else if (t.isHTMLTexture) {
+				if ("texElementImage2D" in o) {
+					let n = o.canvas;
+					if (n.hasAttribute("layoutsubtree") || n.setAttribute("layoutsubtree", "true"), e.parentNode !== n) {
+						n.appendChild(e), v.add(t), n.onpaint = (e) => {
+							let t = e.changedElements;
+							for (let e of v) t.includes(e.image) && (e.needsUpdate = !0);
+						}, n.requestPaint();
+						return;
+					}
+					if (o.texElementImage2D.length === 3) o.texElementImage2D(o.TEXTURE_2D, o.RGBA8, e);
+					else {
+						let t = o.RGBA, n = o.RGBA, r = o.UNSIGNED_BYTE;
+						o.texElementImage2D(o.TEXTURE_2D, 0, t, n, r, e);
+					}
+					o.texParameteri(o.TEXTURE_2D, o.TEXTURE_MIN_FILTER, o.LINEAR), o.texParameteri(o.TEXTURE_2D, o.TEXTURE_WRAP_S, o.CLAMP_TO_EDGE), o.texParameteri(o.TEXTURE_2D, o.TEXTURE_WRAP_T, o.CLAMP_TO_EDGE);
+				}
+			} else if (h.length > 0) {
+				if (_ && y) {
+					let e = De(h[0]);
+					c.texStorage2D(o.TEXTURE_2D, x, p, e.width, e.height);
+				}
+				for (let e = 0, t = h.length; e < t; e++) m = h[e], _ ? b && c.texSubImage2D(o.TEXTURE_2D, e, 0, 0, l, f, m) : c.texImage2D(o.TEXTURE_2D, e, p, l, f, m);
+				t.generateMipmaps = !1;
+			} else if (_) {
+				if (y) {
+					let t = De(e);
+					c.texStorage2D(o.TEXTURE_2D, x, p, t.width, t.height);
+				}
+				b && c.texSubImage2D(o.TEXTURE_2D, 0, 0, 0, l, f, e);
+			} else c.texImage2D(o.TEXTURE_2D, 0, p, l, f, e);
+			w(t) && T(r), s.__version = a.version, t.onUpdate && t.onUpdate(t);
+		}
+		e.__version = t.version;
+	}
+	function me(e, t, n) {
+		if (t.image.length !== 6) return;
+		let r = de(e, t), i = t.source;
+		c.bindTexture(o.TEXTURE_CUBE_MAP, e.__webglTexture, o.TEXTURE0 + n);
+		let a = l.get(i);
+		if (i.version !== a.__version || r === !0) {
+			c.activeTexture(o.TEXTURE0 + n);
+			let e = K.getPrimaries(K.workingColorSpace), s = t.colorSpace === "" ? null : K.getPrimaries(t.colorSpace), l = t.colorSpace === "" || e === s ? o.NONE : o.BROWSER_DEFAULT_WEBGL;
+			c.pixelStorei(o.UNPACK_FLIP_Y_WEBGL, t.flipY), c.pixelStorei(o.UNPACK_PREMULTIPLY_ALPHA_WEBGL, t.premultiplyAlpha), c.pixelStorei(o.UNPACK_ALIGNMENT, t.unpackAlignment), c.pixelStorei(o.UNPACK_COLORSPACE_CONVERSION_WEBGL, l);
+			let f = t.isCompressedTexture || t.image[0].isCompressedTexture, p = t.image[0] && t.image[0].isDataTexture, m = [];
+			for (let e = 0; e < 6; e++) !f && !p ? m[e] = C(t.image[e], !0, u.maxCubemapSize) : m[e] = p ? t.image[e].image : t.image[e], m[e] = Ee(t, m[e]);
+			let h = m[0], g = d.convert(t.format, t.colorSpace), _ = d.convert(t.type), v = D(t.internalFormat, g, _, t.normalized, t.colorSpace), y = t.isVideoTexture !== !0, b = a.__version === void 0 || r === !0, x = i.dataReady, S = k(t, h);
+			V(o.TEXTURE_CUBE_MAP, t);
+			let E;
+			if (f) {
+				y && b && c.texStorage2D(o.TEXTURE_CUBE_MAP, S, v, h.width, h.height);
+				for (let e = 0; e < 6; e++) {
+					E = m[e].mipmaps;
+					for (let n = 0; n < E.length; n++) {
+						let r = E[n];
+						t.format === 1023 ? y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, 0, 0, r.width, r.height, g, _, r.data) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, v, r.width, r.height, 0, g, _, r.data) : g === null ? F("WebGLRenderer: Attempt to load unsupported compressed texture format in .setTextureCube()") : y ? x && c.compressedTexSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, 0, 0, r.width, r.height, g, r.data) : c.compressedTexImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, n, v, r.width, r.height, 0, r.data);
+					}
+				}
+			} else {
+				if (E = t.mipmaps, y && b) {
+					E.length > 0 && S++;
+					let e = De(m[0]);
+					c.texStorage2D(o.TEXTURE_CUBE_MAP, S, v, e.width, e.height);
+				}
+				for (let e = 0; e < 6; e++) if (p) {
+					y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, 0, 0, 0, m[e].width, m[e].height, g, _, m[e].data) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, 0, v, m[e].width, m[e].height, 0, g, _, m[e].data);
+					for (let t = 0; t < E.length; t++) {
+						let n = E[t].image[e].image;
+						y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, t + 1, 0, 0, n.width, n.height, g, _, n.data) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, t + 1, v, n.width, n.height, 0, g, _, n.data);
+					}
+				} else {
+					y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, 0, 0, 0, g, _, m[e]) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, 0, v, g, _, m[e]);
+					for (let t = 0; t < E.length; t++) {
+						let n = E[t];
+						y ? x && c.texSubImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, t + 1, 0, 0, g, _, n.image[e]) : c.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + e, t + 1, v, g, _, n.image[e]);
+					}
+				}
+			}
+			w(t) && T(o.TEXTURE_CUBE_MAP), a.__version = i.version, t.onUpdate && t.onUpdate(t);
+		}
+		e.__version = t.version;
+	}
+	function W(e, t, n, r, i, a) {
+		let s = d.convert(n.format, n.colorSpace), u = d.convert(n.type), f = D(n.internalFormat, s, u, n.normalized, n.colorSpace), m = l.get(t), h = l.get(n);
+		if (h.__renderTarget = t, !m.__hasExternalTextures) {
+			let e = Math.max(1, t.width >> a), n = Math.max(1, t.height >> a);
+			i === o.TEXTURE_3D || i === o.TEXTURE_2D_ARRAY ? c.texImage3D(i, a, f, e, n, t.depth, 0, s, u, null) : c.texImage2D(i, a, f, e, n, 0, s, u, null);
+		}
+		c.bindFramebuffer(o.FRAMEBUFFER, e), we(t) ? p.framebufferTexture2DMultisampleEXT(o.FRAMEBUFFER, r, i, h.__webglTexture, 0, Ce(t)) : (i === o.TEXTURE_2D || i >= o.TEXTURE_CUBE_MAP_POSITIVE_X && i <= o.TEXTURE_CUBE_MAP_NEGATIVE_Z) && o.framebufferTexture2D(o.FRAMEBUFFER, r, i, h.__webglTexture, a), c.bindFramebuffer(o.FRAMEBUFFER, null);
+	}
+	function he(e, t, n) {
+		if (o.bindRenderbuffer(o.RENDERBUFFER, e), t.depthBuffer) {
+			let r = t.depthTexture, i = r && r.isDepthTexture ? r.type : null, a = O(t.stencilBuffer, i), s = t.stencilBuffer ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT;
+			we(t) ? p.renderbufferStorageMultisampleEXT(o.RENDERBUFFER, Ce(t), a, t.width, t.height) : n ? o.renderbufferStorageMultisample(o.RENDERBUFFER, Ce(t), a, t.width, t.height) : o.renderbufferStorage(o.RENDERBUFFER, a, t.width, t.height), o.framebufferRenderbuffer(o.FRAMEBUFFER, s, o.RENDERBUFFER, e);
+		} else {
+			let e = t.textures;
+			for (let r = 0; r < e.length; r++) {
+				let i = e[r], a = d.convert(i.format, i.colorSpace), s = d.convert(i.type), c = D(i.internalFormat, a, s, i.normalized, i.colorSpace);
+				we(t) ? p.renderbufferStorageMultisampleEXT(o.RENDERBUFFER, Ce(t), c, t.width, t.height) : n ? o.renderbufferStorageMultisample(o.RENDERBUFFER, Ce(t), c, t.width, t.height) : o.renderbufferStorage(o.RENDERBUFFER, c, t.width, t.height);
+			}
+		}
+		o.bindRenderbuffer(o.RENDERBUFFER, null);
+	}
+	function ge(e, t, n) {
+		let r = t.isWebGLCubeRenderTarget === !0;
+		if (c.bindFramebuffer(o.FRAMEBUFFER, e), !(t.depthTexture && t.depthTexture.isDepthTexture)) throw Error("THREE.WebGLTextures: renderTarget.depthTexture must be an instance of THREE.DepthTexture.");
+		let i = l.get(t.depthTexture);
+		if (i.__renderTarget = t, (!i.__webglTexture || t.depthTexture.image.width !== t.width || t.depthTexture.image.height !== t.height) && (t.depthTexture.image.width = t.width, t.depthTexture.image.height = t.height, t.depthTexture.needsUpdate = !0), r) {
+			if (i.__webglInit === void 0 && (i.__webglInit = !0, t.depthTexture.addEventListener("dispose", A)), i.__webglTexture === void 0) {
+				i.__webglTexture = o.createTexture(), c.bindTexture(o.TEXTURE_CUBE_MAP, i.__webglTexture), V(o.TEXTURE_CUBE_MAP, t.depthTexture);
+				let e = d.convert(t.depthTexture.format), n = d.convert(t.depthTexture.type), r;
+				t.depthTexture.format === 1026 ? r = o.DEPTH_COMPONENT24 : t.depthTexture.format === 1027 && (r = o.DEPTH24_STENCIL8);
+				for (let i = 0; i < 6; i++) o.texImage2D(o.TEXTURE_CUBE_MAP_POSITIVE_X + i, 0, r, t.width, t.height, 0, e, n, null);
+			}
+		} else se(t.depthTexture, 0);
+		let a = i.__webglTexture, s = Ce(t), u = r ? o.TEXTURE_CUBE_MAP_POSITIVE_X + n : o.TEXTURE_2D, f = t.depthTexture.format === 1027 ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT;
+		if (t.depthTexture.format === 1026) we(t) ? p.framebufferTexture2DMultisampleEXT(o.FRAMEBUFFER, f, u, a, 0, s) : o.framebufferTexture2D(o.FRAMEBUFFER, f, u, a, 0);
+		else if (t.depthTexture.format === 1027) we(t) ? p.framebufferTexture2DMultisampleEXT(o.FRAMEBUFFER, f, u, a, 0, s) : o.framebufferTexture2D(o.FRAMEBUFFER, f, u, a, 0);
+		else throw Error("THREE.WebGLTextures: Unknown depthTexture format.");
+	}
+	function G(e) {
+		let t = l.get(e), n = e.isWebGLCubeRenderTarget === !0;
+		if (t.__boundDepthTexture !== e.depthTexture) {
+			let n = e.depthTexture;
+			if (t.__depthDisposeCallback && t.__depthDisposeCallback(), n) {
+				let e = () => {
+					delete t.__boundDepthTexture, delete t.__depthDisposeCallback, n.removeEventListener("dispose", e);
+				};
+				n.addEventListener("dispose", e), t.__depthDisposeCallback = e;
+			}
+			t.__boundDepthTexture = n;
+		}
+		if (e.depthTexture && !t.__autoAllocateDepthBuffer) if (n) for (let n = 0; n < 6; n++) ge(t.__webglFramebuffer[n], e, n);
+		else {
+			let n = e.texture.mipmaps;
+			n && n.length > 0 ? ge(t.__webglFramebuffer[0], e, 0) : ge(t.__webglFramebuffer, e, 0);
+		}
+		else if (n) {
+			t.__webglDepthbuffer = [];
+			for (let n = 0; n < 6; n++) if (c.bindFramebuffer(o.FRAMEBUFFER, t.__webglFramebuffer[n]), t.__webglDepthbuffer[n] === void 0) t.__webglDepthbuffer[n] = o.createRenderbuffer(), he(t.__webglDepthbuffer[n], e, !1);
+			else {
+				let r = e.stencilBuffer ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT, i = t.__webglDepthbuffer[n];
+				o.bindRenderbuffer(o.RENDERBUFFER, i), o.framebufferRenderbuffer(o.FRAMEBUFFER, r, o.RENDERBUFFER, i);
+			}
+		} else {
+			let n = e.texture.mipmaps;
+			if (n && n.length > 0 ? c.bindFramebuffer(o.FRAMEBUFFER, t.__webglFramebuffer[0]) : c.bindFramebuffer(o.FRAMEBUFFER, t.__webglFramebuffer), t.__webglDepthbuffer === void 0) t.__webglDepthbuffer = o.createRenderbuffer(), he(t.__webglDepthbuffer, e, !1);
+			else {
+				let n = e.stencilBuffer ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT, r = t.__webglDepthbuffer;
+				o.bindRenderbuffer(o.RENDERBUFFER, r), o.framebufferRenderbuffer(o.FRAMEBUFFER, n, o.RENDERBUFFER, r);
+			}
+		}
+		c.bindFramebuffer(o.FRAMEBUFFER, null);
+	}
+	function _e(e, t, n) {
+		let r = l.get(e);
+		t !== void 0 && W(r.__webglFramebuffer, e, e.texture, o.COLOR_ATTACHMENT0, o.TEXTURE_2D, 0), n !== void 0 && G(e);
+	}
+	function ve(e) {
+		let t = e.texture, n = l.get(e), r = l.get(t);
+		e.addEventListener("dispose", j);
+		let i = e.textures, a = e.isWebGLCubeRenderTarget === !0, s = i.length > 1;
+		if (s || (r.__webglTexture === void 0 && (r.__webglTexture = o.createTexture()), r.__version = t.version, f.memory.textures++), a) {
+			n.__webglFramebuffer = [];
+			for (let e = 0; e < 6; e++) if (t.mipmaps && t.mipmaps.length > 0) {
+				n.__webglFramebuffer[e] = [];
+				for (let r = 0; r < t.mipmaps.length; r++) n.__webglFramebuffer[e][r] = o.createFramebuffer();
+			} else n.__webglFramebuffer[e] = o.createFramebuffer();
+		} else {
+			if (t.mipmaps && t.mipmaps.length > 0) {
+				n.__webglFramebuffer = [];
+				for (let e = 0; e < t.mipmaps.length; e++) n.__webglFramebuffer[e] = o.createFramebuffer();
+			} else n.__webglFramebuffer = o.createFramebuffer();
+			if (s) for (let e = 0, t = i.length; e < t; e++) {
+				let t = l.get(i[e]);
+				t.__webglTexture === void 0 && (t.__webglTexture = o.createTexture(), f.memory.textures++);
+			}
+			if (e.samples > 0 && we(e) === !1) {
+				n.__webglMultisampledFramebuffer = o.createFramebuffer(), n.__webglColorRenderbuffer = [], c.bindFramebuffer(o.FRAMEBUFFER, n.__webglMultisampledFramebuffer);
+				for (let t = 0; t < i.length; t++) {
+					let r = i[t];
+					n.__webglColorRenderbuffer[t] = o.createRenderbuffer(), o.bindRenderbuffer(o.RENDERBUFFER, n.__webglColorRenderbuffer[t]);
+					let a = d.convert(r.format, r.colorSpace), s = d.convert(r.type), c = D(r.internalFormat, a, s, r.normalized, r.colorSpace, e.isXRRenderTarget === !0), l = Ce(e);
+					o.renderbufferStorageMultisample(o.RENDERBUFFER, l, c, e.width, e.height), o.framebufferRenderbuffer(o.FRAMEBUFFER, o.COLOR_ATTACHMENT0 + t, o.RENDERBUFFER, n.__webglColorRenderbuffer[t]);
+				}
+				o.bindRenderbuffer(o.RENDERBUFFER, null), e.depthBuffer && (n.__webglDepthRenderbuffer = o.createRenderbuffer(), he(n.__webglDepthRenderbuffer, e, !0)), c.bindFramebuffer(o.FRAMEBUFFER, null);
+			}
+		}
+		if (a) {
+			c.bindTexture(o.TEXTURE_CUBE_MAP, r.__webglTexture), V(o.TEXTURE_CUBE_MAP, t);
+			for (let r = 0; r < 6; r++) if (t.mipmaps && t.mipmaps.length > 0) for (let i = 0; i < t.mipmaps.length; i++) W(n.__webglFramebuffer[r][i], e, t, o.COLOR_ATTACHMENT0, o.TEXTURE_CUBE_MAP_POSITIVE_X + r, i);
+			else W(n.__webglFramebuffer[r], e, t, o.COLOR_ATTACHMENT0, o.TEXTURE_CUBE_MAP_POSITIVE_X + r, 0);
+			w(t) && T(o.TEXTURE_CUBE_MAP), c.unbindTexture();
+		} else if (s) {
+			for (let t = 0, r = i.length; t < r; t++) {
+				let r = i[t], a = l.get(r), s = o.TEXTURE_2D;
+				(e.isWebGL3DRenderTarget || e.isWebGLArrayRenderTarget) && (s = e.isWebGL3DRenderTarget ? o.TEXTURE_3D : o.TEXTURE_2D_ARRAY), c.bindTexture(s, a.__webglTexture), V(s, r), W(n.__webglFramebuffer, e, r, o.COLOR_ATTACHMENT0 + t, s, 0), w(r) && T(s);
+			}
+			c.unbindTexture();
+		} else {
+			let i = o.TEXTURE_2D;
+			if ((e.isWebGL3DRenderTarget || e.isWebGLArrayRenderTarget) && (i = e.isWebGL3DRenderTarget ? o.TEXTURE_3D : o.TEXTURE_2D_ARRAY), c.bindTexture(i, r.__webglTexture), V(i, t), t.mipmaps && t.mipmaps.length > 0) for (let r = 0; r < t.mipmaps.length; r++) W(n.__webglFramebuffer[r], e, t, o.COLOR_ATTACHMENT0, i, r);
+			else W(n.__webglFramebuffer, e, t, o.COLOR_ATTACHMENT0, i, 0);
+			w(t) && T(i), c.unbindTexture();
+		}
+		e.depthBuffer && G(e);
+	}
+	function ye(e) {
+		let t = e.textures;
+		for (let n = 0, r = t.length; n < r; n++) {
+			let r = t[n];
+			if (w(r)) {
+				let t = E(e), n = l.get(r).__webglTexture;
+				c.bindTexture(t, n), T(t), c.unbindTexture();
+			}
+		}
+	}
+	let be = [], xe = [];
+	function Se(e) {
+		if (e.samples > 0) {
+			if (we(e) === !1) {
+				let t = e.textures, n = e.width, r = e.height, i = o.COLOR_BUFFER_BIT, a = e.stencilBuffer ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT, s = l.get(e), u = t.length > 1;
+				if (u) for (let e = 0; e < t.length; e++) c.bindFramebuffer(o.FRAMEBUFFER, s.__webglMultisampledFramebuffer), o.framebufferRenderbuffer(o.FRAMEBUFFER, o.COLOR_ATTACHMENT0 + e, o.RENDERBUFFER, null), c.bindFramebuffer(o.FRAMEBUFFER, s.__webglFramebuffer), o.framebufferTexture2D(o.DRAW_FRAMEBUFFER, o.COLOR_ATTACHMENT0 + e, o.TEXTURE_2D, null, 0);
+				c.bindFramebuffer(o.READ_FRAMEBUFFER, s.__webglMultisampledFramebuffer);
+				let d = e.texture.mipmaps;
+				d && d.length > 0 ? c.bindFramebuffer(o.DRAW_FRAMEBUFFER, s.__webglFramebuffer[0]) : c.bindFramebuffer(o.DRAW_FRAMEBUFFER, s.__webglFramebuffer);
+				for (let c = 0; c < t.length; c++) {
+					if (e.resolveDepthBuffer && (e.depthBuffer && (i |= o.DEPTH_BUFFER_BIT), e.stencilBuffer && e.resolveStencilBuffer && (i |= o.STENCIL_BUFFER_BIT)), u) {
+						o.framebufferRenderbuffer(o.READ_FRAMEBUFFER, o.COLOR_ATTACHMENT0, o.RENDERBUFFER, s.__webglColorRenderbuffer[c]);
+						let e = l.get(t[c]).__webglTexture;
+						o.framebufferTexture2D(o.DRAW_FRAMEBUFFER, o.COLOR_ATTACHMENT0, o.TEXTURE_2D, e, 0);
+					}
+					o.blitFramebuffer(0, 0, n, r, 0, 0, n, r, i, o.NEAREST), m === !0 && (be.length = 0, xe.length = 0, be.push(o.COLOR_ATTACHMENT0 + c), e.depthBuffer && e.resolveDepthBuffer === !1 && (be.push(a), xe.push(a), o.invalidateFramebuffer(o.DRAW_FRAMEBUFFER, xe)), o.invalidateFramebuffer(o.READ_FRAMEBUFFER, be));
+				}
+				if (c.bindFramebuffer(o.READ_FRAMEBUFFER, null), c.bindFramebuffer(o.DRAW_FRAMEBUFFER, null), u) for (let e = 0; e < t.length; e++) {
+					c.bindFramebuffer(o.FRAMEBUFFER, s.__webglMultisampledFramebuffer), o.framebufferRenderbuffer(o.FRAMEBUFFER, o.COLOR_ATTACHMENT0 + e, o.RENDERBUFFER, s.__webglColorRenderbuffer[e]);
+					let n = l.get(t[e]).__webglTexture;
+					c.bindFramebuffer(o.FRAMEBUFFER, s.__webglFramebuffer), o.framebufferTexture2D(o.DRAW_FRAMEBUFFER, o.COLOR_ATTACHMENT0 + e, o.TEXTURE_2D, n, 0);
+				}
+				c.bindFramebuffer(o.DRAW_FRAMEBUFFER, s.__webglMultisampledFramebuffer);
+			} else if (e.depthBuffer && e.resolveDepthBuffer === !1 && m) {
+				let t = e.stencilBuffer ? o.DEPTH_STENCIL_ATTACHMENT : o.DEPTH_ATTACHMENT;
+				o.invalidateFramebuffer(o.DRAW_FRAMEBUFFER, [t]);
+			}
+		}
+	}
+	function Ce(e) {
+		return Math.min(u.maxSamples, e.samples);
+	}
+	function we(e) {
+		let t = l.get(e);
+		return e.samples > 0 && s.has("WEBGL_multisampled_render_to_texture") === !0 && t.__useRenderToTexture !== !1;
+	}
+	function Te(e) {
+		let t = f.render.frame;
+		_.get(e) !== t && (_.set(e, t), e.update());
+	}
+	function Ee(e, t) {
+		let n = e.colorSpace, r = e.format, i = e.type;
+		return e.isCompressedTexture === !0 || e.isVideoTexture === !0 || n !== "srgb-linear" && n !== "" && (K.getTransfer(n) === "srgb" ? (r !== 1023 || i !== 1009) && F("WebGLTextures: sRGB encoded textures have to use RGBAFormat and UnsignedByteType.") : I("WebGLTextures: Unsupported texture color space:", n)), t;
+	}
+	function De(e) {
+		return typeof HTMLImageElement < "u" && e instanceof HTMLImageElement ? (h.width = e.naturalWidth || e.width, h.height = e.naturalHeight || e.height) : typeof VideoFrame < "u" && e instanceof VideoFrame ? (h.width = e.displayWidth, h.height = e.displayHeight) : (h.width = e.width, h.height = e.height), h;
+	}
+	this.allocateTextureUnit = oe, this.resetTextureUnits = ie, this.getTextureUnits = P, this.setTextureUnits = ae, this.setTexture2D = se, this.setTexture2DArray = ce, this.setTexture3D = R, this.setTextureCube = z, this.rebindTextures = _e, this.setupRenderTarget = ve, this.updateRenderTargetMipmap = ye, this.updateMultisampleRenderTarget = Se, this.setupDepthRenderbuffer = G, this.setupFrameBufferTexture = W, this.useMultisampledRTT = we, this.isReversedDepthBuffer = function() {
+		return c.buffers.depth.getReversed();
+	};
+}
+function ds(e, t) {
+	function n(n, r = "") {
+		let i, a = K.getTransfer(r);
+		if (n === 1009) return e.UNSIGNED_BYTE;
+		if (n === 1017) return e.UNSIGNED_SHORT_4_4_4_4;
+		if (n === 1018) return e.UNSIGNED_SHORT_5_5_5_1;
+		if (n === 35902) return e.UNSIGNED_INT_5_9_9_9_REV;
+		if (n === 35899) return e.UNSIGNED_INT_10F_11F_11F_REV;
+		if (n === 1010) return e.BYTE;
+		if (n === 1011) return e.SHORT;
+		if (n === 1012) return e.UNSIGNED_SHORT;
+		if (n === 1013) return e.INT;
+		if (n === 1014) return e.UNSIGNED_INT;
+		if (n === 1015) return e.FLOAT;
+		if (n === 1016) return e.HALF_FLOAT;
+		if (n === 1021) return e.ALPHA;
+		if (n === 1022) return e.RGB;
+		if (n === 1023) return e.RGBA;
+		if (n === 1026) return e.DEPTH_COMPONENT;
+		if (n === 1027) return e.DEPTH_STENCIL;
+		if (n === 1028) return e.RED;
+		if (n === 1029) return e.RED_INTEGER;
+		if (n === 1030) return e.RG;
+		if (n === 1031) return e.RG_INTEGER;
+		if (n === 1033) return e.RGBA_INTEGER;
+		if (n === 33776 || n === 33777 || n === 33778 || n === 33779) if (a === "srgb") if (i = t.get("WEBGL_compressed_texture_s3tc_srgb"), i !== null) {
+			if (n === 33776) return i.COMPRESSED_SRGB_S3TC_DXT1_EXT;
+			if (n === 33777) return i.COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT;
+			if (n === 33778) return i.COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT;
+			if (n === 33779) return i.COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT;
+		} else return null;
+		else if (i = t.get("WEBGL_compressed_texture_s3tc"), i !== null) {
+			if (n === 33776) return i.COMPRESSED_RGB_S3TC_DXT1_EXT;
+			if (n === 33777) return i.COMPRESSED_RGBA_S3TC_DXT1_EXT;
+			if (n === 33778) return i.COMPRESSED_RGBA_S3TC_DXT3_EXT;
+			if (n === 33779) return i.COMPRESSED_RGBA_S3TC_DXT5_EXT;
+		} else return null;
+		if (n === 35840 || n === 35841 || n === 35842 || n === 35843) if (i = t.get("WEBGL_compressed_texture_pvrtc"), i !== null) {
+			if (n === 35840) return i.COMPRESSED_RGB_PVRTC_4BPPV1_IMG;
+			if (n === 35841) return i.COMPRESSED_RGB_PVRTC_2BPPV1_IMG;
+			if (n === 35842) return i.COMPRESSED_RGBA_PVRTC_4BPPV1_IMG;
+			if (n === 35843) return i.COMPRESSED_RGBA_PVRTC_2BPPV1_IMG;
+		} else return null;
+		if (n === 36196 || n === 37492 || n === 37496 || n === 37488 || n === 37489 || n === 37490 || n === 37491) if (i = t.get("WEBGL_compressed_texture_etc"), i !== null) {
+			if (n === 36196 || n === 37492) return a === "srgb" ? i.COMPRESSED_SRGB8_ETC2 : i.COMPRESSED_RGB8_ETC2;
+			if (n === 37496) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ETC2_EAC : i.COMPRESSED_RGBA8_ETC2_EAC;
+			if (n === 37488) return i.COMPRESSED_R11_EAC;
+			if (n === 37489) return i.COMPRESSED_SIGNED_R11_EAC;
+			if (n === 37490) return i.COMPRESSED_RG11_EAC;
+			if (n === 37491) return i.COMPRESSED_SIGNED_RG11_EAC;
+		} else return null;
+		if (n === 37808 || n === 37809 || n === 37810 || n === 37811 || n === 37812 || n === 37813 || n === 37814 || n === 37815 || n === 37816 || n === 37817 || n === 37818 || n === 37819 || n === 37820 || n === 37821) if (i = t.get("WEBGL_compressed_texture_astc"), i !== null) {
+			if (n === 37808) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_4x4_KHR : i.COMPRESSED_RGBA_ASTC_4x4_KHR;
+			if (n === 37809) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_5x4_KHR : i.COMPRESSED_RGBA_ASTC_5x4_KHR;
+			if (n === 37810) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_5x5_KHR : i.COMPRESSED_RGBA_ASTC_5x5_KHR;
+			if (n === 37811) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_6x5_KHR : i.COMPRESSED_RGBA_ASTC_6x5_KHR;
+			if (n === 37812) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR : i.COMPRESSED_RGBA_ASTC_6x6_KHR;
+			if (n === 37813) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_8x5_KHR : i.COMPRESSED_RGBA_ASTC_8x5_KHR;
+			if (n === 37814) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_8x6_KHR : i.COMPRESSED_RGBA_ASTC_8x6_KHR;
+			if (n === 37815) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_8x8_KHR : i.COMPRESSED_RGBA_ASTC_8x8_KHR;
+			if (n === 37816) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_10x5_KHR : i.COMPRESSED_RGBA_ASTC_10x5_KHR;
+			if (n === 37817) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_10x6_KHR : i.COMPRESSED_RGBA_ASTC_10x6_KHR;
+			if (n === 37818) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR : i.COMPRESSED_RGBA_ASTC_10x8_KHR;
+			if (n === 37819) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR : i.COMPRESSED_RGBA_ASTC_10x10_KHR;
+			if (n === 37820) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR : i.COMPRESSED_RGBA_ASTC_12x10_KHR;
+			if (n === 37821) return a === "srgb" ? i.COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR : i.COMPRESSED_RGBA_ASTC_12x12_KHR;
+		} else return null;
+		if (n === 36492 || n === 36494 || n === 36495) if (i = t.get("EXT_texture_compression_bptc"), i !== null) {
+			if (n === 36492) return a === "srgb" ? i.COMPRESSED_SRGB_ALPHA_BPTC_UNORM_EXT : i.COMPRESSED_RGBA_BPTC_UNORM_EXT;
+			if (n === 36494) return i.COMPRESSED_RGB_BPTC_SIGNED_FLOAT_EXT;
+			if (n === 36495) return i.COMPRESSED_RGB_BPTC_UNSIGNED_FLOAT_EXT;
+		} else return null;
+		if (n === 36283 || n === 36284 || n === 36285 || n === 36286) if (i = t.get("EXT_texture_compression_rgtc"), i !== null) {
+			if (n === 36283) return i.COMPRESSED_RED_RGTC1_EXT;
+			if (n === 36284) return i.COMPRESSED_SIGNED_RED_RGTC1_EXT;
+			if (n === 36285) return i.COMPRESSED_RED_GREEN_RGTC2_EXT;
+			if (n === 36286) return i.COMPRESSED_SIGNED_RED_GREEN_RGTC2_EXT;
+		} else return null;
+		return n === 1020 ? e.UNSIGNED_INT_24_8 : e[n] === void 0 ? null : e[n];
+	}
+	return { convert: n };
+}
+var fs = "\nvoid main() {\n\n	gl_Position = vec4( position, 1.0 );\n\n}", ps = "\nuniform sampler2DArray depthColor;\nuniform float depthWidth;\nuniform float depthHeight;\n\nvoid main() {\n\n	vec2 coord = vec2( gl_FragCoord.x / depthWidth, gl_FragCoord.y / depthHeight );\n\n	if ( coord.x >= 1.0 ) {\n\n		gl_FragDepth = texture( depthColor, vec3( coord.x - 1.0, coord.y, 1 ) ).r;\n\n	} else {\n\n		gl_FragDepth = texture( depthColor, vec3( coord.x, coord.y, 0 ) ).r;\n\n	}\n\n}", ms = class {
+	constructor() {
+		this.texture = null, this.mesh = null, this.depthNear = 0, this.depthFar = 0;
+	}
+	init(e, t) {
+		if (this.texture === null) {
+			let n = new nr(e.texture);
+			(e.depthNear !== t.depthNear || e.depthFar !== t.depthFar) && (this.depthNear = e.depthNear, this.depthFar = e.depthFar), this.texture = n;
+		}
+	}
+	getMesh(e) {
+		if (this.texture !== null && this.mesh === null) {
+			let t = e.cameras[0].viewport, n = new mr({
+				vertexShader: fs,
+				fragmentShader: ps,
+				uniforms: {
+					depthColor: { value: this.texture },
+					depthWidth: { value: t.z },
+					depthHeight: { value: t.w }
+				}
+			});
+			this.mesh = new Mn(new ar(20, 20), n);
+		}
+		return this.mesh;
+	}
+	reset() {
+		this.texture = null, this.mesh = null;
+	}
+	getDepthTexture() {
+		return this.texture;
+	}
+}, hs = class extends R {
+	constructor(e, t) {
+		super();
+		let n = this, r = null, i = 1, a = null, s = "local-floor", l = 1, u = null, d = null, f = null, _ = null, v = null, y = null, b = typeof XRWebGLBinding < "u", x = new ms(), S = {}, C = t.getContextAttributes(), w = null, T = null, E = [], D = [], O = new U(), k = null, A = new Vr();
+		A.viewport = new je();
+		let ee = new Vr();
+		ee.viewport = new je();
+		let j = [A, ee], M = new Kr(), te = null, ne = null;
+		this.cameraAutoUpdate = !0, this.enabled = !1, this.isPresenting = !1, this.getController = function(e) {
+			let t = E[e];
+			return t === void 0 && (t = new ct(), E[e] = t), t.getTargetRaySpace();
+		}, this.getControllerGrip = function(e) {
+			let t = E[e];
+			return t === void 0 && (t = new ct(), E[e] = t), t.getGripSpace();
+		}, this.getHand = function(e) {
+			let t = E[e];
+			return t === void 0 && (t = new ct(), E[e] = t), t.getHandSpace();
+		};
+		function N(e) {
+			let t = D.indexOf(e.inputSource);
+			if (t === -1) return;
+			let n = E[t];
+			n !== void 0 && (n.update(e.inputSource, e.frame, u || a), n.dispatchEvent({
+				type: e.type,
+				data: e.inputSource
+			}));
+		}
+		function re() {
+			r.removeEventListener("select", N), r.removeEventListener("selectstart", N), r.removeEventListener("selectend", N), r.removeEventListener("squeeze", N), r.removeEventListener("squeezestart", N), r.removeEventListener("squeezeend", N), r.removeEventListener("end", re), r.removeEventListener("inputsourceschange", ie);
+			for (let e = 0; e < E.length; e++) {
+				let t = D[e];
+				t !== null && (D[e] = null, E[e].disconnect(t));
+			}
+			te = null, ne = null, x.reset();
+			for (let e in S) delete S[e];
+			e.setRenderTarget(w), v = null, _ = null, f = null, r = null, T = null, R.stop(), n.isPresenting = !1, e.setPixelRatio(k), e.setSize(O.width, O.height, !1), n.dispatchEvent({ type: "sessionend" });
+		}
+		this.setFramebufferScaleFactor = function(e) {
+			i = e, n.isPresenting === !0 && F("WebXRManager: Cannot change framebuffer scale while presenting.");
+		}, this.setReferenceSpaceType = function(e) {
+			s = e, n.isPresenting === !0 && F("WebXRManager: Cannot change reference space type while presenting.");
+		}, this.getReferenceSpace = function() {
+			return u || a;
+		}, this.setReferenceSpace = function(e) {
+			u = e;
+		}, this.getBaseLayer = function() {
+			return _ === null ? v : _;
+		}, this.getBinding = function() {
+			return f === null && b && (f = new XRWebGLBinding(r, t)), f;
+		}, this.getFrame = function() {
+			return y;
+		}, this.getSession = function() {
+			return r;
+		}, this.setSession = async function(d) {
+			if (r = d, r !== null) {
+				if (w = e.getRenderTarget(), r.addEventListener("select", N), r.addEventListener("selectstart", N), r.addEventListener("selectend", N), r.addEventListener("squeeze", N), r.addEventListener("squeezestart", N), r.addEventListener("squeezeend", N), r.addEventListener("end", re), r.addEventListener("inputsourceschange", ie), C.xrCompatible !== !0 && await t.makeXRCompatible(), k = e.getPixelRatio(), e.getSize(O), b && "createProjectionLayer" in XRWebGLBinding.prototype) {
+					let n = null, a = null, s = null;
+					C.depth && (s = C.stencil ? t.DEPTH24_STENCIL8 : t.DEPTH_COMPONENT24, n = C.stencil ? g : h, a = C.stencil ? p : c);
+					let l = {
+						colorFormat: t.RGBA8,
+						depthFormat: s,
+						scaleFactor: i
+					};
+					f = this.getBinding(), _ = f.createProjectionLayer(l), r.updateRenderState({ layers: [_] }), e.setPixelRatio(1), e.setSize(_.textureWidth, _.textureHeight, !1), T = new Me(_.textureWidth, _.textureHeight, {
+						format: m,
+						type: o,
+						depthTexture: new er(_.textureWidth, _.textureHeight, a, void 0, void 0, void 0, void 0, void 0, void 0, n),
+						stencilBuffer: C.stencil,
+						colorSpace: e.outputColorSpace,
+						samples: C.antialias ? 4 : 0,
+						resolveDepthBuffer: _.ignoreDepthValues === !1,
+						resolveStencilBuffer: _.ignoreDepthValues === !1
+					});
+				} else {
+					let n = {
+						antialias: C.antialias,
+						alpha: !0,
+						depth: C.depth,
+						stencil: C.stencil,
+						framebufferScaleFactor: i
+					};
+					v = new XRWebGLLayer(r, t, n), r.updateRenderState({ baseLayer: v }), e.setPixelRatio(1), e.setSize(v.framebufferWidth, v.framebufferHeight, !1), T = new Me(v.framebufferWidth, v.framebufferHeight, {
+						format: m,
+						type: o,
+						colorSpace: e.outputColorSpace,
+						stencilBuffer: C.stencil,
+						resolveDepthBuffer: v.ignoreDepthValues === !1,
+						resolveStencilBuffer: v.ignoreDepthValues === !1
+					});
+				}
+				T.isXRRenderTarget = !0, this.setFoveation(l), u = null, a = await r.requestReferenceSpace(s), R.setContext(r), R.start(), n.isPresenting = !0, n.dispatchEvent({ type: "sessionstart" });
+			}
+		}, this.getEnvironmentBlendMode = function() {
+			if (r !== null) return r.environmentBlendMode;
+		}, this.getDepthTexture = function() {
+			return x.getDepthTexture();
+		};
+		function ie(e) {
+			for (let t = 0; t < e.removed.length; t++) {
+				let n = e.removed[t], r = D.indexOf(n);
+				r >= 0 && (D[r] = null, E[r].disconnect(n));
+			}
+			for (let t = 0; t < e.added.length; t++) {
+				let n = e.added[t], r = D.indexOf(n);
+				if (r === -1) {
+					for (let e = 0; e < E.length; e++) if (e >= D.length) {
+						D.push(n), r = e;
+						break;
+					} else if (D[e] === null) {
+						D[e] = n, r = e;
+						break;
+					}
+					if (r === -1) break;
+				}
+				let i = E[r];
+				i && i.connect(n);
+			}
+		}
+		let P = new W(), ae = new W();
+		function oe(e, t, n) {
+			P.setFromMatrixPosition(t.matrixWorld), ae.setFromMatrixPosition(n.matrixWorld);
+			let r = P.distanceTo(ae), i = t.projectionMatrix.elements, a = n.projectionMatrix.elements, o = i[14] / (i[10] - 1), s = i[14] / (i[10] + 1), c = (i[9] + 1) / i[5], l = (i[9] - 1) / i[5], u = (i[8] - 1) / i[0], d = (a[8] + 1) / a[0], f = o * u, p = o * d, m = r / (-u + d), h = m * -u;
+			if (t.matrixWorld.decompose(e.position, e.quaternion, e.scale), e.translateX(h), e.translateZ(m), e.matrixWorld.compose(e.position, e.quaternion, e.scale), e.matrixWorldInverse.copy(e.matrixWorld).invert(), i[10] === -1) e.projectionMatrix.copy(t.projectionMatrix), e.projectionMatrixInverse.copy(t.projectionMatrixInverse);
+			else {
+				let t = o + m, n = s + m, i = f - h, a = p + (r - h), u = c * s / n * t, d = l * s / n * t;
+				e.projectionMatrix.makePerspective(i, a, u, d, t, n), e.projectionMatrixInverse.copy(e.projectionMatrix).invert();
+			}
+		}
+		function I(e, t) {
+			t === null ? e.matrixWorld.copy(e.matrix) : e.matrixWorld.multiplyMatrices(t.matrixWorld, e.matrix), e.matrixWorldInverse.copy(e.matrixWorld).invert();
+		}
+		this.updateCamera = function(e) {
+			if (r === null) return;
+			let t = e.near, n = e.far;
+			x.texture !== null && (x.depthNear > 0 && (t = x.depthNear), x.depthFar > 0 && (n = x.depthFar)), M.near = ee.near = A.near = t, M.far = ee.far = A.far = n, (te !== M.near || ne !== M.far) && (r.updateRenderState({
+				depthNear: M.near,
+				depthFar: M.far
+			}), te = M.near, ne = M.far), M.layers.mask = e.layers.mask | 6, A.layers.mask = M.layers.mask & -5, ee.layers.mask = M.layers.mask & -3;
+			let i = e.parent, a = M.cameras;
+			I(M, i);
+			for (let e = 0; e < a.length; e++) I(a[e], i);
+			a.length === 2 ? oe(M, A, ee) : M.projectionMatrix.copy(A.projectionMatrix), L(e, M, i);
+		};
+		function L(e, t, n) {
+			n === null ? e.matrix.copy(t.matrixWorld) : (e.matrix.copy(n.matrixWorld), e.matrix.invert(), e.matrix.multiply(t.matrixWorld)), e.matrix.decompose(e.position, e.quaternion, e.scale), e.updateMatrixWorld(!0), e.projectionMatrix.copy(t.projectionMatrix), e.projectionMatrixInverse.copy(t.projectionMatrixInverse), e.isPerspectiveCamera && (e.fov = ue * 2 * Math.atan(1 / e.projectionMatrix.elements[5]), e.zoom = 1);
+		}
+		this.getCamera = function() {
+			return M;
+		}, this.getFoveation = function() {
+			if (!(_ === null && v === null)) return l;
+		}, this.setFoveation = function(e) {
+			l = e, _ !== null && (_.fixedFoveation = e), v !== null && v.fixedFoveation !== void 0 && (v.fixedFoveation = e);
+		}, this.hasDepthSensing = function() {
+			return x.texture !== null;
+		}, this.getDepthSensingMesh = function() {
+			return x.getMesh(M);
+		}, this.getCameraTexture = function(e) {
+			return S[e];
+		};
+		let se = null;
+		function ce(t, i) {
+			if (d = i.getViewerPose(u || a), y = i, d !== null) {
+				let t = d.views;
+				v !== null && (e.setRenderTargetFramebuffer(T, v.framebuffer), e.setRenderTarget(T));
+				let i = !1;
+				t.length !== M.cameras.length && (M.cameras.length = 0, i = !0);
+				for (let n = 0; n < t.length; n++) {
+					let r = t[n], a = null;
+					if (v !== null) a = v.getViewport(r);
+					else {
+						let t = f.getViewSubImage(_, r);
+						a = t.viewport, n === 0 && (e.setRenderTargetTextures(T, t.colorTexture, t.depthStencilTexture), e.setRenderTarget(T));
+					}
+					let o = j[n];
+					o === void 0 && (o = new Vr(), o.layers.enable(n), o.viewport = new je(), j[n] = o), o.matrix.fromArray(r.transform.matrix), o.matrix.decompose(o.position, o.quaternion, o.scale), o.projectionMatrix.fromArray(r.projectionMatrix), o.projectionMatrixInverse.copy(o.projectionMatrix).invert(), o.viewport.set(a.x, a.y, a.width, a.height), n === 0 && (M.matrix.copy(o.matrix), M.matrix.decompose(M.position, M.quaternion, M.scale)), i === !0 && M.cameras.push(o);
+				}
+				let a = r.enabledFeatures;
+				if (a && a.includes("depth-sensing") && r.depthUsage == "gpu-optimized" && b) {
+					f = n.getBinding();
+					let e = f.getDepthInformation(t[0]);
+					e && e.isValid && e.texture && x.init(e, r.renderState);
+				}
+				if (a && a.includes("camera-access") && b) {
+					e.state.unbindTexture(), f = n.getBinding();
+					for (let e = 0; e < t.length; e++) {
+						let n = t[e].camera;
+						if (n) {
+							let e = S[n];
+							e || (e = new nr(), S[n] = e);
+							let t = f.getCameraImage(n);
+							e.sourceTexture = t;
+						}
+					}
+				}
+			}
+			for (let e = 0; e < E.length; e++) {
+				let t = D[e], n = E[e];
+				t !== null && n !== void 0 && n.update(t, i, u || a);
+			}
+			se && se(t, i), i.detectedPlanes && n.dispatchEvent({
+				type: "planesdetected",
+				data: i
+			}), y = null;
+		}
+		let R = new si();
+		R.setAnimationLoop(ce), this.setAnimationLoop = function(e) {
+			se = e;
+		}, this.dispose = function() {};
+	}
+}, gs = /*@__PURE__*/ new Fe(), _s = /*@__PURE__*/ new G();
+_s.set(-1, 0, 0, 0, 1, 0, 0, 0, 1);
+function vs(e, t) {
+	function n(e, t) {
+		e.matrixAutoUpdate === !0 && e.updateMatrix(), t.value.copy(e.matrix);
+	}
+	function r(t, n) {
+		n.color.getRGB(t.fogColor.value, ur(e)), n.isFog ? (t.fogNear.value = n.near, t.fogFar.value = n.far) : n.isFogExp2 && (t.fogDensity.value = n.density);
+	}
+	function i(e, t, n, r, i) {
+		t.isNodeMaterial ? t.uniformsNeedUpdate = !1 : t.isMeshBasicMaterial ? a(e, t) : t.isMeshLambertMaterial ? (a(e, t), t.envMap && (e.envMapIntensity.value = t.envMapIntensity)) : t.isMeshToonMaterial ? (a(e, t), d(e, t)) : t.isMeshPhongMaterial ? (a(e, t), u(e, t), t.envMap && (e.envMapIntensity.value = t.envMapIntensity)) : t.isMeshStandardMaterial ? (a(e, t), f(e, t), t.isMeshPhysicalMaterial && p(e, t, i)) : t.isMeshMatcapMaterial ? (a(e, t), m(e, t)) : t.isMeshDepthMaterial ? a(e, t) : t.isMeshDistanceMaterial ? (a(e, t), h(e, t)) : t.isMeshNormalMaterial ? a(e, t) : t.isLineBasicMaterial ? (o(e, t), t.isLineDashedMaterial && s(e, t)) : t.isPointsMaterial ? c(e, t, n, r) : t.isSpriteMaterial ? l(e, t) : t.isShadowMaterial ? (e.color.value.copy(t.color), e.opacity.value = t.opacity) : t.isShaderMaterial && (t.uniformsNeedUpdate = !1);
+	}
+	function a(e, r) {
+		e.opacity.value = r.opacity, r.color && e.diffuse.value.copy(r.color), r.emissive && e.emissive.value.copy(r.emissive).multiplyScalar(r.emissiveIntensity), r.map && (e.map.value = r.map, n(r.map, e.mapTransform)), r.alphaMap && (e.alphaMap.value = r.alphaMap, n(r.alphaMap, e.alphaMapTransform)), r.bumpMap && (e.bumpMap.value = r.bumpMap, n(r.bumpMap, e.bumpMapTransform), e.bumpScale.value = r.bumpScale, r.side === 1 && (e.bumpScale.value *= -1)), r.normalMap && (e.normalMap.value = r.normalMap, n(r.normalMap, e.normalMapTransform), e.normalScale.value.copy(r.normalScale), r.side === 1 && e.normalScale.value.negate()), r.displacementMap && (e.displacementMap.value = r.displacementMap, n(r.displacementMap, e.displacementMapTransform), e.displacementScale.value = r.displacementScale, e.displacementBias.value = r.displacementBias), r.emissiveMap && (e.emissiveMap.value = r.emissiveMap, n(r.emissiveMap, e.emissiveMapTransform)), r.specularMap && (e.specularMap.value = r.specularMap, n(r.specularMap, e.specularMapTransform)), r.alphaTest > 0 && (e.alphaTest.value = r.alphaTest);
+		let i = t.get(r), a = i.envMap, o = i.envMapRotation;
+		a && (e.envMap.value = a, e.envMapRotation.value.setFromMatrix4(gs.makeRotationFromEuler(o)).transpose(), a.isCubeTexture && a.isRenderTargetTexture === !1 && e.envMapRotation.value.premultiply(_s), e.reflectivity.value = r.reflectivity, e.ior.value = r.ior, e.refractionRatio.value = r.refractionRatio), r.lightMap && (e.lightMap.value = r.lightMap, e.lightMapIntensity.value = r.lightMapIntensity, n(r.lightMap, e.lightMapTransform)), r.aoMap && (e.aoMap.value = r.aoMap, e.aoMapIntensity.value = r.aoMapIntensity, n(r.aoMap, e.aoMapTransform));
+	}
+	function o(e, t) {
+		e.diffuse.value.copy(t.color), e.opacity.value = t.opacity, t.map && (e.map.value = t.map, n(t.map, e.mapTransform));
+	}
+	function s(e, t) {
+		e.dashSize.value = t.dashSize, e.totalSize.value = t.dashSize + t.gapSize, e.scale.value = t.scale;
+	}
+	function c(e, t, r, i) {
+		e.diffuse.value.copy(t.color), e.opacity.value = t.opacity, e.size.value = t.size * r, e.scale.value = i * .5, t.map && (e.map.value = t.map, n(t.map, e.uvTransform)), t.alphaMap && (e.alphaMap.value = t.alphaMap, n(t.alphaMap, e.alphaMapTransform)), t.alphaTest > 0 && (e.alphaTest.value = t.alphaTest);
+	}
+	function l(e, t) {
+		e.diffuse.value.copy(t.color), e.opacity.value = t.opacity, e.rotation.value = t.rotation, t.map && (e.map.value = t.map, n(t.map, e.mapTransform)), t.alphaMap && (e.alphaMap.value = t.alphaMap, n(t.alphaMap, e.alphaMapTransform)), t.alphaTest > 0 && (e.alphaTest.value = t.alphaTest);
+	}
+	function u(e, t) {
+		e.specular.value.copy(t.specular), e.shininess.value = Math.max(t.shininess, 1e-4);
+	}
+	function d(e, t) {
+		t.gradientMap && (e.gradientMap.value = t.gradientMap);
+	}
+	function f(e, t) {
+		e.metalness.value = t.metalness, t.metalnessMap && (e.metalnessMap.value = t.metalnessMap, n(t.metalnessMap, e.metalnessMapTransform)), e.roughness.value = t.roughness, t.roughnessMap && (e.roughnessMap.value = t.roughnessMap, n(t.roughnessMap, e.roughnessMapTransform)), t.envMap && (e.envMapIntensity.value = t.envMapIntensity);
+	}
+	function p(e, t, r) {
+		e.ior.value = t.ior, t.sheen > 0 && (e.sheenColor.value.copy(t.sheenColor).multiplyScalar(t.sheen), e.sheenRoughness.value = t.sheenRoughness, t.sheenColorMap && (e.sheenColorMap.value = t.sheenColorMap, n(t.sheenColorMap, e.sheenColorMapTransform)), t.sheenRoughnessMap && (e.sheenRoughnessMap.value = t.sheenRoughnessMap, n(t.sheenRoughnessMap, e.sheenRoughnessMapTransform))), t.clearcoat > 0 && (e.clearcoat.value = t.clearcoat, e.clearcoatRoughness.value = t.clearcoatRoughness, t.clearcoatMap && (e.clearcoatMap.value = t.clearcoatMap, n(t.clearcoatMap, e.clearcoatMapTransform)), t.clearcoatRoughnessMap && (e.clearcoatRoughnessMap.value = t.clearcoatRoughnessMap, n(t.clearcoatRoughnessMap, e.clearcoatRoughnessMapTransform)), t.clearcoatNormalMap && (e.clearcoatNormalMap.value = t.clearcoatNormalMap, n(t.clearcoatNormalMap, e.clearcoatNormalMapTransform), e.clearcoatNormalScale.value.copy(t.clearcoatNormalScale), t.side === 1 && e.clearcoatNormalScale.value.negate())), t.dispersion > 0 && (e.dispersion.value = t.dispersion), t.iridescence > 0 && (e.iridescence.value = t.iridescence, e.iridescenceIOR.value = t.iridescenceIOR, e.iridescenceThicknessMinimum.value = t.iridescenceThicknessRange[0], e.iridescenceThicknessMaximum.value = t.iridescenceThicknessRange[1], t.iridescenceMap && (e.iridescenceMap.value = t.iridescenceMap, n(t.iridescenceMap, e.iridescenceMapTransform)), t.iridescenceThicknessMap && (e.iridescenceThicknessMap.value = t.iridescenceThicknessMap, n(t.iridescenceThicknessMap, e.iridescenceThicknessMapTransform))), t.transmission > 0 && (e.transmission.value = t.transmission, e.transmissionSamplerMap.value = r.texture, e.transmissionSamplerSize.value.set(r.width, r.height), t.transmissionMap && (e.transmissionMap.value = t.transmissionMap, n(t.transmissionMap, e.transmissionMapTransform)), e.thickness.value = t.thickness, t.thicknessMap && (e.thicknessMap.value = t.thicknessMap, n(t.thicknessMap, e.thicknessMapTransform)), e.attenuationDistance.value = t.attenuationDistance, e.attenuationColor.value.copy(t.attenuationColor)), t.anisotropy > 0 && (e.anisotropyVector.value.set(t.anisotropy * Math.cos(t.anisotropyRotation), t.anisotropy * Math.sin(t.anisotropyRotation)), t.anisotropyMap && (e.anisotropyMap.value = t.anisotropyMap, n(t.anisotropyMap, e.anisotropyMapTransform))), e.specularIntensity.value = t.specularIntensity, e.specularColor.value.copy(t.specularColor), t.specularColorMap && (e.specularColorMap.value = t.specularColorMap, n(t.specularColorMap, e.specularColorMapTransform)), t.specularIntensityMap && (e.specularIntensityMap.value = t.specularIntensityMap, n(t.specularIntensityMap, e.specularIntensityMapTransform));
+	}
+	function m(e, t) {
+		t.matcap && (e.matcap.value = t.matcap);
+	}
+	function h(e, n) {
+		let r = t.get(n).light;
+		e.referencePosition.value.setFromMatrixPosition(r.matrixWorld), e.nearDistance.value = r.shadow.camera.near, e.farDistance.value = r.shadow.camera.far;
+	}
+	return {
+		refreshFogUniforms: r,
+		refreshMaterialUniforms: i
+	};
+}
+function ys(e, t, n, r) {
+	let i = {}, a = {}, o = [], s = e.getParameter(e.MAX_UNIFORM_BUFFER_BINDINGS);
+	function c(e, t) {
+		let n = t.program;
+		r.uniformBlockBinding(e, n);
+	}
+	function l(e, n) {
+		let o = i[e.id];
+		o === void 0 && (g(e), o = u(e), i[e.id] = o, e.addEventListener("dispose", v));
+		let s = n.program;
+		r.updateUBOMapping(e, s);
+		let c = t.render.frame;
+		a[e.id] !== c && (f(e), a[e.id] = c);
+	}
+	function u(t) {
+		let n = d();
+		t.__bindingPointIndex = n;
+		let r = e.createBuffer(), i = t.__size, a = t.usage;
+		return e.bindBuffer(e.UNIFORM_BUFFER, r), e.bufferData(e.UNIFORM_BUFFER, i, a), e.bindBuffer(e.UNIFORM_BUFFER, null), e.bindBufferBase(e.UNIFORM_BUFFER, n, r), r;
+	}
+	function d() {
+		for (let e = 0; e < s; e++) if (o.indexOf(e) === -1) return o.push(e), e;
+		return I("WebGLRenderer: Maximum number of simultaneously usable uniforms groups reached."), 0;
+	}
+	function f(t) {
+		let n = i[t.id], r = t.uniforms, a = t.__cache;
+		e.bindBuffer(e.UNIFORM_BUFFER, n);
+		for (let e = 0, t = r.length; e < t; e++) {
+			let t = r[e];
+			if (Array.isArray(t)) for (let n = 0, r = t.length; n < r; n++) p(t[n], e, n, a);
+			else p(t, e, 0, a);
+		}
+		e.bindBuffer(e.UNIFORM_BUFFER, null);
+	}
+	function p(t, n, r, i) {
+		if (h(t, n, r, i) === !0) {
+			let n = t.__offset, r = t.value;
+			if (Array.isArray(r)) {
+				let e = 0;
+				for (let n = 0; n < r.length; n++) {
+					let i = r[n], a = _(i);
+					m(i, t.__data, e), typeof i != "number" && typeof i != "boolean" && !i.isMatrix3 && !ArrayBuffer.isView(i) && (e += a.storage / Float32Array.BYTES_PER_ELEMENT);
+				}
+			} else m(r, t.__data, 0);
+			e.bufferSubData(e.UNIFORM_BUFFER, n, t.__data);
+		}
+	}
+	function m(e, t, n) {
+		typeof e == "number" || typeof e == "boolean" ? t[0] = e : e.isMatrix3 ? (t[0] = e.elements[0], t[1] = e.elements[1], t[2] = e.elements[2], t[3] = 0, t[4] = e.elements[3], t[5] = e.elements[4], t[6] = e.elements[5], t[7] = 0, t[8] = e.elements[6], t[9] = e.elements[7], t[10] = e.elements[8], t[11] = 0) : ArrayBuffer.isView(e) ? t.set(new e.constructor(e.buffer, e.byteOffset, t.length)) : e.toArray(t, n);
+	}
+	function h(e, t, n, r) {
+		let i = e.value, a = t + "_" + n;
+		if (r[a] === void 0) return typeof i == "number" || typeof i == "boolean" ? r[a] = i : ArrayBuffer.isView(i) ? r[a] = i.slice() : r[a] = i.clone(), !0;
+		{
+			let e = r[a];
+			if (typeof i == "number" || typeof i == "boolean") {
+				if (e !== i) return r[a] = i, !0;
+			} else if (ArrayBuffer.isView(i)) return !0;
+			else if (e.equals(i) === !1) return e.copy(i), !0;
+		}
+		return !1;
+	}
+	function g(e) {
+		let t = e.uniforms, n = 0;
+		for (let e = 0, r = t.length; e < r; e++) {
+			let r = Array.isArray(t[e]) ? t[e] : [t[e]];
+			for (let e = 0, t = r.length; e < t; e++) {
+				let t = r[e], i = Array.isArray(t.value) ? t.value : [t.value];
+				for (let e = 0, r = i.length; e < r; e++) {
+					let r = i[e], a = _(r), o = n % 16, s = o % a.boundary, c = o + s;
+					n += s, c !== 0 && 16 - c < a.storage && (n += 16 - c), t.__data = new Float32Array(a.storage / Float32Array.BYTES_PER_ELEMENT), t.__offset = n, n += a.storage;
+				}
+			}
+		}
+		let r = n % 16;
+		return r > 0 && (n += 16 - r), e.__size = n, e.__cache = {}, this;
+	}
+	function _(e) {
+		let t = {
+			boundary: 0,
+			storage: 0
+		};
+		return typeof e == "number" || typeof e == "boolean" ? (t.boundary = 4, t.storage = 4) : e.isVector2 ? (t.boundary = 8, t.storage = 8) : e.isVector3 || e.isColor ? (t.boundary = 16, t.storage = 12) : e.isVector4 ? (t.boundary = 16, t.storage = 16) : e.isMatrix3 ? (t.boundary = 48, t.storage = 48) : e.isMatrix4 ? (t.boundary = 64, t.storage = 64) : e.isTexture ? F("WebGLRenderer: Texture samplers can not be part of an uniforms group.") : ArrayBuffer.isView(e) ? (t.boundary = 16, t.storage = e.byteLength) : F("WebGLRenderer: Unsupported uniform value type.", e), t;
+	}
+	function v(t) {
+		let n = t.target;
+		n.removeEventListener("dispose", v);
+		let r = o.indexOf(n.__bindingPointIndex);
+		o.splice(r, 1), e.deleteBuffer(i[n.id]), delete i[n.id], delete a[n.id];
+	}
+	function y() {
+		for (let t in i) e.deleteBuffer(i[t]);
+		o = [], i = {}, a = {};
+	}
+	return {
+		bind: c,
+		update: l,
+		dispose: y
+	};
+}
+var bs = new Uint16Array([
+	12469,
+	15057,
+	12620,
+	14925,
+	13266,
+	14620,
+	13807,
+	14376,
+	14323,
+	13990,
+	14545,
+	13625,
+	14713,
+	13328,
+	14840,
+	12882,
+	14931,
+	12528,
+	14996,
+	12233,
+	15039,
+	11829,
+	15066,
+	11525,
+	15080,
+	11295,
+	15085,
+	10976,
+	15082,
+	10705,
+	15073,
+	10495,
+	13880,
+	14564,
+	13898,
+	14542,
+	13977,
+	14430,
+	14158,
+	14124,
+	14393,
+	13732,
+	14556,
+	13410,
+	14702,
+	12996,
+	14814,
+	12596,
+	14891,
+	12291,
+	14937,
+	11834,
+	14957,
+	11489,
+	14958,
+	11194,
+	14943,
+	10803,
+	14921,
+	10506,
+	14893,
+	10278,
+	14858,
+	9960,
+	14484,
+	14039,
+	14487,
+	14025,
+	14499,
+	13941,
+	14524,
+	13740,
+	14574,
+	13468,
+	14654,
+	13106,
+	14743,
+	12678,
+	14818,
+	12344,
+	14867,
+	11893,
+	14889,
+	11509,
+	14893,
+	11180,
+	14881,
+	10751,
+	14852,
+	10428,
+	14812,
+	10128,
+	14765,
+	9754,
+	14712,
+	9466,
+	14764,
+	13480,
+	14764,
+	13475,
+	14766,
+	13440,
+	14766,
+	13347,
+	14769,
+	13070,
+	14786,
+	12713,
+	14816,
+	12387,
+	14844,
+	11957,
+	14860,
+	11549,
+	14868,
+	11215,
+	14855,
+	10751,
+	14825,
+	10403,
+	14782,
+	10044,
+	14729,
+	9651,
+	14666,
+	9352,
+	14599,
+	9029,
+	14967,
+	12835,
+	14966,
+	12831,
+	14963,
+	12804,
+	14954,
+	12723,
+	14936,
+	12564,
+	14917,
+	12347,
+	14900,
+	11958,
+	14886,
+	11569,
+	14878,
+	11247,
+	14859,
+	10765,
+	14828,
+	10401,
+	14784,
+	10011,
+	14727,
+	9600,
+	14660,
+	9289,
+	14586,
+	8893,
+	14508,
+	8533,
+	15111,
+	12234,
+	15110,
+	12234,
+	15104,
+	12216,
+	15092,
+	12156,
+	15067,
+	12010,
+	15028,
+	11776,
+	14981,
+	11500,
+	14942,
+	11205,
+	14902,
+	10752,
+	14861,
+	10393,
+	14812,
+	9991,
+	14752,
+	9570,
+	14682,
+	9252,
+	14603,
+	8808,
+	14519,
+	8445,
+	14431,
+	8145,
+	15209,
+	11449,
+	15208,
+	11451,
+	15202,
+	11451,
+	15190,
+	11438,
+	15163,
+	11384,
+	15117,
+	11274,
+	15055,
+	10979,
+	14994,
+	10648,
+	14932,
+	10343,
+	14871,
+	9936,
+	14803,
+	9532,
+	14729,
+	9218,
+	14645,
+	8742,
+	14556,
+	8381,
+	14461,
+	8020,
+	14365,
+	7603,
+	15273,
+	10603,
+	15272,
+	10607,
+	15267,
+	10619,
+	15256,
+	10631,
+	15231,
+	10614,
+	15182,
+	10535,
+	15118,
+	10389,
+	15042,
+	10167,
+	14963,
+	9787,
+	14883,
+	9447,
+	14800,
+	9115,
+	14710,
+	8665,
+	14615,
+	8318,
+	14514,
+	7911,
+	14411,
+	7507,
+	14279,
+	7198,
+	15314,
+	9675,
+	15313,
+	9683,
+	15309,
+	9712,
+	15298,
+	9759,
+	15277,
+	9797,
+	15229,
+	9773,
+	15166,
+	9668,
+	15084,
+	9487,
+	14995,
+	9274,
+	14898,
+	8910,
+	14800,
+	8539,
+	14697,
+	8234,
+	14590,
+	7790,
+	14479,
+	7409,
+	14367,
+	7067,
+	14178,
+	6621,
+	15337,
+	8619,
+	15337,
+	8631,
+	15333,
+	8677,
+	15325,
+	8769,
+	15305,
+	8871,
+	15264,
+	8940,
+	15202,
+	8909,
+	15119,
+	8775,
+	15022,
+	8565,
+	14916,
+	8328,
+	14804,
+	8009,
+	14688,
+	7614,
+	14569,
+	7287,
+	14448,
+	6888,
+	14321,
+	6483,
+	14088,
+	6171,
+	15350,
+	7402,
+	15350,
+	7419,
+	15347,
+	7480,
+	15340,
+	7613,
+	15322,
+	7804,
+	15287,
+	7973,
+	15229,
+	8057,
+	15148,
+	8012,
+	15046,
+	7846,
+	14933,
+	7611,
+	14810,
+	7357,
+	14682,
+	7069,
+	14552,
+	6656,
+	14421,
+	6316,
+	14251,
+	5948,
+	14007,
+	5528,
+	15356,
+	5942,
+	15356,
+	5977,
+	15353,
+	6119,
+	15348,
+	6294,
+	15332,
+	6551,
+	15302,
+	6824,
+	15249,
+	7044,
+	15171,
+	7122,
+	15070,
+	7050,
+	14949,
+	6861,
+	14818,
+	6611,
+	14679,
+	6349,
+	14538,
+	6067,
+	14398,
+	5651,
+	14189,
+	5311,
+	13935,
+	4958,
+	15359,
+	4123,
+	15359,
+	4153,
+	15356,
+	4296,
+	15353,
+	4646,
+	15338,
+	5160,
+	15311,
+	5508,
+	15263,
+	5829,
+	15188,
+	6042,
+	15088,
+	6094,
+	14966,
+	6001,
+	14826,
+	5796,
+	14678,
+	5543,
+	14527,
+	5287,
+	14377,
+	4985,
+	14133,
+	4586,
+	13869,
+	4257,
+	15360,
+	1563,
+	15360,
+	1642,
+	15358,
+	2076,
+	15354,
+	2636,
+	15341,
+	3350,
+	15317,
+	4019,
+	15273,
+	4429,
+	15203,
+	4732,
+	15105,
+	4911,
+	14981,
+	4932,
+	14836,
+	4818,
+	14679,
+	4621,
+	14517,
+	4386,
+	14359,
+	4156,
+	14083,
+	3795,
+	13808,
+	3437,
+	15360,
+	122,
+	15360,
+	137,
+	15358,
+	285,
+	15355,
+	636,
+	15344,
+	1274,
+	15322,
+	2177,
+	15281,
+	2765,
+	15215,
+	3223,
+	15120,
+	3451,
+	14995,
+	3569,
+	14846,
+	3567,
+	14681,
+	3466,
+	14511,
+	3305,
+	14344,
+	3121,
+	14037,
+	2800,
+	13753,
+	2467,
+	15360,
+	0,
+	15360,
+	1,
+	15359,
+	21,
+	15355,
+	89,
+	15346,
+	253,
+	15325,
+	479,
+	15287,
+	796,
+	15225,
+	1148,
+	15133,
+	1492,
+	15008,
+	1749,
+	14856,
+	1882,
+	14685,
+	1886,
+	14506,
+	1783,
+	14324,
+	1608,
+	13996,
+	1398,
+	13702,
+	1183
+]), xs = null;
+function Ss() {
+	return xs === null && (xs = new Fn(bs, 16, 16, y, u), xs.name = "DFG_LUT", xs.minFilter = i, xs.magFilter = i, xs.wrapS = t, xs.wrapT = t, xs.generateMipmaps = !1, xs.needsUpdate = !0), xs;
+}
+var Cs = class {
+	constructor(e = {}) {
+		let { canvas: t = ie(), context: n = null, depth: r = !0, stencil: i = !1, alpha: l = !1, antialias: m = !1, premultipliedAlpha: h = !0, preserveDrawingBuffer: g = !1, powerPreference: _ = "default", failIfMajorPerformanceCaveat: y = !1, reversedDepthBuffer: S = !1, outputBufferType: C = o } = e;
+		this.isWebGLRenderer = !0;
+		let w;
+		if (n !== null) {
+			if (typeof WebGLRenderingContext < "u" && n instanceof WebGLRenderingContext) throw Error("THREE.WebGLRenderer: WebGL 1 is not supported since r163.");
+			w = n.getContextAttributes().alpha;
+		} else w = l;
+		let T = C, E = /* @__PURE__ */ new Set([
+			x,
+			b,
+			v
+		]), D = /* @__PURE__ */ new Set([
+			o,
+			c,
+			s,
+			p,
+			d,
+			f
+		]), O = /* @__PURE__ */ new Uint32Array(4), A = /* @__PURE__ */ new Int32Array(4), ee = new W(), j = null, M = null, ne = [], N = [], re = null;
+		this.domElement = t, this.debug = {
+			checkShaderErrors: !0,
+			onShaderError: null
+		}, this.autoClear = !0, this.autoClearColor = !0, this.autoClearDepth = !0, this.autoClearStencil = !0, this.sortObjects = !0, this.clippingPlanes = [], this.localClippingEnabled = !1, this.toneMapping = 0, this.toneMappingExposure = 1, this.transmissionResolutionScale = 1;
+		let P = this, oe = !1, L = null, ce = null, R = null, z = null;
+		this._outputColorSpace = k;
+		let le = 0, ue = 0, B = null, V = -1, de = null, fe = new je(), pe = new je(), H = null, U = new Z(0), me = 0, he = t.width, ge = t.height, G = 1, _e = null, ve = null, ye = new je(0, 0, he, ge), be = new je(0, 0, he, ge), xe = !1, Se = new Qn(), Ce = !1, we = !1, Te = new Fe(), Ee = new W(), De = new je(), Oe = {
+			background: null,
+			fog: null,
+			environment: null,
+			overrideMaterial: null,
+			isScene: !0
+		}, ke = !1;
+		function Ae() {
+			return B === null ? G : 1;
+		}
+		let q = n;
+		function Ne(e, n) {
+			return t.getContext(e, n);
+		}
+		try {
+			let e = {
+				alpha: !0,
+				depth: r,
+				stencil: i,
+				antialias: m,
+				premultipliedAlpha: h,
+				preserveDrawingBuffer: g,
+				powerPreference: _,
+				failIfMajorPerformanceCaveat: y
+			};
+			if ("setAttribute" in t && t.setAttribute("data-engine", "three.js r185"), t.addEventListener("webglcontextlost", rt, !1), t.addEventListener("webglcontextrestored", it, !1), t.addEventListener("webglcontextcreationerror", at, !1), q === null) {
+				let t = "webgl2";
+				if (q = Ne(t, e), q === null) throw Ne(t) ? Error("THREE.WebGLRenderer: Error creating WebGL context with your selected attributes.") : Error("THREE.WebGLRenderer: Error creating WebGL context.");
+			}
+		} catch (e) {
+			throw I("WebGLRenderer: " + e.message), e;
+		}
+		let Pe, Ie, J, Le, Y, X, Re, ze, Be, Ve, He, Ue, We, Ge, Ke, qe, Je, Ye, Xe, Ze, Qe, $e, et;
+		function tt() {
+			Pe = new Bi(q), Pe.init(), Qe = new ds(q, Pe), Ie = new gi(q, Pe, e, Qe), J = new ls(q, Pe), Ie.reversedDepthBuffer && S && J.buffers.depth.setReversed(!0), ce = q.createFramebuffer(), R = q.createFramebuffer(), z = q.createFramebuffer(), Le = new Ui(q), Y = new Uo(), X = new us(q, Pe, J, Y, Ie, Qe, Le), Re = new zi(P), ze = new ci(q), $e = new mi(q, ze), Be = new Vi(q, ze, Le, $e), Ve = new Gi(q, Be, ze, $e, Le), Ye = new Wi(q, Ie, X), Ke = new _i(Y), He = new Ho(P, Re, Pe, Ie, $e, Ke), Ue = new vs(P, Y), We = new qo(), Ge = new es(Pe), Je = new pi(P, Re, J, Ve, w, h), qe = new cs(P, Ve, Ie), et = new ys(q, Le, Ie, J), Xe = new hi(q, Pe, Le), Ze = new Hi(q, Pe, Le), Le.programs = He.programs, P.capabilities = Ie, P.extensions = Pe, P.properties = Y, P.renderLists = We, P.shadowMap = qe, P.state = J, P.info = Le;
+		}
+		tt(), T !== 1009 && (re = new qi(T, t.width, t.height, m, r, i));
+		let nt = new hs(P, q);
+		this.xr = nt, this.getContext = function() {
+			return q;
+		}, this.getContextAttributes = function() {
+			return q.getContextAttributes();
+		}, this.forceContextLoss = function() {
+			let e = Pe.get("WEBGL_lose_context");
+			e && e.loseContext();
+		}, this.forceContextRestore = function() {
+			let e = Pe.get("WEBGL_lose_context");
+			e && e.restoreContext();
+		}, this.getPixelRatio = function() {
+			return G;
+		}, this.setPixelRatio = function(e) {
+			e !== void 0 && (G = e, this.setSize(he, ge, !1));
+		}, this.getSize = function(e) {
+			return e.set(he, ge);
+		}, this.setSize = function(e, n, r = !0) {
+			if (nt.isPresenting) {
+				F("WebGLRenderer: Can't change size while VR device is presenting.");
+				return;
+			}
+			he = e, ge = n, t.width = Math.floor(e * G), t.height = Math.floor(n * G), r === !0 && (t.style.width = e + "px", t.style.height = n + "px"), re !== null && re.setSize(t.width, t.height), this.setViewport(0, 0, e, n);
+		}, this.getDrawingBufferSize = function(e) {
+			return e.set(he * G, ge * G).floor();
+		}, this.setDrawingBufferSize = function(e, n, r) {
+			he = e, ge = n, G = r, t.width = Math.floor(e * r), t.height = Math.floor(n * r), this.setViewport(0, 0, e, n);
+		}, this.setEffects = function(e) {
+			if (T === 1009) {
+				I("WebGLRenderer: setEffects() requires outputBufferType set to HalfFloatType or FloatType.");
+				return;
+			}
+			if (e) {
+				for (let t = 0; t < e.length; t++) if (e[t].isOutputPass === !0) {
+					F("WebGLRenderer: OutputPass is not needed in setEffects(). Tone mapping and color space conversion are applied automatically.");
+					break;
+				}
+			}
+			re.setEffects(e || []);
+		}, this.getCurrentViewport = function(e) {
+			return e.copy(fe);
+		}, this.getViewport = function(e) {
+			return e.copy(ye);
+		}, this.setViewport = function(e, t, n, r) {
+			e.isVector4 ? ye.set(e.x, e.y, e.z, e.w) : ye.set(e, t, n, r), J.viewport(fe.copy(ye).multiplyScalar(G).round());
+		}, this.getScissor = function(e) {
+			return e.copy(be);
+		}, this.setScissor = function(e, t, n, r) {
+			e.isVector4 ? be.set(e.x, e.y, e.z, e.w) : be.set(e, t, n, r), J.scissor(pe.copy(be).multiplyScalar(G).round());
+		}, this.getScissorTest = function() {
+			return xe;
+		}, this.setScissorTest = function(e) {
+			J.setScissorTest(xe = e);
+		}, this.setOpaqueSort = function(e) {
+			_e = e;
+		}, this.setTransparentSort = function(e) {
+			ve = e;
+		}, this.getClearColor = function(e) {
+			return e.copy(Je.getClearColor());
+		}, this.setClearColor = function() {
+			Je.setClearColor(...arguments);
+		}, this.getClearAlpha = function() {
+			return Je.getClearAlpha();
+		}, this.setClearAlpha = function() {
+			Je.setClearAlpha(...arguments);
+		}, this.clear = function(e = !0, t = !0, n = !0) {
+			let r = 0;
+			if (e) {
+				let e = !1;
+				if (B !== null) {
+					let t = B.texture.format;
+					e = E.has(t);
+				}
+				if (e) {
+					let e = B.texture.type, t = D.has(e), n = Je.getClearColor(), r = Je.getClearAlpha(), i = n.r, a = n.g, o = n.b;
+					t ? (O[0] = i, O[1] = a, O[2] = o, O[3] = r, q.clearBufferuiv(q.COLOR, 0, O)) : (A[0] = i, A[1] = a, A[2] = o, A[3] = r, q.clearBufferiv(q.COLOR, 0, A));
+				} else r |= q.COLOR_BUFFER_BIT;
+			}
+			t && (r |= q.DEPTH_BUFFER_BIT, this.state.buffers.depth.setMask(!0)), n && (r |= q.STENCIL_BUFFER_BIT, this.state.buffers.stencil.setMask(4294967295)), r !== 0 && q.clear(r);
+		}, this.clearColor = function() {
+			this.clear(!0, !1, !1);
+		}, this.clearDepth = function() {
+			this.clear(!1, !0, !1);
+		}, this.clearStencil = function() {
+			this.clear(!1, !1, !0);
+		}, this.setNodesHandler = function(e) {
+			e.setRenderer(this), L = e;
+		}, this.dispose = function() {
+			t.removeEventListener("webglcontextlost", rt, !1), t.removeEventListener("webglcontextrestored", it, !1), t.removeEventListener("webglcontextcreationerror", at, !1), Je.dispose(), We.dispose(), Ge.dispose(), Y.dispose(), Re.dispose(), Ve.dispose(), $e.dispose(), et.dispose(), He.dispose(), nt.dispose(), nt.removeEventListener("sessionstart", ft), nt.removeEventListener("sessionend", pt), mt.stop();
+		};
+		function rt(e) {
+			e.preventDefault(), ae("WebGLRenderer: Context Lost."), oe = !0;
+		}
+		function it() {
+			ae("WebGLRenderer: Context Restored."), oe = !1;
+			let e = Le.autoReset, t = qe.enabled, n = qe.autoUpdate, r = qe.needsUpdate, i = qe.type;
+			tt(), Le.autoReset = e, qe.enabled = t, qe.autoUpdate = n, qe.needsUpdate = r, qe.type = i;
+		}
+		function at(e) {
+			I("WebGLRenderer: A WebGL context could not be created. Reason: ", e.statusMessage);
+		}
+		function ot(e) {
+			let t = e.target;
+			t.removeEventListener("dispose", ot), st(t);
+		}
+		function st(e) {
+			ct(e), Y.remove(e);
+		}
+		function ct(e) {
+			let t = Y.get(e).programs;
+			t !== void 0 && (t.forEach(function(e) {
+				He.releaseProgram(e);
+			}), e.isShaderMaterial && He.releaseShaderCache(e));
+		}
+		this.renderBufferDirect = function(e, t, n, r, i, a) {
+			t === null && (t = Oe);
+			let o = i.isMesh && i.matrixWorld.determinantAffine() < 0, s = wt(e, t, n, r, i);
+			J.setMaterial(r, o);
+			let c = n.index, l = 1;
+			if (r.wireframe === !0) {
+				if (c = Be.getWireframeAttribute(n), c === void 0) return;
+				l = 2;
+			}
+			let u = n.drawRange, d = n.attributes.position, f = u.start * l, p = (u.start + u.count) * l;
+			a !== null && (f = Math.max(f, a.start * l), p = Math.min(p, (a.start + a.count) * l)), c === null ? d != null && (f = Math.max(f, 0), p = Math.min(p, d.count)) : (f = Math.max(f, 0), p = Math.min(p, c.count));
+			let m = p - f;
+			if (m < 0 || m === Infinity) return;
+			$e.setup(i, r, s, n, c);
+			let h, g = Xe;
+			if (c !== null && (h = ze.get(c), g = Ze, g.setIndex(h)), i.isMesh) r.wireframe === !0 ? (J.setLineWidth(r.wireframeLinewidth * Ae()), g.setMode(q.LINES)) : g.setMode(q.TRIANGLES);
+			else if (i.isLine) {
+				let e = r.linewidth;
+				e === void 0 && (e = 1), J.setLineWidth(e * Ae()), i.isLineSegments ? g.setMode(q.LINES) : i.isLineLoop ? g.setMode(q.LINE_LOOP) : g.setMode(q.LINE_STRIP);
+			} else i.isPoints ? g.setMode(q.POINTS) : i.isSprite && g.setMode(q.TRIANGLES);
+			if (i.isBatchedMesh) if (Pe.get("WEBGL_multi_draw")) g.renderMultiDraw(i._multiDrawStarts, i._multiDrawCounts, i._multiDrawCount);
+			else {
+				let e = i._multiDrawStarts, t = i._multiDrawCounts, n = i._multiDrawCount, a = c ? ze.get(c).bytesPerElement : 1, o = Y.get(r).currentProgram.getUniforms();
+				for (let r = 0; r < n; r++) o.setValue(q, "_gl_DrawID", r), g.render(e[r] / a, t[r]);
+			}
+			else if (i.isInstancedMesh) g.renderInstances(f, m, i.count);
+			else if (n.isInstancedBufferGeometry) {
+				let e = n._maxInstanceCount === void 0 ? Infinity : n._maxInstanceCount, t = Math.min(n.instanceCount, e);
+				g.renderInstances(f, m, t);
+			} else g.render(f, m);
+		};
+		function lt(e, t, n) {
+			e.transparent === !0 && e.side === 2 && e.forceSinglePass === !1 ? (e.side = 1, e.needsUpdate = !0, bt(e, t, n), e.side = 0, e.needsUpdate = !0, bt(e, t, n), e.side = 2) : bt(e, t, n);
+		}
+		this.compile = function(e, t, n = null) {
+			n === null && (n = e), M = Ge.get(n), M.init(t), N.push(M), n.traverseVisible(function(e) {
+				e.isLight && e.layers.test(t.layers) && (M.pushLight(e), e.castShadow && M.pushShadow(e));
+			}), e !== n && e.traverseVisible(function(e) {
+				e.isLight && e.layers.test(t.layers) && (M.pushLight(e), e.castShadow && M.pushShadow(e));
+			}), M.setupLights();
+			let r = /* @__PURE__ */ new Set();
+			return e.traverse(function(e) {
+				if (!(e.isMesh || e.isPoints || e.isLine || e.isSprite)) return;
+				let t = e.material;
+				if (t) if (Array.isArray(t)) for (let i = 0; i < t.length; i++) {
+					let a = t[i];
+					lt(a, n, e), r.add(a);
+				}
+				else lt(t, n, e), r.add(t);
+			}), M = N.pop(), r;
+		}, this.compileAsync = function(e, t, n = null) {
+			let r = this.compile(e, t, n);
+			return new Promise((t) => {
+				function n() {
+					if (r.forEach(function(e) {
+						Y.get(e).currentProgram.isReady() && r.delete(e);
+					}), r.size === 0) {
+						t(e);
+						return;
+					}
+					setTimeout(n, 10);
+				}
+				Pe.get("KHR_parallel_shader_compile") === null ? setTimeout(n, 10) : n();
+			});
+		};
+		let ut = null;
+		function dt(e) {
+			ut && ut(e);
+		}
+		function ft() {
+			mt.stop();
+		}
+		function pt() {
+			mt.start();
+		}
+		let mt = new si();
+		mt.setAnimationLoop(dt), typeof self < "u" && mt.setContext(self), this.setAnimationLoop = function(e) {
+			ut = e, nt.setAnimationLoop(e), e === null ? mt.stop() : mt.start();
+		}, nt.addEventListener("sessionstart", ft), nt.addEventListener("sessionend", pt), this.render = function(e, t) {
+			if (t !== void 0 && t.isCamera !== !0) {
+				I("WebGLRenderer.render: camera is not an instance of THREE.Camera.");
+				return;
+			}
+			if (oe === !0) return;
+			L !== null && L.renderStart(e, t);
+			let n = nt.enabled === !0 && nt.isPresenting === !0, r = re !== null && (B === null || n) && re.begin(P, B);
+			if (e.matrixWorldAutoUpdate === !0 && e.updateMatrixWorld(), t.parent === null && t.matrixWorldAutoUpdate === !0 && t.updateMatrixWorld(), nt.enabled === !0 && nt.isPresenting === !0 && (re === null || re.isCompositing() === !1) && (nt.cameraAutoUpdate === !0 && nt.updateCamera(t), t = nt.getCamera()), e.isScene === !0 && e.onBeforeRender(P, e, t, B), M = Ge.get(e, N.length), M.init(t), M.state.textureUnits = X.getTextureUnits(), N.push(M), Te.multiplyMatrices(t.projectionMatrix, t.matrixWorldInverse), Se.setFromProjectionMatrix(Te, te, t.reversedDepth), we = this.localClippingEnabled, Ce = Ke.init(this.clippingPlanes, we), j = We.get(e, ne.length), j.init(), ne.push(j), nt.enabled === !0 && nt.isPresenting === !0) {
+				let e = P.xr.getDepthSensingMesh();
+				e !== null && ht(e, t, -Infinity, P.sortObjects);
+			}
+			ht(e, t, 0, P.sortObjects), j.finish(), P.sortObjects === !0 && j.sort(_e, ve, t.reversedDepth), ke = nt.enabled === !1 || nt.isPresenting === !1 || nt.hasDepthSensing() === !1, ke && Je.addToRenderList(j, e), this.info.render.frame++, this.info.autoReset === !0 && this.info.reset(), Ce === !0 && Ke.beginShadows();
+			let i = M.state.shadowsArray;
+			if (qe.render(i, e, t), Ce === !0 && Ke.endShadows(), (r && re.hasRenderPass()) === !1) {
+				let n = j.opaque, r = j.transmissive;
+				if (M.setupLights(), t.isArrayCamera) {
+					let i = t.cameras;
+					if (r.length > 0) for (let t = 0, a = i.length; t < a; t++) {
+						let a = i[t];
+						_t(n, r, e, a);
+					}
+					ke && Je.render(e);
+					for (let t = 0, n = i.length; t < n; t++) {
+						let n = i[t];
+						gt(j, e, n, n.viewport);
+					}
+				} else r.length > 0 && _t(n, r, e, t), ke && Je.render(e), gt(j, e, t);
+			}
+			B !== null && ue === 0 && (X.updateMultisampleRenderTarget(B), X.updateRenderTargetMipmap(B)), r && re.end(P), e.isScene === !0 && e.onAfterRender(P, e, t), $e.resetDefaultState(), V = -1, de = null, N.pop(), N.length > 0 ? (M = N[N.length - 1], X.setTextureUnits(M.state.textureUnits), Ce === !0 && Ke.setGlobalState(P.clippingPlanes, M.state.camera)) : M = null, ne.pop(), j = ne.length > 0 ? ne[ne.length - 1] : null, L !== null && L.renderEnd();
+		};
+		function ht(e, t, n, r) {
+			if (e.visible === !1) return;
+			if (e.layers.test(t.layers)) {
+				if (e.isGroup) n = e.renderOrder;
+				else if (e.isLOD) e.autoUpdate === !0 && e.update(t);
+				else if (e.isLightProbeGrid) M.pushLightProbeGrid(e);
+				else if (e.isLight) M.pushLight(e), e.castShadow && M.pushShadow(e);
+				else if (e.isSprite) {
+					if (!e.frustumCulled || Se.intersectsSprite(e)) {
+						r && De.setFromMatrixPosition(e.matrixWorld).applyMatrix4(Te);
+						let t = Ve.update(e), i = e.material;
+						i.visible && j.push(e, t, i, n, De.z, null);
+					}
+				} else if ((e.isMesh || e.isLine || e.isPoints) && (!e.frustumCulled || Se.intersectsObject(e))) {
+					let t = Ve.update(e), i = e.material;
+					if (r && (e.boundingSphere === void 0 ? (t.boundingSphere === null && t.computeBoundingSphere(), De.copy(t.boundingSphere.center)) : (e.boundingSphere === null && e.computeBoundingSphere(), De.copy(e.boundingSphere.center)), De.applyMatrix4(e.matrixWorld).applyMatrix4(Te)), Array.isArray(i)) {
+						let r = t.groups;
+						for (let a = 0, o = r.length; a < o; a++) {
+							let o = r[a], s = i[o.materialIndex];
+							s && s.visible && j.push(e, t, s, n, De.z, o);
+						}
+					} else i.visible && j.push(e, t, i, n, De.z, null);
+				}
+			}
+			let i = e.children;
+			for (let e = 0, a = i.length; e < a; e++) ht(i[e], t, n, r);
+		}
+		function gt(e, t, n, r) {
+			let { opaque: i, transmissive: a, transparent: o } = e;
+			M.setupLightsView(n), Ce === !0 && Ke.setGlobalState(P.clippingPlanes, n), r && J.viewport(fe.copy(r)), i.length > 0 && vt(i, t, n), a.length > 0 && vt(a, t, n), o.length > 0 && vt(o, t, n), J.buffers.depth.setTest(!0), J.buffers.depth.setMask(!0), J.buffers.color.setMask(!0), J.setPolygonOffset(!1);
+		}
+		function _t(e, t, n, r) {
+			if ((n.isScene === !0 ? n.overrideMaterial : null) !== null) return;
+			if (M.state.transmissionRenderTarget[r.id] === void 0) {
+				let e = Pe.has("EXT_color_buffer_half_float") || Pe.has("EXT_color_buffer_float");
+				M.state.transmissionRenderTarget[r.id] = new Me(1, 1, {
+					generateMipmaps: !0,
+					type: e ? u : o,
+					minFilter: a,
+					samples: Math.max(4, Ie.samples),
+					stencilBuffer: i,
+					resolveDepthBuffer: !1,
+					resolveStencilBuffer: !1,
+					colorSpace: K.workingColorSpace
+				});
+			}
+			let s = M.state.transmissionRenderTarget[r.id], c = r.viewport || fe;
+			s.setSize(c.z * P.transmissionResolutionScale, c.w * P.transmissionResolutionScale);
+			let l = P.getRenderTarget(), d = P.getActiveCubeFace(), f = P.getActiveMipmapLevel();
+			P.setRenderTarget(s), P.getClearColor(U), me = P.getClearAlpha(), me < 1 && P.setClearColor(16777215, .5), P.clear(), ke && Je.render(n);
+			let p = P.toneMapping;
+			P.toneMapping = 0;
+			let m = r.viewport;
+			if (r.viewport !== void 0 && (r.viewport = void 0), M.setupLightsView(r), Ce === !0 && Ke.setGlobalState(P.clippingPlanes, r), vt(e, n, r), X.updateMultisampleRenderTarget(s), X.updateRenderTargetMipmap(s), Pe.has("WEBGL_multisampled_render_to_texture") === !1) {
+				let e = !1;
+				for (let i = 0, a = t.length; i < a; i++) {
+					let { object: a, geometry: o, material: s, group: c } = t[i];
+					if (s.side === 2 && a.layers.test(r.layers)) {
+						let t = s.side;
+						s.side = 1, s.needsUpdate = !0, yt(a, n, r, o, s, c), s.side = t, s.needsUpdate = !0, e = !0;
+					}
+				}
+				e === !0 && (X.updateMultisampleRenderTarget(s), X.updateRenderTargetMipmap(s));
+			}
+			P.setRenderTarget(l, d, f), P.setClearColor(U, me), m !== void 0 && (r.viewport = m), P.toneMapping = p;
+		}
+		function vt(e, t, n) {
+			let r = t.isScene === !0 ? t.overrideMaterial : null;
+			for (let i = 0, a = e.length; i < a; i++) {
+				let a = e[i], { object: o, geometry: s, group: c } = a, l = a.material;
+				l.allowOverride === !0 && r !== null && (l = r), o.layers.test(n.layers) && yt(o, t, n, s, l, c);
+			}
+		}
+		function yt(e, t, n, r, i, a) {
+			e.onBeforeRender(P, t, n, r, i, a), e.modelViewMatrix.multiplyMatrices(n.matrixWorldInverse, e.matrixWorld), e.normalMatrix.getNormalMatrix(e.modelViewMatrix), i.onBeforeRender(P, t, n, r, e, a), i.transparent === !0 && i.side === 2 && i.forceSinglePass === !1 ? (i.side = 1, i.needsUpdate = !0, P.renderBufferDirect(n, t, r, i, e, a), i.side = 0, i.needsUpdate = !0, P.renderBufferDirect(n, t, r, i, e, a), i.side = 2) : P.renderBufferDirect(n, t, r, i, e, a), e.onAfterRender(P, t, n, r, i, a);
+		}
+		function bt(e, t, n) {
+			t.isScene !== !0 && (t = Oe);
+			let r = Y.get(e), i = M.state.lights, a = M.state.shadowsArray, o = i.state.version, s = He.getParameters(e, i.state, a, t, n, M.state.lightProbeGridArray), c = He.getProgramCacheKey(s), l = r.programs;
+			r.environment = e.isMeshStandardMaterial || e.isMeshLambertMaterial || e.isMeshPhongMaterial ? t.environment : null, r.fog = t.fog;
+			let u = e.isMeshStandardMaterial || e.isMeshLambertMaterial && !e.envMap || e.isMeshPhongMaterial && !e.envMap;
+			r.envMap = Re.get(e.envMap || r.environment, u), r.envMapRotation = r.environment !== null && e.envMap === null ? t.environmentRotation : e.envMapRotation, l === void 0 && (e.addEventListener("dispose", ot), l = /* @__PURE__ */ new Map(), r.programs = l);
+			let d = l.get(c);
+			if (d !== void 0) {
+				if (r.currentProgram === d && r.lightsStateVersion === o) return St(e, s), d;
+			} else s.uniforms = He.getUniforms(e), L !== null && e.isNodeMaterial && L.build(e, n, s), e.onBeforeCompile(s, P), d = He.acquireProgram(s, c), l.set(c, d), r.uniforms = s.uniforms;
+			let f = r.uniforms;
+			return (!e.isShaderMaterial && !e.isRawShaderMaterial || e.clipping === !0) && (f.clippingPlanes = Ke.uniform), St(e, s), r.needsLights = Et(e), r.lightsStateVersion = o, r.needsLights && (f.ambientLightColor.value = i.state.ambient, f.lightProbe.value = i.state.probe, f.directionalLights.value = i.state.directional, f.directionalLightShadows.value = i.state.directionalShadow, f.spotLights.value = i.state.spot, f.spotLightShadows.value = i.state.spotShadow, f.rectAreaLights.value = i.state.rectArea, f.ltc_1.value = i.state.rectAreaLTC1, f.ltc_2.value = i.state.rectAreaLTC2, f.pointLights.value = i.state.point, f.pointLightShadows.value = i.state.pointShadow, f.hemisphereLights.value = i.state.hemi, f.directionalShadowMatrix.value = i.state.directionalShadowMatrix, f.spotLightMatrix.value = i.state.spotLightMatrix, f.spotLightMap.value = i.state.spotLightMap, f.pointShadowMatrix.value = i.state.pointShadowMatrix), r.lightProbeGrid = M.state.lightProbeGridArray.length > 0, r.currentProgram = d, r.uniformsList = null, d;
+		}
+		function xt(e) {
+			if (e.uniformsList === null) {
+				let t = e.currentProgram.getUniforms();
+				e.uniformsList = eo.seqWithValue(t.seq, e.uniforms);
+			}
+			return e.uniformsList;
+		}
+		function St(e, t) {
+			let n = Y.get(e);
+			n.outputColorSpace = t.outputColorSpace, n.batching = t.batching, n.batchingColor = t.batchingColor, n.instancing = t.instancing, n.instancingColor = t.instancingColor, n.instancingMorph = t.instancingMorph, n.skinning = t.skinning, n.morphTargets = t.morphTargets, n.morphNormals = t.morphNormals, n.morphColors = t.morphColors, n.morphTargetsCount = t.morphTargetsCount, n.numClippingPlanes = t.numClippingPlanes, n.numIntersection = t.numClipIntersection, n.vertexAlphas = t.vertexAlphas, n.vertexTangents = t.vertexTangents, n.toneMapping = t.toneMapping;
+		}
+		function Ct(e, t) {
+			if (e.length === 0) return null;
+			if (e.length === 1) return e[0].texture === null ? null : e[0];
+			ee.setFromMatrixPosition(t.matrixWorld);
+			for (let t = 0, n = e.length; t < n; t++) {
+				let n = e[t];
+				if (n.texture !== null && n.boundingBox.containsPoint(ee)) return n;
+			}
+			return null;
+		}
+		function wt(e, t, n, r, i) {
+			t.isScene !== !0 && (t = Oe), X.resetTextureUnits();
+			let a = t.fog, o = r.isMeshStandardMaterial || r.isMeshLambertMaterial || r.isMeshPhongMaterial ? t.environment : null, s = B === null ? P.outputColorSpace : B.isXRRenderTarget === !0 ? B.texture.colorSpace : K.workingColorSpace, c = r.isMeshStandardMaterial || r.isMeshLambertMaterial && !r.envMap || r.isMeshPhongMaterial && !r.envMap, l = Re.get(r.envMap || o, c), u = r.vertexColors === !0 && !!n.attributes.color && n.attributes.color.itemSize === 4, d = !!n.attributes.tangent && (!!r.normalMap || r.anisotropy > 0), f = !!n.morphAttributes.position, p = !!n.morphAttributes.normal, m = !!n.morphAttributes.color, h = 0;
+			r.toneMapped && (B === null || B.isXRRenderTarget === !0) && (h = P.toneMapping);
+			let g = n.morphAttributes.position || n.morphAttributes.normal || n.morphAttributes.color, _ = g === void 0 ? 0 : g.length, v = Y.get(r), y = M.state.lights;
+			if (Ce === !0 && (we === !0 || e !== de)) {
+				let t = e === de && r.id === V;
+				Ke.setState(r, e, t);
+			}
+			let b = !1;
+			r.version === v.__version ? v.needsLights && v.lightsStateVersion !== y.state.version ? b = !0 : v.outputColorSpace === s ? i.isBatchedMesh && v.batching === !1 || !i.isBatchedMesh && v.batching === !0 || i.isBatchedMesh && v.batchingColor === !0 && i.colorTexture === null || i.isBatchedMesh && v.batchingColor === !1 && i.colorTexture !== null || i.isInstancedMesh && v.instancing === !1 || !i.isInstancedMesh && v.instancing === !0 || i.isSkinnedMesh && v.skinning === !1 || !i.isSkinnedMesh && v.skinning === !0 || i.isInstancedMesh && v.instancingColor === !0 && i.instanceColor === null || i.isInstancedMesh && v.instancingColor === !1 && i.instanceColor !== null || i.isInstancedMesh && v.instancingMorph === !0 && i.morphTexture === null || i.isInstancedMesh && v.instancingMorph === !1 && i.morphTexture !== null ? b = !0 : v.envMap === l ? r.fog === !0 && v.fog !== a || v.numClippingPlanes !== void 0 && (v.numClippingPlanes !== Ke.numPlanes || v.numIntersection !== Ke.numIntersection) ? b = !0 : v.vertexAlphas === u && v.vertexTangents === d && v.morphTargets === f && v.morphNormals === p && v.morphColors === m && v.toneMapping === h && v.morphTargetsCount === _ ? !!v.lightProbeGrid != M.state.lightProbeGridArray.length > 0 && (b = !0) : b = !0 : b = !0 : b = !0 : (b = !0, v.__version = r.version);
+			let x = v.currentProgram;
+			b === !0 && (x = bt(r, t, i), L && r.isNodeMaterial && L.onUpdateProgram(r, x, v));
+			let S = !1, C = !1, w = !1, T = x.getUniforms(), E = v.uniforms;
+			if (J.useProgram(x.program) && (S = !0, C = !0, w = !0), r.id !== V && (V = r.id, C = !0), v.needsLights) {
+				let e = Ct(M.state.lightProbeGridArray, i);
+				v.lightProbeGrid !== e && (v.lightProbeGrid = e, C = !0);
+			}
+			if (S || de !== e) {
+				J.buffers.depth.getReversed() && e.reversedDepth !== !0 && (e._reversedDepth = !0, e.updateProjectionMatrix()), T.setValue(q, "projectionMatrix", e.projectionMatrix), T.setValue(q, "viewMatrix", e.matrixWorldInverse);
+				let t = T.map.cameraPosition;
+				t !== void 0 && t.setValue(q, Ee.setFromMatrixPosition(e.matrixWorld)), Ie.logarithmicDepthBuffer && T.setValue(q, "logDepthBufFC", 2 / (Math.log(e.far + 1) / Math.LN2)), (r.isMeshPhongMaterial || r.isMeshToonMaterial || r.isMeshLambertMaterial || r.isMeshBasicMaterial || r.isMeshStandardMaterial || r.isShaderMaterial) && T.setValue(q, "isOrthographic", e.isOrthographicCamera === !0), de !== e && (de = e, C = !0, w = !0);
+			}
+			if (v.needsLights && (y.state.directionalShadowMap.length > 0 && T.setValue(q, "directionalShadowMap", y.state.directionalShadowMap, X), y.state.spotShadowMap.length > 0 && T.setValue(q, "spotShadowMap", y.state.spotShadowMap, X), y.state.pointShadowMap.length > 0 && T.setValue(q, "pointShadowMap", y.state.pointShadowMap, X)), i.isSkinnedMesh) {
+				T.setOptional(q, i, "bindMatrix"), T.setOptional(q, i, "bindMatrixInverse");
+				let e = i.skeleton;
+				e && (e.boneTexture === null && e.computeBoneTexture(), T.setValue(q, "boneTexture", e.boneTexture, X));
+			}
+			i.isBatchedMesh && (T.setOptional(q, i, "batchingTexture"), T.setValue(q, "batchingTexture", i._matricesTexture, X), T.setOptional(q, i, "batchingIdTexture"), T.setValue(q, "batchingIdTexture", i._indirectTexture, X), T.setOptional(q, i, "batchingColorTexture"), i._colorsTexture !== null && T.setValue(q, "batchingColorTexture", i._colorsTexture, X));
+			let D = n.morphAttributes;
+			if ((D.position !== void 0 || D.normal !== void 0 || D.color !== void 0) && Ye.update(i, n, x), (C || v.receiveShadow !== i.receiveShadow) && (v.receiveShadow = i.receiveShadow, T.setValue(q, "receiveShadow", i.receiveShadow)), (r.isMeshStandardMaterial || r.isMeshLambertMaterial || r.isMeshPhongMaterial) && r.envMap === null && t.environment !== null && (E.envMapIntensity.value = t.environmentIntensity), E.dfgLUT !== void 0 && (E.dfgLUT.value = Ss()), C) {
+				if (T.setValue(q, "toneMappingExposure", P.toneMappingExposure), v.needsLights && Tt(E, w), a && r.fog === !0 && Ue.refreshFogUniforms(E, a), Ue.refreshMaterialUniforms(E, r, G, ge, M.state.transmissionRenderTarget[e.id]), v.needsLights && v.lightProbeGrid) {
+					let e = v.lightProbeGrid;
+					E.probesSH.value = e.texture, E.probesMin.value.copy(e.boundingBox.min), E.probesMax.value.copy(e.boundingBox.max), E.probesResolution.value.copy(e.resolution);
+				}
+				eo.upload(q, xt(v), E, X);
+			}
+			if (r.isShaderMaterial && r.uniformsNeedUpdate === !0 && (eo.upload(q, xt(v), E, X), r.uniformsNeedUpdate = !1), r.isSpriteMaterial && T.setValue(q, "center", i.center), T.setValue(q, "modelViewMatrix", i.modelViewMatrix), T.setValue(q, "normalMatrix", i.normalMatrix), T.setValue(q, "modelMatrix", i.matrixWorld), r.uniformsGroups !== void 0) {
+				let e = r.uniformsGroups;
+				for (let t = 0, n = e.length; t < n; t++) {
+					let n = e[t];
+					et.update(n, x), et.bind(n, x);
+				}
+			}
+			return x;
+		}
+		function Tt(e, t) {
+			e.ambientLightColor.needsUpdate = t, e.lightProbe.needsUpdate = t, e.directionalLights.needsUpdate = t, e.directionalLightShadows.needsUpdate = t, e.pointLights.needsUpdate = t, e.pointLightShadows.needsUpdate = t, e.spotLights.needsUpdate = t, e.spotLightShadows.needsUpdate = t, e.rectAreaLights.needsUpdate = t, e.hemisphereLights.needsUpdate = t;
+		}
+		function Et(e) {
+			return e.isMeshLambertMaterial || e.isMeshToonMaterial || e.isMeshPhongMaterial || e.isMeshStandardMaterial || e.isShadowMaterial || e.isShaderMaterial && e.lights === !0;
+		}
+		this.getActiveCubeFace = function() {
+			return le;
+		}, this.getActiveMipmapLevel = function() {
+			return ue;
+		}, this.getRenderTarget = function() {
+			return B;
+		}, this.setRenderTargetTextures = function(e, t, n) {
+			let r = Y.get(e);
+			r.__autoAllocateDepthBuffer = e.resolveDepthBuffer === !1, r.__autoAllocateDepthBuffer === !1 && (r.__useRenderToTexture = !1), Y.get(e.texture).__webglTexture = t, Y.get(e.depthTexture).__webglTexture = r.__autoAllocateDepthBuffer ? void 0 : n, r.__hasExternalTextures = !0;
+		}, this.setRenderTargetFramebuffer = function(e, t) {
+			let n = Y.get(e);
+			n.__webglFramebuffer = t, n.__useDefaultFramebuffer = t === void 0;
+		}, this.setRenderTarget = function(e, t = 0, n = 0) {
+			B = e, le = t, ue = n;
+			let r = null, i = !1, a = !1;
+			if (e) {
+				let o = Y.get(e);
+				if (o.__useDefaultFramebuffer !== void 0) {
+					J.bindFramebuffer(q.FRAMEBUFFER, o.__webglFramebuffer), fe.copy(e.viewport), pe.copy(e.scissor), H = e.scissorTest, J.viewport(fe), J.scissor(pe), J.setScissorTest(H), V = -1;
+					return;
+				} else if (o.__webglFramebuffer === void 0) X.setupRenderTarget(e);
+				else if (o.__hasExternalTextures) X.rebindTextures(e, Y.get(e.texture).__webglTexture, Y.get(e.depthTexture).__webglTexture);
+				else if (e.depthBuffer) {
+					let t = e.depthTexture;
+					if (o.__boundDepthTexture !== t) {
+						if (t !== null && Y.has(t) && (e.width !== t.image.width || e.height !== t.image.height)) throw Error("THREE.WebGLRenderer: Attached DepthTexture is initialized to the incorrect size.");
+						X.setupDepthRenderbuffer(e);
+					}
+				}
+				let s = e.texture;
+				(s.isData3DTexture || s.isDataArrayTexture || s.isCompressedArrayTexture) && (a = !0);
+				let c = Y.get(e).__webglFramebuffer;
+				e.isWebGLCubeRenderTarget ? (r = Array.isArray(c[t]) ? c[t][n] : c[t], i = !0) : r = e.samples > 0 && X.useMultisampledRTT(e) === !1 ? Y.get(e).__webglMultisampledFramebuffer : Array.isArray(c) ? c[n] : c, fe.copy(e.viewport), pe.copy(e.scissor), H = e.scissorTest;
+			} else fe.copy(ye).multiplyScalar(G).floor(), pe.copy(be).multiplyScalar(G).floor(), H = xe;
+			if (n !== 0 && (r = ce), J.bindFramebuffer(q.FRAMEBUFFER, r) && J.drawBuffers(e, r), J.viewport(fe), J.scissor(pe), J.setScissorTest(H), i) {
+				let r = Y.get(e.texture);
+				q.framebufferTexture2D(q.FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_CUBE_MAP_POSITIVE_X + t, r.__webglTexture, n);
+			} else if (a) {
+				let r = t;
+				for (let t = 0; t < e.textures.length; t++) {
+					let i = Y.get(e.textures[t]);
+					q.framebufferTextureLayer(q.FRAMEBUFFER, q.COLOR_ATTACHMENT0 + t, i.__webglTexture, n, r);
+				}
+			} else if (e !== null && n !== 0) {
+				let t = Y.get(e.texture);
+				q.framebufferTexture2D(q.FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_2D, t.__webglTexture, n);
+			}
+			V = -1;
+		}, this.readRenderTargetPixels = function(e, t, n, r, i, a, o, s = 0) {
+			if (!(e && e.isWebGLRenderTarget)) {
+				I("WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.");
+				return;
+			}
+			let c = Y.get(e).__webglFramebuffer;
+			if (e.isWebGLCubeRenderTarget && o !== void 0 && (c = c[o]), c) {
+				J.bindFramebuffer(q.FRAMEBUFFER, c);
+				try {
+					let o = e.textures[s], c = o.format, l = o.type;
+					if (e.textures.length > 1 && q.readBuffer(q.COLOR_ATTACHMENT0 + s), !Ie.textureFormatReadable(c)) {
+						I("WebGLRenderer.readRenderTargetPixels: renderTarget is not in RGBA or implementation defined format.");
+						return;
+					}
+					if (!Ie.textureTypeReadable(l)) {
+						I("WebGLRenderer.readRenderTargetPixels: renderTarget is not in UnsignedByteType or implementation defined type.");
+						return;
+					}
+					t >= 0 && t <= e.width - r && n >= 0 && n <= e.height - i && q.readPixels(t, n, r, i, Qe.convert(c), Qe.convert(l), a);
+				} finally {
+					let e = B === null ? null : Y.get(B).__webglFramebuffer;
+					J.bindFramebuffer(q.FRAMEBUFFER, e);
+				}
+			}
+		}, this.readRenderTargetPixelsAsync = async function(e, t, n, r, i, a, o, s = 0) {
+			if (!(e && e.isWebGLRenderTarget)) throw Error("THREE.WebGLRenderer.readRenderTargetPixels: renderTarget is not THREE.WebGLRenderTarget.");
+			let c = Y.get(e).__webglFramebuffer;
+			if (e.isWebGLCubeRenderTarget && o !== void 0 && (c = c[o]), c) if (t >= 0 && t <= e.width - r && n >= 0 && n <= e.height - i) {
+				J.bindFramebuffer(q.FRAMEBUFFER, c);
+				let o = e.textures[s], l = o.format, u = o.type;
+				if (e.textures.length > 1 && q.readBuffer(q.COLOR_ATTACHMENT0 + s), !Ie.textureFormatReadable(l)) throw Error("THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in RGBA or implementation defined format.");
+				if (!Ie.textureTypeReadable(u)) throw Error("THREE.WebGLRenderer.readRenderTargetPixelsAsync: renderTarget is not in UnsignedByteType or implementation defined type.");
+				let d = q.createBuffer();
+				q.bindBuffer(q.PIXEL_PACK_BUFFER, d), q.bufferData(q.PIXEL_PACK_BUFFER, a.byteLength, q.STREAM_READ), q.readPixels(t, n, r, i, Qe.convert(l), Qe.convert(u), 0);
+				let f = B === null ? null : Y.get(B).__webglFramebuffer;
+				J.bindFramebuffer(q.FRAMEBUFFER, f);
+				let p = q.fenceSync(q.SYNC_GPU_COMMANDS_COMPLETE, 0);
+				return q.flush(), await se(q, p, 4), q.bindBuffer(q.PIXEL_PACK_BUFFER, d), q.getBufferSubData(q.PIXEL_PACK_BUFFER, 0, a), q.deleteBuffer(d), q.deleteSync(p), a;
+			} else throw Error("THREE.WebGLRenderer.readRenderTargetPixelsAsync: requested read bounds are out of range.");
+		}, this.copyFramebufferToTexture = function(e, t = null, n = 0) {
+			let r = 2 ** -n, i = Math.floor(e.image.width * r), a = Math.floor(e.image.height * r), o = t === null ? 0 : t.x, s = t === null ? 0 : t.y;
+			X.setTexture2D(e, 0), q.copyTexSubImage2D(q.TEXTURE_2D, n, 0, 0, o, s, i, a), J.unbindTexture();
+		}, this.copyTextureToTexture = function(e, t, n = null, r = null, i = 0, a = 0) {
+			let o, s, c, l, u, d, f, p, m, h = e.isCompressedTexture ? e.mipmaps[a] : e.image;
+			if (n !== null) o = n.max.x - n.min.x, s = n.max.y - n.min.y, c = n.isBox3 ? n.max.z - n.min.z : 1, l = n.min.x, u = n.min.y, d = n.isBox3 ? n.min.z : 0;
+			else {
+				let t = 2 ** -i;
+				o = Math.floor(h.width * t), s = Math.floor(h.height * t), c = e.isDataArrayTexture ? h.depth : e.isData3DTexture ? Math.floor(h.depth * t) : 1, l = 0, u = 0, d = 0;
+			}
+			r === null ? (f = 0, p = 0, m = 0) : (f = r.x, p = r.y, m = r.z);
+			let g = Qe.convert(t.format), _ = Qe.convert(t.type), v;
+			t.isData3DTexture ? (X.setTexture3D(t, 0), v = q.TEXTURE_3D) : t.isDataArrayTexture || t.isCompressedArrayTexture ? (X.setTexture2DArray(t, 0), v = q.TEXTURE_2D_ARRAY) : (X.setTexture2D(t, 0), v = q.TEXTURE_2D), J.activeTexture(q.TEXTURE0), J.pixelStorei(q.UNPACK_FLIP_Y_WEBGL, t.flipY), J.pixelStorei(q.UNPACK_PREMULTIPLY_ALPHA_WEBGL, t.premultiplyAlpha), J.pixelStorei(q.UNPACK_ALIGNMENT, t.unpackAlignment);
+			let y = J.getParameter(q.UNPACK_ROW_LENGTH), b = J.getParameter(q.UNPACK_IMAGE_HEIGHT), x = J.getParameter(q.UNPACK_SKIP_PIXELS), S = J.getParameter(q.UNPACK_SKIP_ROWS), C = J.getParameter(q.UNPACK_SKIP_IMAGES);
+			J.pixelStorei(q.UNPACK_ROW_LENGTH, h.width), J.pixelStorei(q.UNPACK_IMAGE_HEIGHT, h.height), J.pixelStorei(q.UNPACK_SKIP_PIXELS, l), J.pixelStorei(q.UNPACK_SKIP_ROWS, u), J.pixelStorei(q.UNPACK_SKIP_IMAGES, d);
+			let w = e.isDataArrayTexture || e.isData3DTexture, T = t.isDataArrayTexture || t.isData3DTexture;
+			if (e.isDepthTexture) {
+				let n = Y.get(e), r = Y.get(t), h = Y.get(n.__renderTarget), g = Y.get(r.__renderTarget);
+				J.bindFramebuffer(q.READ_FRAMEBUFFER, h.__webglFramebuffer), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, g.__webglFramebuffer);
+				for (let n = 0; n < c; n++) w && (q.framebufferTextureLayer(q.READ_FRAMEBUFFER, q.COLOR_ATTACHMENT0, Y.get(e).__webglTexture, i, d + n), q.framebufferTextureLayer(q.DRAW_FRAMEBUFFER, q.COLOR_ATTACHMENT0, Y.get(t).__webglTexture, a, m + n)), q.blitFramebuffer(l, u, o, s, f, p, o, s, q.DEPTH_BUFFER_BIT, q.NEAREST);
+				J.bindFramebuffer(q.READ_FRAMEBUFFER, null), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, null);
+			} else if (i !== 0 || e.isRenderTargetTexture || Y.has(e)) {
+				let n = Y.get(e), r = Y.get(t);
+				J.bindFramebuffer(q.READ_FRAMEBUFFER, R), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, z);
+				for (let e = 0; e < c; e++) w ? q.framebufferTextureLayer(q.READ_FRAMEBUFFER, q.COLOR_ATTACHMENT0, n.__webglTexture, i, d + e) : q.framebufferTexture2D(q.READ_FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_2D, n.__webglTexture, i), T ? q.framebufferTextureLayer(q.DRAW_FRAMEBUFFER, q.COLOR_ATTACHMENT0, r.__webglTexture, a, m + e) : q.framebufferTexture2D(q.DRAW_FRAMEBUFFER, q.COLOR_ATTACHMENT0, q.TEXTURE_2D, r.__webglTexture, a), i === 0 ? T ? q.copyTexSubImage3D(v, a, f, p, m + e, l, u, o, s) : q.copyTexSubImage2D(v, a, f, p, l, u, o, s) : q.blitFramebuffer(l, u, o, s, f, p, o, s, q.COLOR_BUFFER_BIT, q.NEAREST);
+				J.bindFramebuffer(q.READ_FRAMEBUFFER, null), J.bindFramebuffer(q.DRAW_FRAMEBUFFER, null);
+			} else T ? e.isDataTexture || e.isData3DTexture ? q.texSubImage3D(v, a, f, p, m, o, s, c, g, _, h.data) : t.isCompressedArrayTexture ? q.compressedTexSubImage3D(v, a, f, p, m, o, s, c, g, h.data) : q.texSubImage3D(v, a, f, p, m, o, s, c, g, _, h) : e.isDataTexture ? q.texSubImage2D(q.TEXTURE_2D, a, f, p, o, s, g, _, h.data) : e.isCompressedTexture ? q.compressedTexSubImage2D(q.TEXTURE_2D, a, f, p, h.width, h.height, g, h.data) : q.texSubImage2D(q.TEXTURE_2D, a, f, p, o, s, g, _, h);
+			J.pixelStorei(q.UNPACK_ROW_LENGTH, y), J.pixelStorei(q.UNPACK_IMAGE_HEIGHT, b), J.pixelStorei(q.UNPACK_SKIP_PIXELS, x), J.pixelStorei(q.UNPACK_SKIP_ROWS, S), J.pixelStorei(q.UNPACK_SKIP_IMAGES, C), a === 0 && t.generateMipmaps && q.generateMipmap(v), J.unbindTexture();
+		}, this.initRenderTarget = function(e) {
+			Y.get(e).__webglFramebuffer === void 0 && X.setupRenderTarget(e);
+		}, this.initTexture = function(e) {
+			e.isCubeTexture ? X.setTextureCube(e, 0) : e.isData3DTexture ? X.setTexture3D(e, 0) : e.isDataArrayTexture || e.isCompressedArrayTexture ? X.setTexture2DArray(e, 0) : X.setTexture2D(e, 0), J.unbindTexture();
+		}, this.resetState = function() {
+			le = 0, ue = 0, B = null, J.reset(), $e.reset();
+		}, typeof __THREE_DEVTOOLS__ < "u" && __THREE_DEVTOOLS__.dispatchEvent(new CustomEvent("observe", { detail: this }));
+	}
+	get coordinateSystem() {
+		return te;
+	}
+	get outputColorSpace() {
+		return this._outputColorSpace;
+	}
+	set outputColorSpace(e) {
+		this._outputColorSpace = e;
+		let t = this.getContext();
+		t.drawingBufferColorSpace = K._getDrawingBufferColorSpace(e), t.unpackColorSpace = K._getUnpackColorSpace();
+	}
+}, ws = "\nattribute vec3 color;\nattribute float along;\nattribute float flow;\nvarying vec3 vColor;\nvarying float vAlong;\nvarying float vFlow;\nvoid main() {\n  vColor = color;\n  vAlong = along;\n  vFlow = flow;\n  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);\n}\n", Ts = "\nprecision highp float;\nuniform float time;\nuniform float opacity;\nvarying vec3 vColor;\nvarying float vAlong;\nvarying float vFlow;\nvoid main() {\n  float moving = fract(vAlong * 7.0 - time * vFlow);\n  float pulse = smoothstep(0.02, 0.20, moving) *\n                (1.0 - smoothstep(0.30, 0.52, moving));\n  vec3 color = vColor * (0.64 + 0.72 * pulse);\n  gl_FragColor = vec4(color, opacity);\n}\n";
+function Es(e) {
+	return new Z(e);
+}
+function Ds(e) {
+	let t = 2166136261;
+	for (let n = 0; n < e.length; n += 1) t ^= e.charCodeAt(n), t = Math.imul(t, 16777619);
+	return Math.abs(t) % 360;
+}
+function Os(e, t) {
+	let n = "", r = 0;
+	for (let [e, i] of Object.entries(t)) i > r && (n = e, r = i);
+	return Es(!n || e >= r ? "hsl(200, 85%, 64%)" : `hsl(${Ds(n)}, 86%, 61%)`);
+}
+function ks(e) {
+	return e.data.is_anchor || e.data.is_center ? Es("#f0cf65") : e.data.network_root == null ? e.data.direction === "backward" ? Es("#d883d9") : Es("#66d6a1") : Es(`hsl(${e.data.network_root * 67 % 360}, 66%, 58%)`);
+}
+function As(e, t) {
+	return typeof e == "number" ? t.get(e) : e;
+}
+function js(e, t, n, r, i, a, o, s, c, l) {
+	let u = r - t, d = i - n, f = Math.max(1e-6, Math.hypot(u, d)), p = -d / f, m = u / f, h = p * o, g = m * o, _ = p * a, v = m * a, y = e.positions.length / 3;
+	e.positions.push(t + h - _, n + g - v, l, t + h + _, n + g + v, l, r + h + _, i + g + v, l, r + h - _, i + g - v, l);
+	for (let t = 0; t < 4; t += 1) e.colors.push(s.r, s.g, s.b), e.flow.push(c);
+	e.along.push(0, 0, 1, 1), e.indices.push(y, y + 1, y + 2, y, y + 2, y + 3);
+}
+function Ms(e) {
+	let t = new ln();
+	return t.setAttribute("position", new Xt(e.positions, 3)), t.setAttribute("color", new Xt(e.colors, 3)), t.setAttribute("along", new Xt(e.along, 1)), t.setAttribute("flow", new Xt(e.flow, 1)), t.setIndex(e.indices), t.computeBoundingSphere(), t;
+}
+function Ns() {
+	return {
+		positions: [],
+		colors: [],
+		along: [],
+		flow: [],
+		indices: []
+	};
+}
+var Ps = class {
+	renderer;
+	scene = new mt();
+	camera;
+	hullMaterial;
+	lumenMaterial;
+	nodeMaterial;
+	fluidMaterial;
+	hullMesh = null;
+	lumenMesh = null;
+	nodeMesh = null;
+	fluidMesh = null;
+	frame = null;
+	animationHandle = 0;
+	disposed = !1;
+	constructor(e) {
+		let t = e.getContext("webgl2", {
+			alpha: !0,
+			antialias: !0,
+			powerPreference: "high-performance"
+		});
+		if (!t) throw Error("WebGL2 is unavailable");
+		this.renderer = new Cs({
+			canvas: e,
+			context: t,
+			alpha: !0,
+			antialias: !0,
+			powerPreference: "high-performance"
+		}), this.renderer.setClearColor(0, 0), this.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, 2)), this.camera = new Hr(0, 900, 0, 560, .1, 100), this.camera.position.z = 20, this.camera.lookAt(0, 0, 0), this.hullMaterial = new mr({
+			vertexShader: ws,
+			fragmentShader: Ts,
+			uniforms: {
+				time: { value: 0 },
+				opacity: { value: .44 }
+			},
+			transparent: !0,
+			depthWrite: !1,
+			side: 2,
+			blending: 1
+		}), this.lumenMaterial = this.hullMaterial.clone(), this.lumenMaterial.uniforms.opacity.value = .92, this.nodeMaterial = new bn({
+			color: 16777215,
+			transparent: !0,
+			opacity: .96,
+			depthWrite: !1,
+			side: 2
+		}), this.fluidMaterial = new bn({
+			color: 16777215,
+			transparent: !0,
+			opacity: .88,
+			depthWrite: !1,
+			side: 2
+		}), this.animate();
+	}
+	update(e) {
+		this.frame = e, this.resize(e.width, e.height), this.rebuildHulls(e), this.rebuildLumens(e), this.rebuildNodes(e);
+	}
+	resize(e, t) {
+		let n = this.renderer.domElement.clientWidth || e, r = this.renderer.domElement.clientHeight || t;
+		this.renderer.setSize(n, r, !1), this.camera.left = 0, this.camera.right = e, this.camera.top = 0, this.camera.bottom = t, this.camera.updateProjectionMatrix();
+	}
+	updateQuadMesh(e, t, n) {
+		let r = e?.geometry.getAttribute("position");
+		if (e && r && r.count === t.positions.length / 3) return r.array.set(t.positions), e.geometry.getAttribute("color").array.set(t.colors), e.geometry.getAttribute("along").array.set(t.along), e.geometry.getAttribute("flow").array.set(t.flow), r.needsUpdate = !0, e.geometry.getAttribute("color").needsUpdate = !0, e.geometry.getAttribute("along").needsUpdate = !0, e.geometry.getAttribute("flow").needsUpdate = !0, e.geometry.computeBoundingSphere(), e;
+		e && (this.scene.remove(e), e.geometry.dispose());
+		let i = new Mn(Ms(t), n);
+		return i.frustumCulled = !1, this.scene.add(i), i;
+	}
+	rebuildHulls(e) {
+		let t = new Map(e.nodes.map((e) => [e.id, e])), n = Ns();
+		for (let r of e.links) {
+			let e = As(r.source, t), i = As(r.target, t);
+			if (!e || !i) continue;
+			let a = r.influence ?? {}, o = Math.max(1, Number(a.count) || 1), s = Math.max(0, Math.min(1, Number(a.maturity) || 0)), c = Math.max(0, Math.min(1, Number(a.avg) || 0)), l = 2.6 + Math.sqrt(o) * 1.6 + s * 2.4, u = new Z().setHSL(c * .32, .72, .42);
+			js(n, e.x, e.y, i.x, i.y, l, 0, u, Number(a.flow) || 0, 0);
+		}
+		this.hullMesh = this.updateQuadMesh(this.hullMesh, n, this.hullMaterial);
+	}
+	rebuildLumens(e) {
+		let t = new Map(e.nodes.map((e) => [e.id, e])), n = /* @__PURE__ */ new Map();
+		for (let t of e.tubes) t.edges.forEach((e, r) => {
+			let i = `${e[0]}:${e[1]}`, a = n.get(i) ?? [];
+			a.push({
+				tube: t,
+				segment: r,
+				edge: e
+			}), n.set(i, a);
+		});
+		let r = Ns();
+		for (let e of n.values()) {
+			let n = Math.min(1.7, 12 / Math.max(1, e.length - 1));
+			e.forEach(({ tube: i, segment: a, edge: o }, s) => {
+				let c = t.get(o[0]), l = t.get(o[1]);
+				if (!c || !l) return;
+				let u = (s - (e.length - 1) / 2) * n, d = Number(i.solvent[a]) || 0, f = i.solubles[a] ?? {}, p = Number(i.pressures[a]) || 0, m = d + Object.values(f).reduce((e, t) => e + Number(t || 0), 0), h = (i.direction === "forward" ? 1 : -1) * (.25 + Math.min(4, p + m));
+				js(r, c.x, c.y, l.x, l.y, Math.min(.58 + Math.min(1.4, Math.sqrt(Math.max(0, m)) * .32), Math.max(.12, n * .38)), u, Os(d, f), h, 2);
+			});
+		}
+		this.lumenMesh = this.updateQuadMesh(this.lumenMesh, r, this.lumenMaterial);
+	}
+	rebuildNodes(e) {
+		let t = e.nodes.length;
+		if (!this.nodeMesh || this.nodeMesh.count !== t) {
+			this.nodeMesh && (this.scene.remove(this.nodeMesh), this.nodeMesh.geometry.dispose()), this.fluidMesh && (this.scene.remove(this.fluidMesh), this.fluidMesh.geometry.dispose());
+			let e = new ir(1, 24);
+			this.nodeMesh = new Wn(e, this.nodeMaterial, t), this.fluidMesh = new Wn(e.clone(), this.fluidMaterial, t), this.nodeMesh.frustumCulled = !1, this.fluidMesh.frustumCulled = !1, this.scene.add(this.nodeMesh, this.fluidMesh);
+		}
+		let n = Math.max(1e-9, ...e.nodes.map((e) => Number(e.data.volume) || 0)), r = this.nodeMesh, i = this.fluidMesh;
+		if (!r || !i) return;
+		let a = new Fe();
+		e.nodes.forEach((e, t) => {
+			a.makeTranslation(e.x, e.y, 4), a.scale(new W(e.r, e.r, 1)), r.setMatrixAt(t, a), r.setColorAt(t, ks(e));
+			let o = Math.max(0, Number(e.data.volume) || 0), s = e.r * Math.min(.9, Math.sqrt(o / n));
+			a.makeTranslation(e.x, e.y, 5), a.scale(new W(s, s, 1)), i.setMatrixAt(t, a), i.setColorAt(t, Os(Number(e.data.solvent) || 0, e.data.solubles ?? {}));
+		}), r.instanceMatrix.needsUpdate = !0, i.instanceMatrix.needsUpdate = !0, r.instanceColor && (r.instanceColor.needsUpdate = !0), i.instanceColor && (i.instanceColor.needsUpdate = !0);
+	}
+	animate = () => {
+		if (this.disposed) return;
+		let e = performance.now() / 1e3;
+		this.hullMaterial.uniforms.time.value = e, this.lumenMaterial.uniforms.time.value = e, this.renderer.render(this.scene, this.camera), this.animationHandle = requestAnimationFrame(this.animate);
+	};
+	dispose() {
+		this.disposed = !0, cancelAnimationFrame(this.animationHandle), this.hullMesh?.geometry.dispose(), this.lumenMesh?.geometry.dispose(), this.nodeMesh?.geometry.dispose(), this.fluidMesh?.geometry.dispose(), this.hullMaterial.dispose(), this.lumenMaterial.dispose(), this.nodeMaterial.dispose(), this.fluidMaterial.dispose(), this.renderer.dispose();
+	}
+};
+//#endregion
+export { Ps as FluxWebGLRenderer };

--- a/speaktome/flux_radar_server.py
+++ b/speaktome/flux_radar_server.py
@@ -1304,10 +1304,12 @@ class Handler(BaseHTTPRequestHandler):
         try:
             payload = self._read_json_body()
             domain = str(payload.pop("domain", "client"))
-            ring = payload.get("ring_proximity")
-            if isinstance(ring, dict):
+            proximity = payload.get("habitat_proximity")
+            if isinstance(proximity, dict):
                 # JSON object keys are always strings; node ids are ints.
-                payload["ring_proximity"] = {int(k): float(v) for k, v in ring.items()}
+                payload["habitat_proximity"] = {
+                    int(k): float(v) for k, v in proximity.items()
+                }
             fluid_result = payload.pop("fluid_result", None)
             if isinstance(fluid_result, dict):
                 session.submit_fluid_result(fluid_result)

--- a/speaktome/flux_radar_server.py
+++ b/speaktome/flux_radar_server.py
@@ -282,6 +282,8 @@ class ModelBundle:
             overpressure_ceiling=float(params.get("overpressure_ceiling", 0.0)),
             burn_after_ticks=int(params.get("burn_after_ticks", 3)),
             anchor_can_decay=bool(params.get("anchor_can_decay", False)),
+            reroot_margin=float(params.get("reroot_margin", 0.05)),
+            reroot_cooldown_ticks=int(params.get("reroot_cooldown_ticks", 3)),
             compute_budget_per_tick=int(params.get("budget", 3)),
             branch_factor=int(params.get("branch", 3)),
             hot_loop_depth=int(params.get("hot_loop_depth", 1)),
@@ -419,6 +421,8 @@ class ModelBundle:
             "alpha": choice_policy.alpha,
             "beta": choice_policy.beta,
             "anchor_can_decay": config.anchor_can_decay,
+            "reroot_margin": config.reroot_margin,
+            "reroot_cooldown_ticks": config.reroot_cooldown_ticks,
             "no_repeat_ngram_size": config.no_repeat_ngram_size or 0,
             "poetic_enabled": config.poetic_attractor is not None,
             "poetic_scale": config.poetic_scale,
@@ -1255,7 +1259,11 @@ class Handler(BaseHTTPRequestHandler):
             _autosave()
             self._send_json(200, state)
         except Exception as e:  # noqa: BLE001 -- surfaced to the browser, not swallowed
-            self._send_json(500, {"error": str(e)})
+            traceback.print_exc()
+            self._send_json(500, {
+                "error": f"{type(e).__name__}: {e!r}",
+                "traceback": traceback.format_exc(),
+            })
 
     def _handle_live_stop(self) -> None:
         with _live_session_lock:

--- a/speaktome/flux_radar_server.py
+++ b/speaktome/flux_radar_server.py
@@ -304,6 +304,13 @@ class ModelBundle:
             poetic_shortlist_k=int(params.get("poetic_shortlist_k", 20)),
             auxin_suppression=float(params.get("auxin_suppression", 0.0)),
             auxin_decay=float(params.get("auxin_decay", 0.6)),
+            growth_commitment_gain=float(params.get("growth_commitment_gain", 1.0)),
+            growth_commitment_retention=float(params.get("growth_commitment_retention", 0.85)),
+            growth_commitment_diffusion=float(params.get("growth_commitment_diffusion", 0.15)),
+            growth_commitment_inheritance=float(params.get("growth_commitment_inheritance", 0.5)),
+            growth_commitment_after_growth=float(params.get("growth_commitment_after_growth", 0.25)),
+            growth_commitment_threshold=float(params.get("growth_commitment_threshold", 3.0)),
+            growth_commitment_max=float(params.get("growth_commitment_max", 6.0)),
             head_pressure_coefficient=float(params.get("head_pressure_coefficient", 0.0)),
             decay_rate=float(params.get("decay_rate", 0.0)),
             population_target=population_target,
@@ -350,6 +357,23 @@ class ModelBundle:
             ),
             growth_target_ion_concentration=float(
                 params.get("growth_target_ion_concentration", 0.1)
+            ),
+            habitat_ring_ion_amount=float(params.get("habitat_ring_ion_amount", 4.0)),
+            ring_uptake_rate=float(params.get("ring_uptake_rate", 1.0)),
+            branch_maturity_gain=float(params.get("branch_maturity_gain", 0.1)),
+            branch_maturity_retention=float(params.get("branch_maturity_retention", 0.995)),
+            branch_maturity_conductance_bonus=float(
+                params.get("branch_maturity_conductance_bonus", 1.0)
+            ),
+            fluid_solver_substeps=int(params.get("fluid_solver_substeps", 8)),
+            fluid_bulk_conductance=float(
+                params.get("fluid_bulk_conductance", 0.35)
+            ),
+            fluid_diffusion_conductance=float(
+                params.get("fluid_diffusion_conductance", 0.6)
+            ),
+            fluid_osmotic_pressure=float(
+                params.get("fluid_osmotic_pressure", 0.25)
             ),
             csf_link_rate=float(params.get("csf_link_rate", 0.05)),
             lymph_return_rate=float(params.get("lymph_return_rate", 0.02)),
@@ -415,6 +439,13 @@ class ModelBundle:
             "max_subword_steps": config.max_subword_steps,
             "auxin_suppression": config.auxin_suppression,
             "auxin_decay": config.auxin_decay,
+            "growth_commitment_gain": config.growth_commitment_gain,
+            "growth_commitment_retention": config.growth_commitment_retention,
+            "growth_commitment_diffusion": config.growth_commitment_diffusion,
+            "growth_commitment_inheritance": config.growth_commitment_inheritance,
+            "growth_commitment_after_growth": config.growth_commitment_after_growth,
+            "growth_commitment_threshold": config.growth_commitment_threshold,
+            "growth_commitment_max": config.growth_commitment_max,
             "head_pressure_coefficient": config.head_pressure_coefficient,
             "decay_rate": config.decay_rate,
             "population_target": config.population_target or 0,
@@ -444,6 +475,15 @@ class ModelBundle:
             "soil_forward_ion_permeability": config.soil_forward_ion_permeability,
             "root_soil_uptake_permeability": config.root_soil_uptake_permeability,
             "growth_target_ion_concentration": config.growth_target_ion_concentration,
+            "habitat_ring_ion_amount": config.habitat_ring_ion_amount,
+            "ring_uptake_rate": config.ring_uptake_rate,
+            "branch_maturity_gain": config.branch_maturity_gain,
+            "branch_maturity_retention": config.branch_maturity_retention,
+            "branch_maturity_conductance_bonus": config.branch_maturity_conductance_bonus,
+            "fluid_solver_substeps": config.fluid_solver_substeps,
+            "fluid_bulk_conductance": config.fluid_bulk_conductance,
+            "fluid_diffusion_conductance": config.fluid_diffusion_conductance,
+            "fluid_osmotic_pressure": config.fluid_osmotic_pressure,
             "csf_link_rate": config.csf_link_rate,
             "lymph_return_rate": config.lymph_return_rate,
             "rhizome_csf_pump_rate": config.rhizome_csf_pump_rate,
@@ -502,6 +542,9 @@ class ModelBundle:
         """
         orthogonal = graph.orthogonal_node_ids()
         network_roots = graph.orthogonal_network_roots(orthogonal)
+        node_openings = graph.node_archetype_opening_state(
+            list(graph.nodes.values())
+        )
         nodes = []
         for nid, n in graph.nodes.items():
             # A node's own tokens are empty only while it's the current
@@ -539,20 +582,26 @@ class ModelBundle:
                 "solubles": {k: round(v, 4) for k, v in n.solubles.items() if v},
                 "hull_permeability": n.hull_permeability,
                 "pore_permeabilities": dict(n.pore_permeabilities),
-                "learned_hull_opening": graph._gate_value(
-                    graph._node_hull_gate_key(nid)
-                ),
-                "learned_pore_openings": {
-                    key.split(":pore:", 1)[1]: graph._gate_value(key)
-                    for key in graph.physiology_parameters
-                    if key.startswith(f"node:{nid}:pore:")
-                },
+                "learned_hull_opening": node_openings.get(
+                    nid, {}
+                ).get("hull", 1.0),
+                "learned_pore_openings": node_openings.get(
+                    nid, {}
+                ).get("pores", {}),
                 "factory_roles": [factory.name for factory in n.factories if factory.enabled],
                 "factory_auxin": round(n.factory_auxin, 4),
                 "backward_growth_interest": round(n.backward_growth_interest, 4),
                 "forward_growth_interest": round(n.forward_growth_interest, 4),
             })
-        influence = graph.audit_edge_influence()
+        influence = graph.audit_edge_influence(
+            ensure_current=(
+                not graph.config.graph_auditor_enabled
+                or not graph.traversals
+            )
+        )
+        edge_openings = graph.edge_archetype_opening_state(
+            list(influence)
+        )
         # audit_edge_influence's key set is the live parent/child edges;
         # fold each one's fluid flow + pressure drop (see Edge) in beside
         # its quality/count so the frontend can animate direction/speed.
@@ -571,11 +620,14 @@ class ModelBundle:
                     {name: round(amount, 5) for name, amount in edge.component_flows.items() if amount}
                     if edge is not None else {}
                 ),
-                "forward_valve": graph._gate_value(
-                    graph._edge_gate_key(a, b, "forward")
-                ),
-                "reverse_valve": graph._gate_value(
-                    graph._edge_gate_key(a, b, "reverse")
+                "forward_valve": edge_openings.get((a, b), (1.0, 1.0))[0],
+                "reverse_valve": edge_openings.get((a, b), (1.0, 1.0))[1],
+                "maturity": round(edge.maturity, 5) if edge is not None else 0.0,
+                "hull_pressure": round(edge.hull_pressure, 5) if edge is not None else 0.0,
+                "hull_solvent": round(edge.hull_solvent, 5) if edge is not None else 0.0,
+                "hull_solubles": (
+                    {name: round(amount, 5) for name, amount in edge.hull_solubles.items() if amount}
+                    if edge is not None else {}
                 ),
             })
         # Per-region heart chamber contents and the shared CSF bath.
@@ -610,10 +662,45 @@ class ModelBundle:
             "hearts": hearts,
             "reservoirs": reservoirs,
             "bath": {k: round(v, 4) for k, v in graph.bath.items() if v},
+            "bath_by_node": {
+                str(node_id): {k: round(v, 5) for k, v in mixture.items() if v}
+                for node_id, mixture in graph.bath_by_node.items()
+                if mixture
+            },
+            "tube_state": [
+                {
+                    "traversal": list(traversal.node_ids),
+                    "direction": sub.direction,
+                    "edges": [list(edge_key) for edge_key in sub.segment_edge_keys],
+                    "solvent": [round(value, 5) for value in sub.segment_solvent],
+                    "solubles": [
+                        {name: round(amount, 5) for name, amount in mixture.items() if amount}
+                        for mixture in sub.segment_solubles
+                    ],
+                    "pressures": [round(value, 5) for value in sub.segment_pressures],
+                    "delivered_utility": round(sub.delivered_utility, 6),
+                }
+                for traversal in graph.traversals.values()
+                for sub in traversal.subedges
+            ],
+            "fluid_proof": graph.last_fluid_proof,
             "background": {k: round(v, 4) for k, v in graph.background.items() if v},
             "soil": {k: round(v, 4) for k, v in graph.soil.items() if v},
             "rhizome": {k: round(v, 4) for k, v in graph.rhizome.items() if v},
             "rhizome_owner_id": graph.rhizome_owner_id,
+            "current_habitat_id": graph.anchor_id,
+            "current_habitat": {
+                k: round(v, 4)
+                for k, v in graph.habitats.get(graph.anchor_id, {}).items()
+                if v
+            },
+            "current_habitat_signature": list(
+                graph.habitat_signatures.get(graph.anchor_id, [])
+            ),
+            "current_habitat_phrase": self.tokenizer.decode(
+                graph.habitat_signatures.get(graph.anchor_id, [])
+            ),
+            "movement_count": graph.movement_count,
             "physiology": graph.physiology_state(),
             "best_path": self.tokenizer.decode(tokens),
             "best_score": round(score, 4),
@@ -707,6 +794,10 @@ class LiveSession:
         self.error: Optional[str] = None
         self.mid_tick_status: Dict[str, Any] = {}
         self._state_lock = threading.RLock()
+        self._fluid_condition = threading.Condition(self._state_lock)
+        self.pending_fluid_work: Optional[Dict[str, Any]] = None
+        self._fluid_result: Optional[Dict[str, Any]] = None
+        self._fluid_work_counter = 0
         if hasattr(self.graph, "set_status_callback"):
             self.graph.set_status_callback(self._receive_tick_status)
         self._stop_event = threading.Event()
@@ -745,6 +836,10 @@ class LiveSession:
         session.error = None
         session.mid_tick_status = {}
         session._state_lock = threading.RLock()
+        session._fluid_condition = threading.Condition(session._state_lock)
+        session.pending_fluid_work = None
+        session._fluid_result = None
+        session._fluid_work_counter = 0
         if hasattr(session.graph, "set_status_callback"):
             session.graph.set_status_callback(session._receive_tick_status)
         session._stop_event = threading.Event()
@@ -778,17 +873,53 @@ class LiveSession:
 
     def start(self) -> None:
         self.graph.spawn_first_children()
+        self.graph.fluid_work_delegate = self._delegate_fluid_work
         with self._state_lock:
             self.history.append({"tick": 0, **self.bundle.snapshot_graph(self.graph)})
         self._thread.start()
 
     def start_resumed(self) -> None:
         """Like start(), but the graph is already fully grown from saved state -- just resume ticking."""
+        self.graph.fluid_work_delegate = self._delegate_fluid_work
         self._thread.start()
 
     def _receive_tick_status(self, status: Dict[str, Any]) -> None:
         with self._state_lock:
             self.mid_tick_status = dict(status)
+
+    def _delegate_fluid_work(self, packet: Dict[str, Any]) -> Dict[str, Any]:
+        """Publish a frozen relaxation job and wait for its browser result."""
+        with self._fluid_condition:
+            self._fluid_work_counter += 1
+            work_id = f"{self.tick_index + 1}:{self._fluid_work_counter}"
+            self.pending_fluid_work = {**packet, "work_id": work_id}
+            self._fluid_result = None
+            self.mid_tick_status = {
+                "phase": "client-relaxation",
+                "detail": "waiting for browser fluid proof",
+                "tick": packet.get("tick", self.tick_index + 1),
+                "current": 0,
+                "total": packet.get("parameters", {}).get("substeps", 1),
+            }
+            self._fluid_condition.notify_all()
+            while self._fluid_result is None and not self._stop_event.is_set():
+                self._fluid_condition.wait(timeout=0.5)
+            if self._fluid_result is None:
+                raise RuntimeError("client fluid relaxation stopped before completion")
+            result = self._fluid_result
+            self.pending_fluid_work = None
+            self._fluid_result = None
+            return result
+
+    def submit_fluid_result(self, result: Dict[str, Any]) -> None:
+        with self._fluid_condition:
+            pending = self.pending_fluid_work
+            if pending is None:
+                raise ValueError("there is no pending fluid work")
+            if result.get("work_id") != pending.get("work_id"):
+                raise ValueError("fluid result does not match pending work")
+            self._fluid_result = result
+            self._fluid_condition.notify_all()
 
     def _run_loop(self) -> None:
         try:
@@ -807,6 +938,8 @@ class LiveSession:
 
     def stop(self) -> None:
         self._stop_event.set()
+        with self._fluid_condition:
+            self._fluid_condition.notify_all()
         self._thread.join(timeout=5)
 
     def snapshot_state(
@@ -831,6 +964,10 @@ class LiveSession:
                 "running": self._thread.is_alive() and not self._stop_event.is_set(),
                 "error": self.error,
                 "mid_tick": dict(self.mid_tick_status),
+                "fluid_work": getattr(self, "pending_fluid_work", None),
+                "fluid_proof": getattr(
+                    getattr(self, "graph", None), "last_fluid_proof", None
+                ),
                 "history": history,
             }
 
@@ -1171,6 +1308,9 @@ class Handler(BaseHTTPRequestHandler):
             if isinstance(ring, dict):
                 # JSON object keys are always strings; node ids are ints.
                 payload["ring_proximity"] = {int(k): float(v) for k, v in ring.items()}
+            fluid_result = payload.pop("fluid_result", None)
+            if isinstance(fluid_result, dict):
+                session.submit_fluid_result(fluid_result)
             session.graph.absorb_external_physics(domain, payload)
             self._send_json(200, {"absorbed": domain})
         except Exception as e:  # noqa: BLE001 -- surfaced to the browser, not swallowed

--- a/tests/test_flux_graph.py
+++ b/tests/test_flux_graph.py
@@ -136,7 +136,12 @@ def test_seed_reservoir_gate_supplies_and_skims_ions_bidirectionally():
     assert deficient["main:forward"] > 0.0
     supplied_balance = reservoir.ion_amount
 
-    saturated = {"main:forward": 1.0}
+    # A chamber with no solvent has nothing for the ion to be dissolved in --
+    # exchange_with requires water present at the membrane to move anything
+    # across it in either direction. A small amount is enough to pass that
+    # gate without materially changing this chamber's over-concentration
+    # (still well above the reservoir's 0.5 band) that the skim below tests.
+    saturated = {"main:forward": 1.0, "solvent": 0.1}
     reservoir.exchange_with(saturated)
 
     assert saturated["main:forward"] < 1.0
@@ -239,6 +244,9 @@ def test_generic_node_factory_consumes_declared_materials_in_declared_medium():
     anchor_id = graph.seed([0])
     graph._attach_forward_children(anchor_id, [-0.1], [[1]])
     node = graph.nodes[graph.nodes[anchor_id].children_ids[-1]]
+    # A factory's medium is the water it reacts in -- no solvent, no
+    # metabolism, regardless of how much feedstock is sitting there.
+    node.solvent = 5.0
     node.solubles = {"feedstock": 2.0}
     node.factories = [
         MaterialFactory(
@@ -279,6 +287,7 @@ def test_factory_waste_dumps_into_local_interstitial_bath():
     anchor_id = graph.seed([0])
     graph._attach_forward_children(anchor_id, [-0.1], [[1]])
     node = graph.nodes[graph.nodes[anchor_id].children_ids[-1]]
+    node.solvent = 5.0
     node.solubles = {"feedstock": 2.0}
     node.factories = [
         MaterialFactory(
@@ -602,6 +611,16 @@ def test_ion_diffusion_has_an_independent_speed_from_bulk_current():
     graph.nodes[anchor_id].solvent = graph.nodes[child_id].solvent = 10.0
     graph.nodes[anchor_id].solubles["salt"] = 1.0
     graph._run_graph_auditor()
+    # Diffusion needs a real water medium along the whole path, not just at
+    # its two node endpoints -- a tube segment with zero solvent has nothing
+    # for the salt to diffuse through regardless of the concentration gap on
+    # either side of it. Bulk transport is the only mechanism that would
+    # normally deliver that water, and it's deliberately zeroed out below to
+    # isolate diffusion's own speed -- so this pipe needs to already be wet,
+    # the way it would be from prior real bulk flow in an actual run.
+    trav = graph.traversals[(anchor_id, child_id)]
+    for sub in trav.subedges:
+        sub.segment_solvent = [10.0] * len(sub.segment_solvent)
 
     graph._transport_subedges()
 
@@ -1091,7 +1110,13 @@ def test_burn_reaps_a_farther_backward_component_cut_off_from_the_seed():
 
     assert graph.nodes[connector_id].burned is True
     assert graph.nodes[far_id].burned is True
-    assert graph.bath_by_node[far_id]["stored-ion"] == 2.0
+    # far_id's own bath_by_node entry is permanently excluded from the fluid
+    # solver once it's burned -- its water is conserved to a live neighbor
+    # instead (here, by the time it's reaped, none of its neighbors are
+    # still alive, so it falls back to the anchor, same as Heart._spill_
+    # heart_to_csf's own dead-heart fallback).
+    assert "stored-ion" not in graph.bath_by_node.get(far_id, {})
+    assert graph.bath_by_node[seed_id]["stored-ion"] == 2.0
     assert all(far_id not in edge_key for edge_key in graph.edges)
     assert all(
         far_id not in traversal.node_ids
@@ -3443,6 +3468,13 @@ def test_previously_orthogonal_node_can_itself_become_the_next_anchor():
     """Displacing the root doesn't remove anything from the graph -- an
     orthogonal node is still fully live and can be re-rooted to again."""
     graph = _build_graph()
+    # This test calls _maybe_reroot() twice back-to-back with no ticks in
+    # between -- exercising reroot mechanics directly, not the cooldown/
+    # margin throttle (see FluxGraphConfig.reroot_cooldown_ticks), which
+    # would otherwise block the second reroot from a real event this soon
+    # after the first.
+    graph.config.reroot_cooldown_ticks = 0
+    graph.config.reroot_margin = 0.0
     anchor_id = graph.seed([99])
     weak_id = _add_node(graph, anchor_id, 1, -5.0, 1, direction=Direction.FORWARD, pressure=0.5)
     _add_node(graph, anchor_id, 2, -0.01, 1, direction=Direction.FORWARD, pressure=5.0)

--- a/tests/test_flux_graph.py
+++ b/tests/test_flux_graph.py
@@ -662,7 +662,7 @@ def test_client_fluid_delegate_owns_relaxation_and_returns_conservation_proof():
     }
 
 
-def test_ring_contact_transfers_named_ion_without_transmuting_opposite_ion():
+def test_nd_habitat_shell_contact_transfers_named_ion_without_transmutation():
     graph = _build_graph(branch_factor=1)
     graph.config.habitat_ring_ion_amount = 4.0
     anchor_id = graph.seed([0])
@@ -674,10 +674,10 @@ def test_ring_contact_transfers_named_ion_without_transmuting_opposite_ion():
     patch = graph.habitats[anchor_id]
     total_before = patch["main:forward"] + node.solubles.get("main:forward", 0.0)
     graph.absorb_external_physics(
-        "client", {"ring_proximity": {node_id: 1.0}}
+        "client_nd", {"habitat_proximity": {node_id: 1.0}}
     )
 
-    graph._ingest_from_rings()
+    graph._ingest_from_habitat_shells()
 
     assert node.solubles["main:backward"] == 2.0
     assert node.solubles["main:forward"] > 0.0

--- a/tests/test_flux_graph.py
+++ b/tests/test_flux_graph.py
@@ -1,5 +1,6 @@
 """Tests for speaktome.core.flux_graph."""
 
+import copy
 import math
 
 import torch
@@ -83,6 +84,7 @@ def test_seed_creates_anchor():
 
 def test_tick_publishes_aggregate_mid_tick_status_without_graph_objects():
     graph = _build_graph(branch_factor=1, compute_budget=1)
+    graph.config.graph_auditor_enabled = True
     graph.seed([0])
     graph.spawn_first_children()
     statuses = []
@@ -91,14 +93,16 @@ def test_tick_publishes_aggregate_mid_tick_status_without_graph_objects():
     graph.tick()
 
     phases = [status["phase"] for status in statuses]
-    assert phases[0] == "settling"
-    assert "model_inference" in phases
+    assert phases[0] == "auditing"
+    assert "settling" in phases
+    assert "expanding" in phases
     assert "auditing" in phases
     assert phases[-1] == "complete"
     assert statuses[-1]["tick"] == 1
     assert statuses[-1]["current"] == statuses[-1]["total"] == 1
     assert statuses[-1]["live_nodes"] > 0
     assert statuses[-1]["elapsed_seconds"] >= 0
+    assert statuses[-1]["phase_elapsed_seconds"] >= 0
     assert all("nodes" not in status and "edges" not in status for status in statuses)
 
 
@@ -155,10 +159,11 @@ def test_seed_displacement_dumps_all_old_heart_contents_to_csf():
     assert heart.chambers == {}
     assert all(reservoir.ion_amount == 0.0 for reservoir in heart.reservoirs.values())
     assert all(reservoir.design_storage == 1.0 for reservoir in heart.reservoirs.values())
-    assert graph.bath["main:forward"] == 3.0
-    assert graph.bath["main:backward"] == 3.0
-    assert graph.bath["solvent"] == 2.0
-    assert graph.bath["salt"] == 0.5
+    old_local_bath = graph.bath_by_node[old_anchor_id]
+    assert old_local_bath["main:forward"] == 3.0
+    assert old_local_bath["main:backward"] == 3.0
+    assert old_local_bath["solvent"] == 2.0
+    assert old_local_bath["salt"] == 0.5
 
 
 def test_off_seed_tier_heart_is_spilled_and_removed():
@@ -175,8 +180,8 @@ def test_off_seed_tier_heart_is_spilled_and_removed():
 
     assert pumps == {"main": seed_id}
     assert f"net:{forward_id}" not in graph.hearts
-    assert graph.bath["solvent"] == 1.25
-    assert graph.bath[f"net:{forward_id}:forward"] == 0.75
+    assert graph.bath_by_node[forward_id]["solvent"] == 1.25
+    assert graph.bath_by_node[forward_id][f"net:{forward_id}:forward"] == 0.75
 
 def test_seed_reservoir_state_round_trips_with_fluid_persistence():
     graph = _build_graph()
@@ -188,6 +193,8 @@ def test_seed_reservoir_state_round_trips_with_fluid_persistence():
     graph.background["main:forward"] = 0.3
     graph.soil["main:forward"] = 0.1
     graph.rhizome["waste:salt"] = 0.4
+    graph.habitats[graph.anchor_id]["main:forward"] = 1.5
+    graph.movement_count = 2
 
     state = graph.export_fluid_state()
     restored = _build_graph()
@@ -203,6 +210,28 @@ def test_seed_reservoir_state_round_trips_with_fluid_persistence():
     assert restored.soil == {"main:forward": 0.1}
     assert restored.rhizome == {"waste:salt": 0.4}
     assert restored.rhizome_owner_id == restored.anchor_id
+    assert restored.habitats[restored.anchor_id]["main:forward"] == 1.5
+    assert restored.movement_count == 2
+
+
+def test_branch_maturity_round_trips_with_reconstructed_edges():
+    graph = _build_graph(branch_factor=1)
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    child_id = graph.nodes[anchor_id].children_ids[-1]
+    graph.edges[(anchor_id, child_id)].maturity = 0.7
+    state = graph.export_fluid_state()
+    restored = _build_graph(branch_factor=1)
+
+    restored.restore_state(
+        copy.deepcopy(graph.nodes),
+        anchor_id,
+        graph.anchor_tokens,
+        graph.tick_count,
+    )
+    restored.import_fluid_state(state)
+
+    assert math.isclose(restored.edges[(anchor_id, child_id)].maturity, 0.7)
 
 
 def test_generic_node_factory_consumes_declared_materials_in_declared_medium():
@@ -245,7 +274,7 @@ def test_material_scarcity_drives_fractional_growth_interest():
     assert node.backward_growth_interest == 0.0
 
 
-def test_factory_waste_dumps_into_global_csf():
+def test_factory_waste_dumps_into_local_interstitial_bath():
     graph = _build_graph(branch_factor=1)
     anchor_id = graph.seed([0])
     graph._attach_forward_children(anchor_id, [-0.1], [[1]])
@@ -264,10 +293,10 @@ def test_factory_waste_dumps_into_global_csf():
     graph._run_node_factories()
 
     assert node.solubles["useful"] == 1.0
-    assert graph.bath["waste:salt"] == 0.5
+    assert graph.bath_by_node[node.id]["waste:salt"] == 0.5
 
 
-def test_all_cousin_hearts_share_one_global_csf_bath():
+def test_cousin_hearts_exchange_with_their_own_spatial_bath_localities():
     graph = _build_graph(branch_factor=1)
     graph.config.csf_link_rate = 0.5
     anchor_id = graph.seed([0])
@@ -284,8 +313,8 @@ def test_all_cousin_hearts_share_one_global_csf_bath():
     main._run_hooks("post")
     cousin._run_hooks("post")
 
-    assert graph.bath["main:forward"] > 0.0
-    assert graph.bath[f"{cousin_region}:backward"] > 0.0
+    assert graph.bath_by_node[anchor_id]["main:forward"] > 0.0
+    assert graph.bath_by_node[cousin_id][f"{cousin_region}:backward"] > 0.0
 
 
 def test_active_seed_owns_one_conserved_rhizome_and_exudes_soil_salts():
@@ -299,7 +328,10 @@ def test_active_seed_owns_one_conserved_rhizome_and_exudes_soil_salts():
     graph._exude_rhizome_to_soil()
 
     assert graph.rhizome_owner_id == anchor_id
-    assert graph.bath == {"solvent": 2.0, "main:forward": 5.0, "waste:salt": 2.0}
+    assert graph.bath == {}
+    assert graph.bath_by_node[anchor_id] == {
+        "solvent": 2.0, "main:forward": 5.0, "waste:salt": 2.0
+    }
     assert graph.rhizome == {"main:forward": 4.0, "waste:salt": 1.6}
     assert graph.soil == {"main:forward": 1.0, "waste:salt": 0.4}
     graph._attach_forward_children(anchor_id, [-0.1], [[3]])
@@ -466,8 +498,14 @@ def test_reciprocal_ion_shortage_accumulates_center_seeking_interest():
     graph.nodes[forward_id].solubles["main:backward"] = 1.0
     graph.nodes[backward_id].solubles["main:forward"] = 1.0
     graph._update_nutrient_growth_interest()
-    assert graph.nodes[forward_id].backward_growth_interest == 0.0
-    assert graph.nodes[backward_id].forward_growth_interest == 0.0
+    assert math.isclose(
+        graph.nodes[forward_id].backward_growth_interest,
+        graph.config.growth_commitment_retention,
+    )
+    assert math.isclose(
+        graph.nodes[backward_id].forward_growth_interest,
+        graph.config.growth_commitment_retention,
+    )
 
 
 def test_nutrient_reconciliation_clears_supply_without_double_counting_shortage():
@@ -506,7 +544,7 @@ def test_edge_records_water_and_each_ion_flow_separately():
     assert edge.flow == 0.0
     assert edge.component_flows == {}
 
-def test_each_named_ion_diffuses_osmotically_and_counterflows_without_bulk_current():
+def test_each_named_ion_diffuses_into_independent_counterflowing_tube_lumens():
     graph = _build_graph(branch_factor=1)
     anchor_id = graph.seed([0])
     graph._attach_forward_children(anchor_id, [-0.1], [[1]])
@@ -523,14 +561,208 @@ def test_each_named_ion_diffuses_osmotically_and_counterflows_without_bulk_curre
 
     graph._transport_subedges()
 
-    assert math.isclose(start.solubles["main:forward"], 0.5)
-    assert math.isclose(end.solubles["main:forward"], 0.5)
-    assert math.isclose(start.solubles["main:backward"], 0.5)
-    assert math.isclose(end.solubles["main:backward"], 0.5)
+    # A real tube has transit state: one solve moves ions into its lumen,
+    # rather than teleporting endpoints directly to equilibrium.
+    traversal = graph.traversals[(start_id, end_id)]
+    forward, reverse = traversal.subedges
+    assert forward.segment_solubles[0]["main:forward"] > 0.0
+    assert reverse.segment_solubles[0]["main:backward"] > 0.0
+    assert start.solubles["main:forward"] > end.solubles["main:forward"]
+    assert end.solubles["main:backward"] > start.solubles["main:backward"]
+    forward_total = sum(
+        node.solubles.get("main:forward", 0.0)
+        for node in graph.nodes.values()
+    )
+    forward_total += sum(
+        mixture.get("main:forward", 0.0)
+        for traversal_item in graph.traversals.values()
+        for sub in traversal_item.subedges
+        for mixture in sub.segment_solubles
+    )
+    forward_total += sum(
+        edge_item.hull_solubles.get("main:forward", 0.0)
+        for edge_item in graph.edges.values()
+    )
+    forward_total += sum(
+        mixture.get("main:forward", 0.0)
+        for mixture in graph.bath_by_node.values()
+    )
+    assert math.isclose(forward_total, 1.0, rel_tol=1e-9)
     edge = graph.edges[(start_id, end_id)]
-    assert math.isclose(edge.flow, 0.0)
-    assert math.isclose(edge.component_flows["main:forward"], 0.5)
-    assert math.isclose(edge.component_flows["main:backward"], -0.5)
+    assert graph.last_fluid_proof["conservation_residual"] < 1e-9
+
+
+def test_ion_diffusion_has_an_independent_speed_from_bulk_current():
+    graph = _build_graph(branch_factor=1)
+    graph.config.fluid_bulk_conductance = 0.0
+    graph.config.fluid_diffusion_conductance = 0.5
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    child_id = graph.nodes[anchor_id].children_ids[-1]
+    graph.nodes[anchor_id].solvent = graph.nodes[child_id].solvent = 10.0
+    graph.nodes[anchor_id].solubles["salt"] = 1.0
+    graph._run_graph_auditor()
+
+    graph._transport_subedges()
+
+    assert graph.nodes[child_id].solubles["salt"] > 0.0
+    assert graph.edges[(anchor_id, child_id)].flow == 0.0
+
+
+def test_audited_path_owns_ordered_persistent_segments_for_every_crossed_edge():
+    graph = _build_graph(branch_factor=1)
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    middle_id = graph.nodes[anchor_id].children_ids[-1]
+    graph._attach_forward_children(middle_id, [-0.1], [[2]])
+    end_id = graph.nodes[middle_id].children_ids[-1]
+    graph._run_graph_auditor()
+
+    traversal = graph.traversals[(anchor_id, end_id)]
+    assert traversal.subedges[0].segment_edge_keys == [
+        (anchor_id, middle_id), (middle_id, end_id)
+    ]
+    assert traversal.subedges[1].segment_edge_keys == [
+        (middle_id, end_id), (anchor_id, middle_id)
+    ]
+    assert all(sub.is_open_at(anchor_id) and sub.is_open_at(end_id)
+               and not sub.is_open_at(middle_id)
+               for sub in traversal.subedges)
+
+
+def test_client_fluid_delegate_owns_relaxation_and_returns_conservation_proof():
+    graph = _build_graph(branch_factor=1)
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    graph._run_graph_auditor()
+    seen = {}
+
+    def delegate(packet):
+        seen.update(packet)
+        return {
+            "work_id": "test-work",
+            "values": packet["values"],
+            "arc_bulk": [0.0] * len(packet["arcs"]["source"]),
+            "arc_components": [
+                [0.0] * len(packet["components"])
+                for _ in packet["arcs"]["source"]
+            ],
+        }
+
+    graph.fluid_work_delegate = delegate
+    graph._transport_subedges()
+
+    assert seen["compartments"]
+    assert graph.last_fluid_proof == {
+        "tick": graph.tick_count,
+        "worker": "client",
+        "conservation_residual": 0.0,
+        "substeps": graph.config.fluid_solver_substeps,
+        "work_id": "test-work",
+    }
+
+
+def test_ring_contact_transfers_named_ion_without_transmuting_opposite_ion():
+    graph = _build_graph(branch_factor=1)
+    graph.config.habitat_ring_ion_amount = 4.0
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    node_id = graph.nodes[anchor_id].children_ids[-1]
+    node = graph.nodes[node_id]
+    node.solvent = 9.0
+    node.solubles["main:backward"] = 2.0
+    patch = graph.habitats[anchor_id]
+    total_before = patch["main:forward"] + node.solubles.get("main:forward", 0.0)
+    graph.absorb_external_physics(
+        "client", {"ring_proximity": {node_id: 1.0}}
+    )
+
+    graph._ingest_from_rings()
+
+    assert node.solubles["main:backward"] == 2.0
+    assert node.solubles["main:forward"] > 0.0
+    assert math.isclose(
+        patch["main:forward"] + node.solubles["main:forward"],
+        total_before,
+    )
+
+
+def test_reroot_moves_to_new_finite_habitat_and_revisit_does_not_refill():
+    graph = _build_graph(branch_factor=1)
+    graph.config.habitat_ring_ion_amount = 4.0
+    first_anchor = graph.seed([0])
+    graph.habitats[first_anchor]["main:forward"] = 1.25
+    graph._attach_forward_children(first_anchor, [-0.1], [[1]])
+    second_anchor = graph.nodes[first_anchor].children_ids[-1]
+
+    graph._reroot(second_anchor)
+
+    assert graph.anchor_id == second_anchor
+    assert graph.habitats[second_anchor]["main:forward"] == 4.0
+    assert graph.movement_count == 1
+
+    graph._reroot(first_anchor)
+
+    assert graph.anchor_id == first_anchor
+    assert graph.habitats[first_anchor]["main:forward"] == 1.25
+    assert graph.movement_count == 2
+
+
+def test_growth_commitment_accumulates_diffuses_and_is_inherited():
+    graph = _build_graph(branch_factor=1)
+    graph.config.growth_commitment_gain = 1.0
+    graph.config.growth_commitment_retention = 0.5
+    graph.config.growth_commitment_diffusion = 0.25
+    graph.config.growth_commitment_inheritance = 0.5
+    graph.config.growth_commitment_after_growth = 0.25
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    inner_id = graph.nodes[anchor_id].children_ids[-1]
+    graph._attach_forward_children(inner_id, [-0.1], [[2]])
+    outer_id = graph.nodes[inner_id].children_ids[-1]
+    inner = graph.nodes[inner_id]
+    outer = graph.nodes[outer_id]
+    inner.solvent = 9.0
+    inner.solubles["main:backward"] = 1.0
+    outer.solvent = 10.0
+
+    graph._update_nutrient_growth_interest()
+    graph._update_nutrient_growth_interest()
+
+    assert inner.backward_growth_interest > 0.0
+    assert outer.backward_growth_interest > 1.0
+    source_commitment = outer.backward_growth_interest
+
+    graph._attach_backward_parents(outer_id, [-0.2], [[3]])
+
+    parent_id = max(graph.nodes[outer_id].parent_ids)
+    assert math.isclose(
+        graph.nodes[parent_id].backward_growth_interest,
+        source_commitment * graph.config.growth_commitment_inheritance,
+    )
+    assert math.isclose(
+        outer.backward_growth_interest,
+        source_commitment * graph.config.growth_commitment_after_growth,
+    )
+
+
+def test_useful_ion_flow_hardens_branch_and_raises_conductance():
+    graph = _build_graph(branch_factor=1)
+    graph.config.branch_maturity_gain = 0.5
+    graph.config.branch_maturity_retention = 1.0
+    graph.config.branch_maturity_conductance_bonus = 2.0
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    child_id = graph.nodes[anchor_id].children_ids[-1]
+    edge = graph.edges[(anchor_id, child_id)]
+    base = graph._directional_conductance(child_id, anchor_id)
+    graph._run_graph_auditor()
+    graph.traversals[(anchor_id, child_id)].subedges[0].delivered_utility = 1.0
+
+    graph._update_branch_maturity()
+
+    assert 0.0 < edge.maturity <= 1.0
+    assert graph._directional_conductance(child_id, anchor_id) > base
 
 def test_tick_one_heart_count_uses_safe_cross_growth_defaults():
     graph = _build_graph(branch_factor=VOCAB, compute_budget=2)
@@ -540,7 +772,9 @@ def test_tick_one_heart_count_uses_safe_cross_growth_defaults():
 
     graph.tick()
 
-    assert len(graph.hearts) == 1 + graph.config.compute_budget_per_tick
+    # New organs are a consequence of reconciled scarcity on a later beat;
+    # ordinary beam growth does not manufacture hearts immediately.
+    assert 1 <= len(graph.hearts) <= 1 + graph.config.compute_budget_per_tick
 
 
 def test_air_root_width_and_depth_are_separate_from_backward_beam_controls():
@@ -595,6 +829,31 @@ def test_any_needy_node_can_launch_cross_growth():
         calls.append((node.id, direction))
 
     graph._expand_nutrient_hot_loop = record_cross_growth
+
+    graph._expand_top_pressure_nodes()
+
+    assert calls == [(internal_id, Direction.BACKWARD)]
+
+
+def test_committed_growth_outranks_uncommitted_pressure_within_its_budget():
+    graph = _build_graph(branch_factor=1, compute_budget=1)
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.1], [[1]])
+    internal_id = graph.nodes[anchor_id].children_ids[-1]
+    graph._attach_forward_children(internal_id, [-0.1], [[2]])
+    leaf_id = graph.nodes[internal_id].children_ids[-1]
+    graph._attach_backward_parents(anchor_id, [-0.1], [[3]])
+    graph.config.forward_budget_per_tick = 0
+    graph.config.backward_budget_per_tick = 1
+    graph.config.growth_commitment_threshold = 3.0
+    graph.nodes[internal_id].backward_growth_interest = 3.0
+    graph.nodes[internal_id].pressure = 0.0
+    graph.nodes[leaf_id].backward_growth_interest = 2.99
+    graph.nodes[leaf_id].pressure = 1_000.0
+    calls = []
+    graph._expand_nutrient_hot_loop = (
+        lambda node, direction: calls.append((node.id, direction))
+    )
 
     graph._expand_top_pressure_nodes()
 
@@ -832,7 +1091,7 @@ def test_burn_reaps_a_farther_backward_component_cut_off_from_the_seed():
 
     assert graph.nodes[connector_id].burned is True
     assert graph.nodes[far_id].burned is True
-    assert graph.bath["stored-ion"] == 2.0
+    assert graph.bath_by_node[far_id]["stored-ion"] == 2.0
     assert all(far_id not in edge_key for edge_key in graph.edges)
     assert all(
         far_id not in traversal.node_ids
@@ -1069,6 +1328,32 @@ def test_starvation_burns_a_low_evidence_leaf_with_no_support():
     assert healthy_id in graph.nodes[anchor_id].children_ids
 
 
+def test_new_growth_gets_a_full_physiology_pass_before_first_survival_check():
+    graph = _build_graph()
+    graph.config.starvation_floor = 1.0
+    graph.config.burn_after_ticks = 1
+    anchor_id = graph.seed([0])
+    graph.tick_count = 7
+    graph._attach_forward_children(anchor_id, [-50.0], [[1]])
+    newborn_id = graph.nodes[anchor_id].children_ids[-1]
+    newborn = graph.nodes[newborn_id]
+
+    assert newborn.created_tick == graph.tick_count
+    assert newborn.pressure < graph.config.starvation_floor
+
+    graph._starve_and_burn()
+
+    assert newborn.burned is False
+    assert newborn.low_pressure_ticks == 0
+
+    # The normal remainder of tick 7 now gets to run. On tick 8, after
+    # pressure settlement, the node becomes eligible for its first check.
+    graph.tick_count += 1
+    graph._starve_and_burn()
+
+    assert newborn.burned is True
+
+
 def test_starved_internal_branch_burns_without_leaving_orphans():
     # Starvation applies to every non-anchor node. When an internal node
     # burns, descendants that have no other causal parent burn with it.
@@ -1147,27 +1432,14 @@ def _build_chain(graph, length, local_evidence, direction=Direction.FORWARD):
     return chain
 
 
-def test_settle_circuit_does_more_than_one_relaxation_step():
+def test_settle_circuit_uses_physical_inventory_not_score_relaxation():
     graph = _build_graph()
     graph.seed([0])
     _build_chain(graph, length=10, local_evidence=-1.0)
 
-    graph._update_pressures()
-    single_step = {nid: n.pressure for nid, n in graph.nodes.items()}
-
-    graph2 = _build_graph()
-    graph2.seed([0])
-    _build_chain(graph2, length=10, local_evidence=-1.0)
-    iterations = graph2._settle_circuit()
-
-    assert iterations > 1
-    settled = {nid: n.pressure for nid, n in graph2.nodes.items()}
-    # Settling changes the far end of the chain relative to a single sweep --
-    # multi-hop support hasn't had time to arrive after just one update.
-    assert any(
-        abs(settled[nid] - single_step[nid]) > 1e-6
-        for nid in settled if nid != graph.anchor_id
-    )
+    iterations = graph._settle_circuit()
+    assert iterations == 1
+    assert all(node.pressure == 0.0 for node in graph.nodes.values())
 
 
 def test_settle_circuit_is_a_no_op_once_already_converged():
@@ -2169,7 +2441,7 @@ def test_head_pressure_costs_forward_and_backward_equally_at_equal_distance():
     assert math.isclose(graph.nodes[fwd_id].pressure, graph.nodes[bwd_id].pressure, rel_tol=1e-9)
 
 
-def test_head_pressure_increases_with_distance_from_anchor():
+def test_topological_height_does_not_manufacture_hydraulic_pressure():
     graph = _build_graph()
     graph.config.head_pressure_coefficient = 0.05
     anchor_id = graph.seed([0])
@@ -2180,7 +2452,7 @@ def test_head_pressure_increases_with_distance_from_anchor():
     graph.nodes[far_id].direction = Direction.FORWARD
 
     graph._settle_circuit()
-    assert graph.nodes[near_id].pressure > graph.nodes[far_id].pressure
+    assert graph.nodes[near_id].pressure == graph.nodes[far_id].pressure
 
 
 def test_head_pressure_never_drives_pressure_negative():
@@ -2275,6 +2547,32 @@ def test_resolve_keep_count_topp_mode_capped_by_auxin_suppression_when_on():
     node.auxin_level = 100.0  # heavy ambient suppression -> effective_branch_factor collapses to 1
     spans = [([i], math.log(0.1)) for i in range(10)]
     assert graph._resolve_keep_count(node, spans) == graph._effective_branch_factor(node) == 1
+
+
+def test_stddev_selection_spans_score_bands_and_keeps_true_scores():
+    graph = _build_graph(branch_factor=4)
+    graph.config.forward_selection_mode = "stddev"
+    anchor_id = graph.seed([0])
+    node_id = _add_hand_node(graph, anchor_id, 1, -0.5, 1)
+    node = graph.nodes[node_id]
+    node.direction = Direction.FORWARD
+    candidates = [
+        ([index], score)
+        for index, score in enumerate(
+            [0.0, -0.1, -0.2, -1.0, -1.1, -2.0, -2.1, -3.0]
+        )
+    ]
+
+    selected = graph._select_final_candidates(
+        node,
+        "forward",
+        candidates,
+        graph._resolve_keep_count(node, candidates),
+    )
+
+    assert len(selected) == 4
+    assert len({round(score) for _, score in selected}) >= 3
+    assert all(pair in candidates for pair in selected)
 
 
 def test_expand_top_pressure_nodes_explicit_per_direction_budget_is_a_hard_cap_no_redistribution():
@@ -2390,6 +2688,49 @@ def test_expand_top_pressure_nodes_does_not_reseed_when_both_anchor_sides_are_in
     assert set(graph.nodes[anchor_id].parent_ids) == parents_before
 
 
+def test_heart_without_either_same_lineage_side_feels_both_stresses():
+    graph = _build_graph()
+    anchor_id = graph.seed([0])
+
+    stresses = graph._heart_growth_stresses()
+
+    assert stresses["main"]["missing_forward"] is True
+    assert stresses["main"]["missing_backward"] is True
+    assert graph.nodes[anchor_id].forward_growth_interest == 1.0
+    assert graph.nodes[anchor_id].backward_growth_interest == 1.0
+
+
+def test_foreign_cousin_connection_does_not_satisfy_heart_side():
+    graph = _build_graph()
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.2], [[1]])
+    foreign_id = graph.nodes[anchor_id].children_ids[-1]
+    graph.nodes[foreign_id].center_id = foreign_id
+
+    stress = graph._heart_growth_stresses()["main"]
+
+    assert stress["missing_forward"] is True
+    assert stress["forward_connections"] == []
+
+
+def test_heart_clears_each_stress_only_after_its_own_side_connects():
+    graph = _build_graph()
+    anchor_id = graph.seed([0])
+    graph._attach_forward_children(anchor_id, [-0.2], [[1]])
+
+    forward_only = graph._heart_growth_stresses()["main"]
+    assert forward_only["missing_forward"] is False
+    assert forward_only["missing_backward"] is True
+
+    graph._attach_backward_parents(anchor_id, [-0.2], [[2]])
+    complete = graph._heart_growth_stresses()["main"]
+
+    assert complete["missing_forward"] is False
+    assert complete["missing_backward"] is False
+    assert graph.nodes[anchor_id].forward_growth_interest == 0.0
+    assert graph.nodes[anchor_id].backward_growth_interest == 0.0
+
+
 def test_return_conductance_scale_default_matches_edge_conductance_exactly():
     graph = _build_graph()
     assert graph.config.return_conductance_scale == 1.0
@@ -2419,7 +2760,7 @@ def test_return_conductance_scale_only_dampens_the_return_leg():
     assert math.isclose(ret, graph._edge_conductance(anchor_id, child_id) * 0.25)
 
 
-def test_return_conductance_scale_dampens_how_much_a_strong_child_inflates_its_parent():
+def test_score_conductance_does_not_let_a_strong_child_inflate_parent_pressure():
     strong_child_evidence = -0.05  # near-zero evidence -> local_value close to 1.0, a strong claim
 
     full_return = _build_graph()
@@ -2442,7 +2783,7 @@ def test_return_conductance_scale_dampens_how_much_a_strong_child_inflates_its_p
     # Same weak parent, same strong child -- but with the return leg
     # dampened, the parent's settled pressure ends up lower: the child's
     # strength reports back less than it would through a symmetric edge.
-    assert full_return.nodes[weak_parent_id].pressure > damped_return.nodes[damped_weak_parent_id].pressure
+    assert full_return.nodes[weak_parent_id].pressure == damped_return.nodes[damped_weak_parent_id].pressure
 
 
 def test_inflow_is_weighted_by_conductance_not_diluted_by_raw_neighbor_count():
@@ -2524,7 +2865,7 @@ def test_balance_weight_disabled_by_default_is_a_true_noop_on_settled_pressure()
     assert math.isclose(graph.nodes[near_bwd_id].pressure, baseline.nodes[baseline_bwd_id].pressure, rel_tol=1e-9)
 
 
-def test_balance_weight_raises_settled_pressure_of_the_lagging_side():
+def test_balance_reward_does_not_manufacture_pressure_on_lagging_side():
     graph = _build_graph()
     graph.config.balance_weight = 0.1
     anchor_id = graph.seed([0])
@@ -2544,7 +2885,7 @@ def test_balance_weight_raises_settled_pressure_of_the_lagging_side():
     # Same backward node, but this time forward is way out ahead with the
     # knob on -- its settled pressure should come out higher than the
     # exact same node settled with nothing to lag behind.
-    assert graph.nodes[near_bwd_id].pressure > baseline.nodes[baseline_bwd_id].pressure
+    assert graph.nodes[near_bwd_id].pressure == baseline.nodes[baseline_bwd_id].pressure
     # The far-ahead forward node itself is already leading -- it gets no
     # gain from its own knob.
     far_baseline = _build_graph()
@@ -2599,7 +2940,7 @@ def test_reroot_simple_one_hop_moves_focus_without_reversing_edge():
     assert f1.direction is None
     assert f1.parent_id == anchor_id
     assert f1.depth == 0
-    assert f1.local_evidence == 0.0
+    assert f1.local_evidence == -0.1
     assert f1.tokens == []
     assert graph.anchor_tokens == [1]
 
@@ -2781,8 +3122,20 @@ def test_soft_traversal_physiology_learns_structures_and_subedge_archetype():
         key: float(parameter.detach())
         for key, parameter in graph.physiology_parameters.items()
     }
-    assert {"edge", "node", "heart", "archetype"} <= {
-        key.split(":")[0] for key in before
+    assert all(key.startswith("archetype:") for key in before)
+    assert {
+        "subedge:forward",
+        "subedge:reverse",
+        "edge:forward",
+        "edge:reverse",
+        "node:hull",
+        "node:pore",
+        "heart:valve",
+        "reservoir:coverage",
+        "reservoir:exchange",
+        "reservoir:membrane",
+    } <= {
+        ":".join(key.split(":")[1:-1]) for key in before
     }
     assert not any(key.startswith("traversal:") for key in before)
     changed = {
@@ -2790,7 +3143,8 @@ def test_soft_traversal_physiology_learns_structures_and_subedge_archetype():
         if after[key] != before[key]
     }
     assert any(key.startswith("archetype:subedge:") for key in changed)
-    assert any(not key.startswith("archetype:") for key in changed)
+    assert any(key.startswith("archetype:node:") for key in changed)
+    assert any(key.startswith("archetype:edge:") for key in changed)
     assert any(
         key.startswith("archetype:subedge:")
         and not key.endswith(":bias")
@@ -2802,7 +3156,7 @@ def test_soft_traversal_physiology_learns_structures_and_subedge_archetype():
     assert graph.physiology_best_traversal is not None
     state = graph.physiology_state()
     assert state["parameter_count"] == len(before)
-    assert state["archetype_parameter_count"] == 16
+    assert state["archetype_parameter_count"] == len(before)
 
 
 def test_physiology_logits_round_trip_with_fluid_state():
@@ -2829,6 +3183,71 @@ def test_physiology_logits_round_trip_with_fluid_state():
     } == expected
     assert restored.physiology_steps == graph.physiology_steps
     assert restored.physiology_best_traversal == graph.physiology_best_traversal
+
+
+def test_physiology_parameter_count_is_fixed_as_topology_grows():
+    graph = _build_graph(branch_factor=2)
+    graph.config.physiology_learning_enabled = True
+    anchor_id = graph.seed([0])
+    graph.spawn_first_children()
+    graph._run_graph_auditor()
+    graph._ensure_physiology_parameters()
+    initial_count = len(graph.physiology_parameters)
+
+    frontier = [
+        node.id
+        for node in graph.nodes.values()
+        if node.direction is Direction.FORWARD
+    ]
+    for depth in range(4):
+        next_frontier = []
+        for node_id in frontier:
+            graph._attach_forward_children(
+                node_id,
+                [-0.2, -0.3],
+                [[(depth + 1) % VOCAB], [(depth + 2) % VOCAB]],
+            )
+            next_frontier.extend(graph.nodes[node_id].children_ids[-2:])
+        frontier = next_frontier
+    graph._run_graph_auditor()
+    graph._ensure_physiology_parameters()
+
+    assert initial_count == 60
+    assert len(graph.physiology_parameters) == initial_count
+    assert not any(
+        key.startswith(("edge:", "node:", "heart:", "traversal:"))
+        for key in graph.physiology_parameters
+    )
+
+
+def test_subedge_archetype_responds_to_endpoint_water_state():
+    graph = _build_graph()
+    graph.config.physiology_learning_enabled = True
+    graph.seed([0])
+    graph._ensure_physiology_parameters()
+    with torch.no_grad():
+        graph.physiology_parameters[
+            graph._subedge_archetype_key(
+                "forward", "source_water_fraction"
+            )
+        ].fill_(4.0)
+        graph.physiology_parameters[
+            graph._subedge_archetype_key(
+                "forward", "destination_water_fraction"
+            )
+        ].fill_(-4.0)
+
+    openings = graph._subedge_archetype_openings(
+        torch.zeros(2),
+        torch.zeros(2),
+        torch.ones(2),
+        torch.ones(2),
+        torch.tensor([0.9, 0.1]),
+        torch.tensor([0.1, 0.9]),
+        torch.tensor([-0.2, -0.2]),
+    )
+
+    assert openings[0, 0] > openings[1, 0]
 
 
 def test_pytorch_model_wrapper_can_enable_gradient_tracked_forwards():
@@ -2975,7 +3394,7 @@ def test_reroot_restores_a_demoted_nodes_real_local_evidence():
     b_id = _add_node(graph, a_id, 2, -0.4, 2, direction=Direction.FORWARD, pressure=1.0)
 
     graph._reroot(b_id)  # promotes b -- its real -0.4 must be stashed
-    assert graph.nodes[b_id].local_evidence == 0.0  # zeroed while it holds anchor status
+    assert graph.nodes[b_id].local_evidence == -0.4
     assert graph.anchor_local_evidence == -0.4
 
     graph._reroot(a_id)  # demotes b -- its real -0.4 must come back
@@ -3206,7 +3625,7 @@ def test_shared_token_intrinsic_ignores_lone_instances():
     assert solo not in overrides  # nothing to trade against -- keeps its own ordinary intrinsic
 
 
-def test_shared_token_pressure_divides_settled_pressure_by_group_size():
+def test_duplicate_score_does_not_divide_physical_pressure():
     solo = _build_graph()
     anchor_id = solo.seed([0])
     solo_leaf = _add_node(solo, anchor_id, 5, -0.1, 1, direction=Direction.FORWARD, pressure=1.0)
@@ -3219,8 +3638,8 @@ def test_shared_token_pressure_divides_settled_pressure_by_group_size():
     b = _add_node(duo, anchor_id2, 5, -0.1, 1, direction=Direction.FORWARD, pressure=1.0)
     duo._settle_circuit()
 
-    assert duo.nodes[a].pressure < solo_pressure
-    assert duo.nodes[b].pressure < solo_pressure
+    assert duo.nodes[a].pressure == solo_pressure
+    assert duo.nodes[b].pressure == solo_pressure
     assert abs(duo.nodes[a].pressure - duo.nodes[b].pressure) < 1e-9  # identical siblings, identical share
 
 
@@ -3317,7 +3736,7 @@ def test_decay_rate_zero_is_a_true_noop():
     assert graph2.nodes[leaf2].pressure == without_decay
 
 
-def test_decay_rate_lowers_the_settled_pressure_of_an_unsupported_node():
+def test_legacy_score_decay_does_not_change_physical_pressure():
     baseline = _build_graph()
     anchor_id = baseline.seed([0])
     leaf = _add_hand_node(baseline, anchor_id, 1, -0.5, 1)
@@ -3330,10 +3749,10 @@ def test_decay_rate_lowers_the_settled_pressure_of_an_unsupported_node():
     leaf2 = _add_hand_node(decaying, anchor_id2, 1, -0.5, 1)
     decaying._settle_circuit()
 
-    assert decaying.nodes[leaf2].pressure < baseline_pressure
+    assert decaying.nodes[leaf2].pressure == baseline_pressure
 
 
-def test_population_target_scales_up_decay_when_over_target():
+def test_population_target_does_not_manufacture_physical_pressure_change():
     under_target = _build_graph()
     under_target.config.decay_rate = 0.5
     under_target.config.population_target = 100  # nowhere near the live count below
@@ -3351,10 +3770,10 @@ def test_population_target_scales_up_decay_when_over_target():
     _add_hand_node(over_target, anchor_id2, 2, -0.5, 1)
     over_target._settle_circuit()
 
-    assert over_target.nodes[leaf2].pressure < under_target_pressure
+    assert over_target.nodes[leaf2].pressure == under_target_pressure
 
 
-def test_population_target_alone_drives_decay_without_decay_rate():
+def test_population_target_is_not_a_hydraulic_source_or_sink():
     """Regression test for a real bug: an earlier version gated the whole
     population_target mechanism behind decay_rate > 0 (`if cfg.decay_rate
     > 0 and cfg.population_target`), so leaving decay_rate at its default
@@ -3380,7 +3799,7 @@ def test_population_target_alone_drives_decay_without_decay_rate():
     _add_hand_node(over_target, anchor_id2, 2, -0.5, 1)
     over_target._settle_circuit()
 
-    assert over_target.nodes[leaf2].pressure < under_target_pressure
+    assert over_target.nodes[leaf2].pressure == under_target_pressure
 
 
 def test_population_target_none_leaves_decay_rate_unscaled():

--- a/tests/test_flux_radar_server.py
+++ b/tests/test_flux_radar_server.py
@@ -78,6 +78,9 @@ def test_build_graph_enables_global_csf_scarcity_and_rhizome_defaults():
     assert graph.config.lymph_return_rate == 0.02
     assert graph.config.rhizome_csf_pump_rate == 0.1
     assert graph.config.rhizome_soil_exudation_rate == 0.01
+    assert graph.config.growth_commitment_threshold == 3.0
+    assert graph.config.habitat_ring_ion_amount == 4.0
+    assert graph.config.branch_maturity_gain == 0.1
     assert graph.config.physiology_learning_enabled is True
     assert graph.config.physiology_learning_rate == 0.05
     assert graph.config.physiology_resource_cost == 0.1
@@ -85,6 +88,8 @@ def test_build_graph_enables_global_csf_scarcity_and_rhizome_defaults():
     assert graph.config.physiology_traversal_temperature == 0.5
     assert graph.config.physiology_track_model_gradients is False
     assert resolved["rhizome_csf_pump_rate"] == 0.1
+    assert resolved["growth_commitment_threshold"] == 3.0
+    assert resolved["habitat_ring_ion_amount"] == 4.0
     assert resolved["physiology_learning_enabled"] is True
 
 def test_build_graph_poetic_booster_off_by_default():
@@ -183,6 +188,35 @@ def test_get_root_serves_index_html():
         httpd.shutdown()
 
 
+def test_radar_serves_bundled_threejs_webgl2_renderer():
+    bundle_path = server_mod.STATIC_DIR / "webgl" / "webgl_renderer.js"
+    source_path = server_mod.STATIC_DIR / "src" / "webgl_renderer.ts"
+    index_source = (server_mod.STATIC_DIR / "index.html").read_text(
+        encoding="utf-8"
+    )
+    assert bundle_path.is_file()
+    assert source_path.is_file()
+    assert 'id="fgWebGL"' in index_source
+    assert 'from "/static/webgl/webgl_renderer.js"' in index_source
+    assert "currentTubeState = snap.tube_state || []" in index_source
+    source = source_path.read_text(encoding="utf-8")
+    assert "new THREE.WebGLRenderer" in source
+    assert "new THREE.InstancedMesh" in source
+    assert "rebuildLumens" in source
+    assert "dominantFluid" in source
+
+    httpd, port = _start_server()
+    try:
+        with urllib.request.urlopen(
+            f"http://127.0.0.1:{port}/static/webgl/webgl_renderer.js"
+        ) as resp:
+            assert resp.status == 200
+            assert resp.headers.get_content_type() == "application/javascript"
+            assert b"FluxWebGLRenderer" in resp.read()
+    finally:
+        httpd.shutdown()
+
+
 def test_radar_uses_change_aware_hydraulic_straightening():
     """The browser layout must not kick a settled graph on every live poll."""
     index_path = server_mod.STATIC_DIR / "index.html"
@@ -199,6 +233,11 @@ def test_radar_uses_change_aware_hydraulic_straightening():
     assert "fg-water-flow" in source
     assert "fg-ion-flow" in source
     assert "regionBindingForce" in source
+    assert "ringWedgeCollisionForce" in source
+    assert "enforceNetworkGeometry" in source
+    assert ".force('collide', ringWedgeCollisionForce" in source
+    assert "node.x = CX + radius * radialX" in source
+    assert "addRayLoad(direction + ':' + boundaryIndex" in source
     assert "addRayLoad" in source
     assert "rayContainmentForce" not in source
 
@@ -243,6 +282,7 @@ def test_radar_has_snapshot_driven_heart_and_storage_hud():
     assert "const tokenString = pumpNode" in source
     assert "heartNameNode.title = tokenString" in source
     assert "currentRhizome = snap.rhizome || {}" in source
+    assert "currentHabitat = snap.current_habitat || {}" in source
     assert "currentPhysiology = snap.physiology || {}" in source
     assert "learned physiology" in source
     assert "global fluid" in source
@@ -262,14 +302,26 @@ def test_snapshot_preserves_each_reservoirs_full_ion_name():
     assert stores["main:backward"]["ion_name"] == "main:backward"
     assert snapshot["rhizome"] == {"waste:salt": 0.4}
     assert snapshot["rhizome_owner_id"] == graph.anchor_id
+    assert snapshot["current_habitat_id"] == graph.anchor_id
+    assert snapshot["current_habitat"]["main:forward"] == 4.0
+    assert snapshot["current_habitat_phrase"] == bundle.tokenizer.decode(
+        graph.habitat_signatures[graph.anchor_id]
+    )
+    assert snapshot["movement_count"] == 0
     assert snapshot["physiology"]["enabled"] is True
-    assert "parameter_count" in snapshot["physiology"]
+    assert snapshot["physiology"]["parameter_count"] == 60
+    assert snapshot["physiology"]["archetype_parameter_count"] == 60
+    assert all(
+        key.startswith("archetype:")
+        for key in graph.physiology_parameters
+    )
 
 def test_radar_exposes_separate_sprout_and_air_root_shapes():
     from pathlib import Path
 
     source = (server_mod.STATIC_DIR / "index.html").read_text(encoding="utf-8")
     server_source = Path(server_mod.__file__).read_text(encoding="utf-8")
+    assert 'value="stddev"' in source
 
     for field_id, param in (
         ("fSproutBranch", "sprout_branch_factor"),
@@ -287,6 +339,13 @@ def test_radar_exposes_separate_sprout_and_air_root_shapes():
         ("fPhysiologyInitial", "physiology_initial_opening"),
         ("fPhysiologyTemperature", "physiology_traversal_temperature"),
         ("fModelGradients", "physiology_track_model_gradients"),
+        ("fCommitmentGain", "growth_commitment_gain"),
+        ("fCommitmentRetention", "growth_commitment_retention"),
+        ("fCommitmentThreshold", "growth_commitment_threshold"),
+        ("fHabitatIonAmount", "habitat_ring_ion_amount"),
+        ("fRingUptake", "ring_uptake_rate"),
+        ("fMaturityGain", "branch_maturity_gain"),
+        ("fMaturityBonus", "branch_maturity_conductance_bonus"),
     ):
         assert f'id="{field_id}"' in source
         assert f"'{field_id}', '{param}'" in source

--- a/tests/test_flux_radar_server.py
+++ b/tests/test_flux_radar_server.py
@@ -191,11 +191,17 @@ def test_get_root_serves_index_html():
 def test_radar_serves_bundled_threejs_webgl2_renderer():
     bundle_path = server_mod.STATIC_DIR / "webgl" / "webgl_renderer.js"
     source_path = server_mod.STATIC_DIR / "src" / "webgl_renderer.ts"
+    projection_path = (
+        server_mod.STATIC_DIR / "src" / "hypersphere_projection.ts"
+    )
+    force_path = server_mod.STATIC_DIR / "src" / "nd_force_assembly.ts"
     index_source = (server_mod.STATIC_DIR / "index.html").read_text(
         encoding="utf-8"
     )
     assert bundle_path.is_file()
     assert source_path.is_file()
+    assert projection_path.is_file()
+    assert force_path.is_file()
     assert 'id="fgWebGL"' in index_source
     assert 'from "/static/webgl/webgl_renderer.js"' in index_source
     assert "currentTubeState = snap.tube_state || []" in index_source
@@ -204,6 +210,8 @@ def test_radar_serves_bundled_threejs_webgl2_renderer():
     assert "new THREE.InstancedMesh" in source
     assert "rebuildLumens" in source
     assert "dominantFluid" in source
+    assert "NDForceAssembly" in source
+    assert "HypersphereProjector" in source
 
     httpd, port = _start_server()
     try:
@@ -217,29 +225,24 @@ def test_radar_serves_bundled_threejs_webgl2_renderer():
         httpd.shutdown()
 
 
-def test_radar_uses_change_aware_hydraulic_straightening():
-    """The browser layout must not kick a settled graph on every live poll."""
+def test_radar_uses_nd_force_assembly_not_screen_space_physics():
+    """Biology is solved in network dimensions; S² is display-only."""
     index_path = server_mod.STATIC_DIR / "index.html"
     source = index_path.read_text(encoding="utf-8")
 
-    assert "pipeStraighteningForce" in source
-    assert "Math.abs(flow * pressureDrop)" in source
-    assert "snapshotChanged" in source
-    assert "if (snapshotChanged)" in source
-    assert "simulation.alpha(0.9).restart()" not in source
-    assert "pipeRestLength" in source
-    assert "pressureLengthFactor" in source
+    assert "NDForceAssembly" in source
+    assert "solveNDForceAssembly" in source
+    assert "latent_coordinates" in source
+    assert "window.fluxNDPhysicsFrame" in source
+    assert "window.fluxObservationFrame" in source
+    assert "domain: 'client_nd'" in source
+    assert "habitat_proximity: ndForceAssembly.habitatProximity()" in source
+    assert "force_proof: state.proof" in source
+    assert "d3.forceSimulation" not in source
+    assert "simulation.force" not in source
     assert "component_flows" in source
     assert "fg-water-flow" in source
     assert "fg-ion-flow" in source
-    assert "regionBindingForce" in source
-    assert "ringWedgeCollisionForce" in source
-    assert "enforceNetworkGeometry" in source
-    assert ".force('collide', ringWedgeCollisionForce" in source
-    assert "node.x = CX + radius * radialX" in source
-    assert "addRayLoad(direction + ':' + boundaryIndex" in source
-    assert "addRayLoad" in source
-    assert "rayContainmentForce" not in source
 
 
 def test_ring_depth_is_absolute_signed_level_for_main_and_cousin_seeds():
@@ -252,15 +255,18 @@ def test_ring_depth_is_absolute_signed_level_for_main_and_cousin_seeds():
     assert server_mod._ring_index_from_level(SimpleNamespace(level=2)) == 2
 
 
-def test_radar_uses_one_authoritative_hop_radius_and_recovery_force():
+def test_nd_force_assembly_uses_level_shells_without_screen_coordinates():
     source = (server_mod.STATIC_DIR / "index.html").read_text(encoding="utf-8")
+    force_source = (
+        server_mod.STATIC_DIR / "src" / "nd_force_assembly.ts"
+    ).read_text(encoding="utf-8")
 
-    assert "const initialRadius = targetRadius(n)" in source
-    assert "sn.targetR = targetRadius(n)" in source
-    assert "ringData = currentRingRadii.map" in source
-    assert "ringData = displayRingRadii.map" not in source
-    assert "depthRingRecoveryForce" in source
-    assert "node.x += shiftX; node.y += shiftY" in source
+    assert "sn.targetR = targetRadius(n)" not in source
+    assert "const initialRadius = targetRadius(n)" not in source
+    assert "addLocalShellForces" in force_source
+    assert "Math.abs(this.levels[node]) * 1.05" in force_source
+    assert "this.localOffset(this.networkIndices[node])" in force_source
+    assert "screen" not in force_source
     assert "selectAll('line.fg-edge')" in source
     assert ".attr('class', 'fg-edge')" in source
 

--- a/tests/test_state_persistence.py
+++ b/tests/test_state_persistence.py
@@ -84,6 +84,40 @@ def _dummy_bundle():
     return bundle
 
 
+def test_live_session_blocks_on_and_accepts_matching_client_fluid_work():
+    session = server_mod.LiveSession(
+        _dummy_bundle(),
+        {"seed": "hi", "window": 5, "interval_ms": 100000},
+    )
+    packet = {
+        "tick": 1,
+        "components": ["solvent"],
+        "values": [[1.0]],
+        "compliance": [1.0],
+        "arcs": {"source": [], "destination": [], "conductance": []},
+        "parameters": {"substeps": 1},
+    }
+    result_holder = {}
+    worker = threading.Thread(
+        target=lambda: result_holder.setdefault(
+            "result", session._delegate_fluid_work(packet)
+        )
+    )
+    worker.start()
+    deadline = time.time() + 2.0
+    while session.pending_fluid_work is None and time.time() < deadline:
+        time.sleep(0.01)
+    assert session.pending_fluid_work is not None
+    work_id = session.pending_fluid_work["work_id"]
+
+    session.submit_fluid_result({"work_id": work_id, "values": [[1.0]]})
+    worker.join(timeout=2.0)
+
+    assert not worker.is_alive()
+    assert result_holder["result"]["work_id"] == work_id
+    assert session.pending_fluid_work is None
+
+
 def test_node_to_dict_and_from_dict_roundtrip():
     node = FluxNode(
         id=7, tokens=[1, 2], direction=Direction.BACKWARD, parent_id=3, depth=2,

--- a/todo/1785765928_turing_native_c_shell_io_handoff.stub.md
+++ b/todo/1785765928_turing_native_c_shell_io_handoff.stub.md
@@ -1,0 +1,50 @@
+# Turing native C-shell I/O handoff
+
+The adjacent `turing` repository now generates a working dependency-free
+Windows display shell around emitted whole-program Fortran. Start with:
+
+- `src/compiler/fortran_c_shell.py`
+- `src/compiler/shell_io.py`
+- `src/compiler/python_native_shell.py`
+- `tests/test_fortran_c_shell.py`
+- `build/columnar_fortran_c_shell/columnar_multifluid_native.exe`
+- `build/columnar_fortran_c_shell/verification.json`
+
+## Proven boundary
+
+`ShellIOManifest` binds the final ABI parameters. For the current demo the
+required capability is `display_double_buffer`, the format is
+`rgb_f64_planar`, and the resources are `display.red`, `display.green`, and
+`display.blue`. The generated C shell owns conversion to a top-down 32-bit DIB
+and presents through `StretchDIBits`. It does not inspect application names.
+
+The compiler-selected control entry must be called. Do not substitute the
+numerical entry to make a demo run once. The fix in `ssa_fortran_backend.py`
+ensures the API sidecar describes transitive extents on the final control
+signature.
+
+## Work remaining
+
+1. Add a native SPSC input-event ring using `ShellIOABI.input_events`.
+   Translate Win32 keyboard, pointer, wheel, and close messages into the shared
+   record fields; do not call back into Fortran from the window procedure.
+2. Add the native file broker using `file_requests` and `file_completions`.
+   Keep handles shell-owned and paths/payloads as offset-length spans.
+3. Support packed `rgb8`, `rgba8`, and `indexed_float32` display bindings.
+4. Introduce a stable native build entrypoint which accepts a compiled module,
+   manifest, state-feedback table, specialization extents, and initial state.
+5. If presentation is moved to another thread, retain explicit front/back
+   generation ownership and measure compute completion separately from blit.
+
+## Verification baseline
+
+Run from `C:\dev\Powershell\turing`:
+
+```powershell
+python -m pytest -q tests/test_fortran_c_shell.py tests/test_fortran_control_target.py tests/test_fortran_fidelity.py tests/test_ssa_fortran_and_optimizing_llvm.py tests/test_process_graph_shell.py -x
+```
+
+Baseline: 34 passed. The full-size fidelity report records 30 matching output
+arrays, 45,056 elements per plane, and maximum absolute error
+`2.842170943040401e-14`.
+


### PR DESCRIPTION
## What changed

- Reworked graph pressure as an emergent result of conserved node, lumen, hull, and spatial CSF/lymph compartments.
- Added independent ordered traversal tubes, ion diffusion, hydration transport, branch maturity, local growth commitment, and finite seed-relative habitats.
- Added the client relaxation work/proof protocol and live visualization of tube state.
- Introduced a bundled Three.js/WebGL2 renderer for vascular hulls, audited-path lumens, fluid flow, and instanced nodes.
- Replaced the active screen-space force layout with one generalized nD mechanics domain: two shared dimensions plus a separate four-dimensional local subspace per network.
- Added sparse pipe forces, pressure-dependent rest lengths, fixed anchors, local shell constraints, spatial-hash collision assembly, damped integration, and an nD force proof.
- Replaced SVG-ring biological feedback with habitat proximity measured inside each network's own dimensions.
- Added deterministic arbitrary-dimensional and hyperspherical projection onto an S² observation shell. The projection is reversible through an exposed frame manifest and never feeds mechanics.

## Why

Pressure and growth should emerge from physiology rather than language-model score or screen geometry. Networks should own their mechanical dimensions, while the 3D shell remains only a shared observation lens. Individual audited tubes must also remain physically independent rather than collapsing into endpoint-only links.

## Validation

- 220 directly runnable FluxGraph/radar/persistence tests passed; 23 fixture-dependent tests skipped.
- Executable nD force/projection tests passed.
- Strict TypeScript typecheck and Vite production build passed.
- Browser smoke test confirmed WebGL2, a 10-dimensional force solve, normalized shell positions, finite coordinates, 6 draw calls, 388 triangles, and no page errors.
- Python compilation and classic JavaScript parsing passed.
- `npm audit` reported zero vulnerabilities.
- Guestbook validation and `git diff --check` passed.

Ordinary pytest remains obstructed by the repository's pre-existing environment bootstrap issue documented in the included reports.